### PR TITLE
Shader crate cargo features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Signed for loops like `for _ in 0..4i32 {}` no longer compile. We recommend switching to unsigned for loops and casting back to signed integers in the meanwhile.
 
 ### Changed 🛠
+- [PR#13](https://github.com/Rust-GPU/rust-gpu/pull/13) allow cargo features to be passed to the shader crate
 - [PR#12](https://github.com/rust-gpu/rust-gpu/pull/12) updated toolchain to `nightly-2024-04-24`
 - [PR#9](https://github.com/Rust-GPU/rust-gpu/pull/9) relaxed `glam` version requirements (`>=0.22, <=0.29`)
 - [PR#1127](https://github.com/EmbarkStudios/rust-gpu/pull/1127) updated `spirv-tools` to `0.10.0`, which follows `vulkan-sdk-1.3.275`

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -282,11 +282,19 @@ pub enum ShaderPanicStrategy {
     UNSOUND_DO_NOT_USE_UndefinedBehaviorViaUnreachable,
 }
 
+/// Cargo features specification for building the shader crate.
+#[derive(Default)]
+struct ShaderCrateFeatures {
+    default_features: Option<bool>,
+    features: Vec<String>,
+}
+
 pub struct SpirvBuilder {
     path_to_crate: PathBuf,
     print_metadata: MetadataPrintout,
     release: bool,
     target: String,
+    shader_crate_features: ShaderCrateFeatures,
     deny_warnings: bool,
     multimodule: bool,
     spirv_metadata: SpirvMetadata,
@@ -333,6 +341,7 @@ impl SpirvBuilder {
             skip_block_layout: false,
 
             preserve_bindings: false,
+            shader_crate_features: ShaderCrateFeatures::default(),
         }
     }
 
@@ -456,6 +465,20 @@ impl SpirvBuilder {
     #[must_use]
     pub fn extra_arg(mut self, arg: impl Into<String>) -> Self {
         self.extra_args.push(arg.into());
+        self
+    }
+
+    /// Set --default-features for the target shader crate.
+    #[must_use]
+    pub fn shader_crate_default_features(mut self, default_features: bool) -> Self {
+        self.shader_crate_features.default_features = Some(default_features);
+        self
+    }
+
+    /// Set --features for the target shader crate.
+    #[must_use]
+    pub fn shader_crate_features(mut self, features: impl IntoIterator<Item = String>) -> Self {
+        self.shader_crate_features.features = features.into_iter().collect();
         self
     }
 
@@ -754,6 +777,18 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
             .join("target-specs")
             .join(format!("{}.json", builder.target)),
     );
+
+    if let Some(default_features) = builder.shader_crate_features.default_features {
+        if !default_features {
+            cargo.arg("--no-default-features");
+        }
+    }
+
+    if !builder.shader_crate_features.features.is_empty() {
+        cargo
+            .arg("--features")
+            .arg(builder.shader_crate_features.features.join(","));
+    }
 
     // NOTE(eddyb) see above how this is computed and why it might be missing.
     if let Some(target_dir) = target_dir {


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/12 to be merged first

Adds fields for default-features and features to SpirvBuilder [and] pipes those fields through to the cargo command that builds the shader crate.

[Original PR in embark's repo](https://github.com/EmbarkStudios/rust-gpu/pull/1124)