### PR TITLE
Panic structurization improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,15 +2434,15 @@ dependencies = [
 
 [[package]]
 name = "spirt"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e1f7903720ff818d6da824edf2c4082c6e7a029a99317fd10c39dd7c40c7ff"
+checksum = "f2d5968bd2a36466468aac637b355776f080edfb0c6f769b2b99b9708260c42a"
 dependencies = [
  "arrayvec",
  "bytemuck",
  "derive_more",
  "elsa",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "internal-iterator",
  "itertools",
  "lazy_static",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -55,7 +55,7 @@ rustc_codegen_spirv-types.workspace = true
 rustc-demangle = "0.1.21"
 sanitize-filename = "0.4"
 smallvec = { version = "1.6.1", features = ["union"] }
-spirt = "0.3.0"
+spirt = "0.4.0"
 spirv-tools.workspace = true
 lazy_static = "1.4.0"
 itertools = "0.10.5"

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -462,6 +462,11 @@ impl CodegenArgs {
             );
             opts.optflag(
                 "",
+                "spirt-keep-unstructured-cfg-in-dumps",
+                "include initial unstructured CFG when dumping SPIR-T",
+            );
+            opts.optflag(
+                "",
                 "specializer-debug",
                 "enable debug logging for the specializer",
             );
@@ -629,6 +634,8 @@ impl CodegenArgs {
                 .opt_present("spirt-strip-custom-debuginfo-from-dumps"),
             spirt_keep_debug_sources_in_dumps: matches
                 .opt_present("spirt-keep-debug-sources-in-dumps"),
+            spirt_keep_unstructured_cfg_in_dumps: matches
+                .opt_present("spirt-keep-unstructured-cfg-in-dumps"),
             specializer_debug: matches.opt_present("specializer-debug"),
             specializer_dump_instances: matches_opt_path("specializer-dump-instances"),
             print_all_zombie: matches.opt_present("print-all-zombie"),

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -62,6 +62,7 @@ pub struct Options {
     pub dump_spirt_passes: Option<PathBuf>,
     pub spirt_strip_custom_debuginfo_from_dumps: bool,
     pub spirt_keep_debug_sources_in_dumps: bool,
+    pub spirt_keep_unstructured_cfg_in_dumps: bool,
     pub specializer_debug: bool,
     pub specializer_dump_instances: Option<PathBuf>,
     pub print_all_zombie: bool,
@@ -434,7 +435,11 @@ pub fn link(
                 }
             }
         };
-        after_pass("lower_from_spv", &module);
+        // HACK(eddyb) don't dump the unstructured state if not requested, as
+        // after SPIR-T 0.4.0 it's extremely verbose (due to def-use hermeticity).
+        if opts.spirt_keep_unstructured_cfg_in_dumps || !opts.structurize {
+            after_pass("lower_from_spv", &module);
+        }
 
         // NOTE(eddyb) this *must* run on unstructured CFGs, to do its job.
         {

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -442,6 +442,9 @@ pub fn link(
         }
 
         // NOTE(eddyb) this *must* run on unstructured CFGs, to do its job.
+        // FIXME(eddyb) no longer relying on structurization, try porting this
+        // to replace custom aborts in `Block`s and inject `ExitInvocation`s
+        // after them (truncating the `Block` and/or parent region if necessary).
         {
             let _timer = sess.timer("spirt_passes::controlflow::convert_custom_aborts_to_unstructured_returns_in_entry_points");
             spirt_passes::controlflow::convert_custom_aborts_to_unstructured_returns_in_entry_points(opts, &mut module);

--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -208,3 +208,11 @@ all the "file contents debuginfo" (i.e. from SPIR-V `OpSource` instructions),
 which will end up being included, in full, at the start of the dump.
 
 The default (of hiding the file contents) is less verbose, but (arguably) lossier.
+
+### `--spirt-keep-unstructured-cfg-in-dumps`
+
+When dumping (pretty-printed) `SPIR-🇹` (e.g. with `--dump-spirt-passes`), include
+the initial unstructured state, as well (i.e. just after lowering from SPIR-V).
+
+The default (of only dumping structured SPIR-T) can have far less noisy dataflow,
+but unstructured SPIR-T may be needed for e.g. debugging the structurizer itself.

--- a/tests/ui/dis/entry-pass-mode-cast-array.stderr
+++ b/tests/ui/dis/entry-pass-mode-cast-array.stderr
@@ -8,6 +8,10 @@ OpNoLine
 OpSelectionMerge %13 None
 OpBranchConditional %9 %14 %15
 %14 = OpLabel
+OpBranch %13
+%15 = OpLabel
+OpReturn
+%13 = OpLabel
 OpLine %5 14 4
 %16 = OpCompositeExtract  %17  %6 0
 %18 = OpFAdd  %17  %16 %19
@@ -15,9 +19,5 @@ OpLine %5 14 4
 OpLine %5 15 4
 OpStore %21 %20
 OpNoLine
-OpBranch %13
-%15 = OpLabel
-OpBranch %13
-%13 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/index_user_dst.stderr
+++ b/tests/ui/dis/index_user_dst.stderr
@@ -9,13 +9,13 @@ OpNoLine
 OpSelectionMerge %14 None
 OpBranchConditional %12 %15 %16
 %15 = OpLabel
+OpBranch %14
+%16 = OpLabel
+OpReturn
+%14 = OpLabel
 OpLine %5 10 21
 %17 = OpInBoundsAccessChain  %18  %6 %9
 %19 = OpLoad  %20  %17
 OpNoLine
-OpBranch %14
-%16 = OpLabel
-OpBranch %14
-%14 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/issue-731.stderr
+++ b/tests/ui/dis/issue-731.stderr
@@ -8,6 +8,10 @@ OpNoLine
 OpSelectionMerge %13 None
 OpBranchConditional %9 %14 %15
 %14 = OpLabel
+OpBranch %13
+%15 = OpLabel
+OpReturn
+%13 = OpLabel
 OpLine %5 12 4
 %16 = OpCompositeExtract  %17  %6 0
 %18 = OpFAdd  %17  %16 %19
@@ -15,9 +19,5 @@ OpLine %5 12 4
 OpLine %5 13 4
 OpStore %21 %20
 OpNoLine
-OpBranch %13
-%15 = OpLabel
-OpBranch %13
-%13 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/panic_builtin_bounds_check.stderr
+++ b/tests/ui/dis/panic_builtin_bounds_check.stderr
@@ -32,7 +32,7 @@ OpBranch %14
 OpLine %4 275 4
 %17 = OpExtInst  %6  %1 1 %3 %11 %10
 OpNoLine
-OpBranch %14
+OpReturn
 %14 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/panic_sequential_many.rs
+++ b/tests/ui/dis/panic_sequential_many.rs
@@ -1,0 +1,30 @@
+#![crate_name = "panic_sequential_many"]
+
+// Test a long sequence of conditional panics, which has historically generated
+// very nested structured control-flow (instead of a single merged chain).
+
+// build-pass
+// compile-flags: -C target-feature=+ext:SPV_KHR_non_semantic_info
+// compile-flags: -C llvm-args=--abort-strategy=debug-printf
+// compile-flags: -C llvm-args=--disassemble
+
+// FIXME(eddyb) consider using such replacements also for dealing
+// with `OpLine` changing all the time (esp. in libcore functions).
+//
+// normalize-stderr-test "; (SPIR-V|Generator: rspirv|Version: 1\.\d+|Bound: \d+)\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+// FIXME(eddyb) handle this one in the test runner.
+// normalize-stderr-test "\S*/lib/rustlib/" -> "$$SYSROOT/lib/rustlib/"
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(#[spirv(flat)] x: u32, #[spirv(flat)] y: u32, o: &mut u32) {
+    // HACK(eddyb) this might stop working if the checks get optimized out,
+    // after the first `y != 0` (which dominates the rest of the function).
+    *o = x / y / y / y / y / y / y / y / y / y / y / y / y / y / y / y / y / y;
+}

--- a/tests/ui/dis/panic_sequential_many.rs
+++ b/tests/ui/dis/panic_sequential_many.rs
@@ -7,7 +7,7 @@
 // compile-flags: -C target-feature=+ext:SPV_KHR_non_semantic_info
 // compile-flags: -C llvm-args=--abort-strategy=debug-printf
 // compile-flags: -C llvm-args=--disassemble
-
+//
 // FIXME(eddyb) consider using such replacements also for dealing
 // with `OpLine` changing all the time (esp. in libcore functions).
 //
@@ -16,7 +16,7 @@
 // normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
-
+// normalize-stderr-test "\S:\S*/panic_sequential_many.rs" -> "$$DIR/panic_sequential_many.rs"
 // FIXME(eddyb) handle this one in the test runner.
 // normalize-stderr-test "\S*/lib/rustlib/" -> "$$SYSROOT/lib/rustlib/"
 

--- a/tests/ui/dis/panic_sequential_many.stderr
+++ b/tests/ui/dis/panic_sequential_many.stderr
@@ -1,0 +1,281 @@
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_non_semantic_info"
+OpExtension "SPV_KHR_shader_clock"
+%1 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %2 "main" %3 %4 %5
+OpExecutionMode %2 OriginUpperLeft
+%6 = OpString "/n[Rust panicked at $DIR/panic_sequential_many.rs:29:10]/n attempt to divide by zero/n      in main()/n"
+%7 = OpString "$DIR/panic_sequential_many.rs"
+OpName %3 "x"
+OpName %4 "y"
+OpName %5 "o"
+OpDecorate %3 Flat
+OpDecorate %3 Location 0
+OpDecorate %4 Flat
+OpDecorate %4 Location 1
+OpDecorate %5 Location 0
+%8 = OpTypeInt 32 0
+%9 = OpTypePointer Input %8
+%10 = OpTypePointer Output %8
+%11 = OpTypeVoid
+%12 = OpTypeFunction %11
+%3 = OpVariable  %9  Input
+%4 = OpVariable  %9  Input
+%13 = OpTypeBool
+%14 = OpConstant  %8  0
+%5 = OpVariable  %10  Output
+%2 = OpFunction  %11  None %12
+%15 = OpLabel
+OpLine %7 26 12
+%16 = OpLoad  %8  %3
+OpLine %7 26 35
+%17 = OpLoad  %8  %4
+OpLine %7 29 9
+%18 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %19 None
+OpBranchConditional %18 %20 %21
+%20 = OpLabel
+OpLine %7 29 9
+%22 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %19
+%21 = OpLabel
+OpLine %7 29 9
+%23 = OpUDiv  %8  %16 %17
+%24 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %25 None
+OpBranchConditional %24 %26 %27
+%26 = OpLabel
+OpLine %7 29 9
+%28 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %25
+%27 = OpLabel
+OpLine %7 29 9
+%29 = OpUDiv  %8  %23 %17
+%30 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %31 None
+OpBranchConditional %30 %32 %33
+%32 = OpLabel
+OpLine %7 29 9
+%34 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %31
+%33 = OpLabel
+OpLine %7 29 9
+%35 = OpUDiv  %8  %29 %17
+%36 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %37 None
+OpBranchConditional %36 %38 %39
+%38 = OpLabel
+OpLine %7 29 9
+%40 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %37
+%39 = OpLabel
+OpLine %7 29 9
+%41 = OpUDiv  %8  %35 %17
+%42 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %43 None
+OpBranchConditional %42 %44 %45
+%44 = OpLabel
+OpLine %7 29 9
+%46 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %43
+%45 = OpLabel
+OpLine %7 29 9
+%47 = OpUDiv  %8  %41 %17
+%48 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %49 None
+OpBranchConditional %48 %50 %51
+%50 = OpLabel
+OpLine %7 29 9
+%52 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %49
+%51 = OpLabel
+OpLine %7 29 9
+%53 = OpUDiv  %8  %47 %17
+%54 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %55 None
+OpBranchConditional %54 %56 %57
+%56 = OpLabel
+OpLine %7 29 9
+%58 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %55
+%57 = OpLabel
+OpLine %7 29 9
+%59 = OpUDiv  %8  %53 %17
+%60 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %61 None
+OpBranchConditional %60 %62 %63
+%62 = OpLabel
+OpLine %7 29 9
+%64 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %61
+%63 = OpLabel
+OpLine %7 29 9
+%65 = OpUDiv  %8  %59 %17
+%66 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %67 None
+OpBranchConditional %66 %68 %69
+%68 = OpLabel
+OpLine %7 29 9
+%70 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %67
+%69 = OpLabel
+OpLine %7 29 9
+%71 = OpUDiv  %8  %65 %17
+%72 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %73 None
+OpBranchConditional %72 %74 %75
+%74 = OpLabel
+OpLine %7 29 9
+%76 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %73
+%75 = OpLabel
+OpLine %7 29 9
+%77 = OpUDiv  %8  %71 %17
+%78 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %79 None
+OpBranchConditional %78 %80 %81
+%80 = OpLabel
+OpLine %7 29 9
+%82 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %79
+%81 = OpLabel
+OpLine %7 29 9
+%83 = OpUDiv  %8  %77 %17
+%84 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %85 None
+OpBranchConditional %84 %86 %87
+%86 = OpLabel
+OpLine %7 29 9
+%88 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %85
+%87 = OpLabel
+OpLine %7 29 9
+%89 = OpUDiv  %8  %83 %17
+%90 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %91 None
+OpBranchConditional %90 %92 %93
+%92 = OpLabel
+OpLine %7 29 9
+%94 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %91
+%93 = OpLabel
+OpLine %7 29 9
+%95 = OpUDiv  %8  %89 %17
+%96 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %97 None
+OpBranchConditional %96 %98 %99
+%98 = OpLabel
+OpLine %7 29 9
+%100 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %97
+%99 = OpLabel
+OpLine %7 29 9
+%101 = OpUDiv  %8  %95 %17
+%102 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %103 None
+OpBranchConditional %102 %104 %105
+%104 = OpLabel
+OpLine %7 29 9
+%106 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %103
+%105 = OpLabel
+OpLine %7 29 9
+%107 = OpUDiv  %8  %101 %17
+%108 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %109 None
+OpBranchConditional %108 %110 %111
+%110 = OpLabel
+OpLine %7 29 9
+%112 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %109
+%111 = OpLabel
+OpLine %7 29 9
+%113 = OpUDiv  %8  %107 %17
+%114 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %115 None
+OpBranchConditional %114 %116 %117
+%116 = OpLabel
+OpLine %7 29 9
+%118 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %115
+%117 = OpLabel
+OpLine %7 29 4
+%119 = OpUDiv  %8  %113 %17
+OpStore %5 %119
+OpNoLine
+OpBranch %115
+%115 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %103
+%103 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %91
+%91 = OpLabel
+OpBranch %85
+%85 = OpLabel
+OpBranch %79
+%79 = OpLabel
+OpBranch %73
+%73 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %61
+%61 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpReturn
+OpFunctionEnd

--- a/tests/ui/dis/panic_sequential_many.stderr
+++ b/tests/ui/dis/panic_sequential_many.stderr
@@ -45,8 +45,10 @@ OpBranchConditional %18 %20 %21
 OpLine %7 29 9
 %22 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %19
+OpReturn
 %21 = OpLabel
+OpBranch %19
+%19 = OpLabel
 OpLine %7 29 9
 %23 = OpUDiv  %8  %16 %17
 %24 = OpIEqual  %13  %17 %14
@@ -57,8 +59,10 @@ OpBranchConditional %24 %26 %27
 OpLine %7 29 9
 %28 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %25
+OpReturn
 %27 = OpLabel
+OpBranch %25
+%25 = OpLabel
 OpLine %7 29 9
 %29 = OpUDiv  %8  %23 %17
 %30 = OpIEqual  %13  %17 %14
@@ -69,8 +73,10 @@ OpBranchConditional %30 %32 %33
 OpLine %7 29 9
 %34 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %31
+OpReturn
 %33 = OpLabel
+OpBranch %31
+%31 = OpLabel
 OpLine %7 29 9
 %35 = OpUDiv  %8  %29 %17
 %36 = OpIEqual  %13  %17 %14
@@ -81,8 +87,10 @@ OpBranchConditional %36 %38 %39
 OpLine %7 29 9
 %40 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %37
+OpReturn
 %39 = OpLabel
+OpBranch %37
+%37 = OpLabel
 OpLine %7 29 9
 %41 = OpUDiv  %8  %35 %17
 %42 = OpIEqual  %13  %17 %14
@@ -93,8 +101,10 @@ OpBranchConditional %42 %44 %45
 OpLine %7 29 9
 %46 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %43
+OpReturn
 %45 = OpLabel
+OpBranch %43
+%43 = OpLabel
 OpLine %7 29 9
 %47 = OpUDiv  %8  %41 %17
 %48 = OpIEqual  %13  %17 %14
@@ -105,8 +115,10 @@ OpBranchConditional %48 %50 %51
 OpLine %7 29 9
 %52 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %49
+OpReturn
 %51 = OpLabel
+OpBranch %49
+%49 = OpLabel
 OpLine %7 29 9
 %53 = OpUDiv  %8  %47 %17
 %54 = OpIEqual  %13  %17 %14
@@ -117,8 +129,10 @@ OpBranchConditional %54 %56 %57
 OpLine %7 29 9
 %58 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %55
+OpReturn
 %57 = OpLabel
+OpBranch %55
+%55 = OpLabel
 OpLine %7 29 9
 %59 = OpUDiv  %8  %53 %17
 %60 = OpIEqual  %13  %17 %14
@@ -129,8 +143,10 @@ OpBranchConditional %60 %62 %63
 OpLine %7 29 9
 %64 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %61
+OpReturn
 %63 = OpLabel
+OpBranch %61
+%61 = OpLabel
 OpLine %7 29 9
 %65 = OpUDiv  %8  %59 %17
 %66 = OpIEqual  %13  %17 %14
@@ -141,8 +157,10 @@ OpBranchConditional %66 %68 %69
 OpLine %7 29 9
 %70 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %67
+OpReturn
 %69 = OpLabel
+OpBranch %67
+%67 = OpLabel
 OpLine %7 29 9
 %71 = OpUDiv  %8  %65 %17
 %72 = OpIEqual  %13  %17 %14
@@ -153,8 +171,10 @@ OpBranchConditional %72 %74 %75
 OpLine %7 29 9
 %76 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %73
+OpReturn
 %75 = OpLabel
+OpBranch %73
+%73 = OpLabel
 OpLine %7 29 9
 %77 = OpUDiv  %8  %71 %17
 %78 = OpIEqual  %13  %17 %14
@@ -165,8 +185,10 @@ OpBranchConditional %78 %80 %81
 OpLine %7 29 9
 %82 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %79
+OpReturn
 %81 = OpLabel
+OpBranch %79
+%79 = OpLabel
 OpLine %7 29 9
 %83 = OpUDiv  %8  %77 %17
 %84 = OpIEqual  %13  %17 %14
@@ -177,8 +199,10 @@ OpBranchConditional %84 %86 %87
 OpLine %7 29 9
 %88 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %85
+OpReturn
 %87 = OpLabel
+OpBranch %85
+%85 = OpLabel
 OpLine %7 29 9
 %89 = OpUDiv  %8  %83 %17
 %90 = OpIEqual  %13  %17 %14
@@ -189,8 +213,10 @@ OpBranchConditional %90 %92 %93
 OpLine %7 29 9
 %94 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %91
+OpReturn
 %93 = OpLabel
+OpBranch %91
+%91 = OpLabel
 OpLine %7 29 9
 %95 = OpUDiv  %8  %89 %17
 %96 = OpIEqual  %13  %17 %14
@@ -201,8 +227,10 @@ OpBranchConditional %96 %98 %99
 OpLine %7 29 9
 %100 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %97
+OpReturn
 %99 = OpLabel
+OpBranch %97
+%97 = OpLabel
 OpLine %7 29 9
 %101 = OpUDiv  %8  %95 %17
 %102 = OpIEqual  %13  %17 %14
@@ -213,8 +241,10 @@ OpBranchConditional %102 %104 %105
 OpLine %7 29 9
 %106 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %103
+OpReturn
 %105 = OpLabel
+OpBranch %103
+%103 = OpLabel
 OpLine %7 29 9
 %107 = OpUDiv  %8  %101 %17
 %108 = OpIEqual  %13  %17 %14
@@ -225,8 +255,10 @@ OpBranchConditional %108 %110 %111
 OpLine %7 29 9
 %112 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %109
+OpReturn
 %111 = OpLabel
+OpBranch %109
+%109 = OpLabel
 OpLine %7 29 9
 %113 = OpUDiv  %8  %107 %17
 %114 = OpIEqual  %13  %17 %14
@@ -237,45 +269,13 @@ OpBranchConditional %114 %116 %117
 OpLine %7 29 9
 %118 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %115
+OpReturn
 %117 = OpLabel
+OpBranch %115
+%115 = OpLabel
 OpLine %7 29 4
 %119 = OpUDiv  %8  %113 %17
 OpStore %5 %119
 OpNoLine
-OpBranch %115
-%115 = OpLabel
-OpBranch %109
-%109 = OpLabel
-OpBranch %103
-%103 = OpLabel
-OpBranch %97
-%97 = OpLabel
-OpBranch %91
-%91 = OpLabel
-OpBranch %85
-%85 = OpLabel
-OpBranch %79
-%79 = OpLabel
-OpBranch %73
-%73 = OpLabel
-OpBranch %67
-%67 = OpLabel
-OpBranch %61
-%61 = OpLabel
-OpBranch %55
-%55 = OpLabel
-OpBranch %49
-%49 = OpLabel
-OpBranch %43
-%43 = OpLabel
-OpBranch %37
-%37 = OpLabel
-OpBranch %31
-%31 = OpLabel
-OpBranch %25
-%25 = OpLabel
-OpBranch %19
-%19 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/lang/core/unwrap_or.stderr
+++ b/tests/ui/lang/core/unwrap_or.stderr
@@ -15,17 +15,9 @@ OpBranch %18
 %20 = OpLabel
 OpBranch %18
 %18 = OpLabel
-%21 = OpPhi  %16  %22 %19 %23 %20
-%24 = OpPhi  %11  %25 %19 %10 %20
-OpSelectionMerge %26 None
-OpBranchConditional %21 %27 %28
-%27 = OpLabel
-OpBranch %26
-%28 = OpLabel
-OpBranch %26
-%26 = OpLabel
+%21 = OpPhi  %11  %22 %19 %10 %20
 OpLine %5 13 4
-OpStore %29 %24
+OpStore %23 %21
 OpNoLine
 OpReturn
 OpFunctionEnd


### PR DESCRIPTION
This PR improves structurization of panics and other functions that exit the invocation, like `OpKill` (`discard;` in glsl) in fragment shaders. This should hopefully reduce the amount of structurization errors in the resulting spv.

Mainly developed by @eddyb with some test fixes by @LegNeato 