### PR TITLE
Linker: speedup and debug info preservation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,14 +2435,13 @@ dependencies = [
 [[package]]
 name = "spirt"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e1f7903720ff818d6da824edf2c4082c6e7a029a99317fd10c39dd7c40c7ff"
+source = "git+https://github.com/Rust-GPU/spirt?rev=39140c7f74d4cf77412f619b3b74d3be236ee5d3#39140c7f74d4cf77412f619b3b74d3be236ee5d3"
 dependencies = [
  "arrayvec",
  "bytemuck",
  "derive_more",
  "elsa",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "internal-iterator",
  "itertools",
  "lazy_static",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -55,7 +55,9 @@ rustc_codegen_spirv-types.workspace = true
 rustc-demangle = "0.1.21"
 sanitize-filename = "0.4"
 smallvec = { version = "1.6.1", features = ["union"] }
-spirt = "0.3.0"
+# FIXME(eddyb) release 0.4.0
+# spirt = "0.4.0"
+spirt = { version = "0.3.0", git = "https://github.com/Rust-GPU/spirt", rev = "39140c7f74d4cf77412f619b3b74d3be236ee5d3" }
 spirv-tools.workspace = true
 lazy_static = "1.4.0"
 itertools = "0.10.5"

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -462,6 +462,11 @@ impl CodegenArgs {
             );
             opts.optflag(
                 "",
+                "spirt-keep-unstructured-cfg-in-dumps",
+                "include initial unstructured CFG when dumping SPIR-T",
+            );
+            opts.optflag(
+                "",
                 "specializer-debug",
                 "enable debug logging for the specializer",
             );
@@ -629,6 +634,8 @@ impl CodegenArgs {
                 .opt_present("spirt-strip-custom-debuginfo-from-dumps"),
             spirt_keep_debug_sources_in_dumps: matches
                 .opt_present("spirt-keep-debug-sources-in-dumps"),
+            spirt_keep_unstructured_cfg_in_dumps: matches
+                .opt_present("spirt-keep-unstructured-cfg-in-dumps"),
             specializer_debug: matches.opt_present("specializer-debug"),
             specializer_dump_instances: matches_opt_path("specializer-dump-instances"),
             print_all_zombie: matches.opt_present("print-all-zombie"),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -440,6 +440,18 @@ impl CodegenArgs {
             );
             opts.optopt(
                 "",
+                "dump-pre-inline",
+                "dump the module immediately before inlining, to a file in DIR",
+                "DIR",
+            );
+            opts.optopt(
+                "",
+                "dump-post-inline",
+                "dump the module immediately after inlining, to a file in DIR",
+                "DIR",
+            );
+            opts.optopt(
+                "",
                 "dump-post-split",
                 "dump modules immediately after multimodule splitting, to files in DIR",
                 "DIR",
@@ -628,6 +640,8 @@ impl CodegenArgs {
             // NOTE(eddyb) these are debugging options that used to be env vars
             // (for more information see `docs/src/codegen-args.md`).
             dump_post_merge: matches_opt_dump_dir_path("dump-post-merge"),
+            dump_pre_inline: matches_opt_dump_dir_path("dump-pre-inline"),
+            dump_post_inline: matches_opt_dump_dir_path("dump-post-inline"),
             dump_post_split: matches_opt_dump_dir_path("dump-post-split"),
             dump_spirt_passes: matches_opt_dump_dir_path("dump-spirt-passes"),
             spirt_strip_custom_debuginfo_from_dumps: matches

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -17,8 +17,6 @@ use rustc_session::Session;
 use smallvec::SmallVec;
 use std::mem;
 
-type FunctionMap = FxHashMap<Word, Function>;
-
 // FIXME(eddyb) this is a bit silly, but this keeps being repeated everywhere.
 fn next_id(header: &mut ModuleHeader) -> Word {
     let result = header.bound;
@@ -30,6 +28,9 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
     // This algorithm gets real sad if there's recursion - but, good news, SPIR-V bans recursion
     deny_recursion_in_module(sess, module)?;
 
+    // Compute the call-graph that will drive (inside-out, aka bottom-up) inlining.
+    let (call_graph, func_id_to_idx) = CallGraph::collect_with_func_id_to_idx(module);
+
     let custom_ext_inst_set_import = module
         .ext_inst_imports
         .iter()
@@ -39,62 +40,7 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
         })
         .map(|inst| inst.result_id.unwrap());
 
-    // HACK(eddyb) compute the set of functions that may `Abort` *transitively*,
-    // which is only needed because of how we inline (sometimes it's outside-in,
-    // aka top-down, instead of always being inside-out, aka bottom-up).
-    //
-    // (inlining is needed in the first place because our custom `Abort`
-    // instructions get lowered to a simple `OpReturn` in entry-points, but
-    // that requires that they get inlined all the way up to the entry-points)
-    let functions_that_may_abort = custom_ext_inst_set_import
-        .map(|custom_ext_inst_set_import| {
-            let mut may_abort_by_id = FxHashSet::default();
-
-            // FIXME(eddyb) use this `CallGraph` abstraction more during inlining.
-            let call_graph = CallGraph::collect(module);
-            for func_idx in call_graph.post_order() {
-                let func_id = module.functions[func_idx].def_id().unwrap();
-
-                let any_callee_may_abort = call_graph.callees[func_idx].iter().any(|&callee_idx| {
-                    may_abort_by_id.contains(&module.functions[callee_idx].def_id().unwrap())
-                });
-                if any_callee_may_abort {
-                    may_abort_by_id.insert(func_id);
-                    continue;
-                }
-
-                let may_abort_directly = module.functions[func_idx].blocks.iter().any(|block| {
-                    match &block.instructions[..] {
-                        [.., last_normal_inst, terminator_inst]
-                            if last_normal_inst.class.opcode == Op::ExtInst
-                                && last_normal_inst.operands[0].unwrap_id_ref()
-                                    == custom_ext_inst_set_import
-                                && CustomOp::decode_from_ext_inst(last_normal_inst)
-                                    == CustomOp::Abort =>
-                        {
-                            assert_eq!(terminator_inst.class.opcode, Op::Unreachable);
-                            true
-                        }
-
-                        _ => false,
-                    }
-                });
-                if may_abort_directly {
-                    may_abort_by_id.insert(func_id);
-                }
-            }
-
-            may_abort_by_id
-        })
-        .unwrap_or_default();
-
-    let functions = module
-        .functions
-        .iter()
-        .map(|f| (f.def_id().unwrap(), f.clone()))
-        .collect();
-    let legal_globals = LegalGlobal::gather_from_module(module);
-
+    /*
     // Drop all the functions we'll be inlining. (This also means we won't waste time processing
     // inlines in functions that will get inlined)
     let mut dropped_ids = FxHashSet::default();
@@ -123,6 +69,9 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
             ));
         }
     }
+     */
+
+    let legal_globals = LegalGlobal::gather_from_module(module);
 
     let header = module.header.as_mut().unwrap();
     // FIXME(eddyb) clippy false positive (separate `map` required for borrowck).
@@ -154,6 +103,8 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
             id
         }),
 
+        func_id_to_idx,
+
         id_to_name: module
             .debug_names
             .iter()
@@ -173,22 +124,61 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
         annotations: &mut module.annotations,
         types_global_values: &mut module.types_global_values,
 
-        functions: &functions,
-        legal_globals: &legal_globals,
-        functions_that_may_abort: &functions_that_may_abort,
+        legal_globals,
+
+        // NOTE(eddyb) this is needed because our custom `Abort` instructions get
+        // lowered to a simple `OpReturn` in entry-points, but that requires that
+        // they get inlined all the way up to the entry-points in the first place.
+        functions_that_may_abort: module
+            .functions
+            .iter()
+            .filter_map(|func| {
+                let custom_ext_inst_set_import = custom_ext_inst_set_import?;
+                func.blocks
+                    .iter()
+                    .any(|block| match &block.instructions[..] {
+                        [.., last_normal_inst, terminator_inst]
+                            if last_normal_inst.class.opcode == Op::ExtInst
+                                && last_normal_inst.operands[0].unwrap_id_ref()
+                                    == custom_ext_inst_set_import
+                                && CustomOp::decode_from_ext_inst(last_normal_inst)
+                                    == CustomOp::Abort =>
+                        {
+                            assert_eq!(terminator_inst.class.opcode, Op::Unreachable);
+                            true
+                        }
+
+                        _ => false,
+                    })
+                    .then_some(func.def_id().unwrap())
+            })
+            .collect(),
     };
-    for function in &mut module.functions {
-        inliner.inline_fn(function);
-        fuse_trivial_branches(function);
+
+    let mut functions: Vec<_> = mem::take(&mut module.functions)
+        .into_iter()
+        .map(Ok)
+        .collect();
+
+    // Inline functions in post-order (aka inside-out aka bottom-out) - that is,
+    // callees are processed before their callers, to avoid duplicating work.
+    for func_idx in call_graph.post_order() {
+        let mut function = mem::replace(&mut functions[func_idx], Err(FuncIsBeingInlined)).unwrap();
+        inliner.inline_fn(&mut function, &functions);
+        fuse_trivial_branches(&mut function);
+        functions[func_idx] = Ok(function);
     }
 
+    module.functions = functions.into_iter().map(|func| func.unwrap()).collect();
+
+    /*
     // Drop OpName etc. for inlined functions
     module.debug_names.retain(|inst| {
         !inst.operands.iter().any(|op| {
             op.id_ref_any()
                 .map_or(false, |id| dropped_ids.contains(&id))
         })
-    });
+    });*/
 
     Ok(())
 }
@@ -456,18 +446,26 @@ fn should_inline(
     Ok(callee_control.contains(FunctionControl::INLINE))
 }
 
+/// Helper error type for `Inliner`'s `functions` field, indicating a `Function`
+/// was taken out of its slot because it's being inlined.
+#[derive(Debug)]
+struct FuncIsBeingInlined;
+
 // Steps:
 // Move OpVariable decls
 // Rewrite return
 // Renumber IDs
 // Insert blocks
 
-struct Inliner<'m, 'map> {
+struct Inliner<'m> {
     /// ID of `OpExtInstImport` for our custom "extended instruction set"
     /// (see `crate::custom_insts` for more details).
     custom_ext_inst_set_import: Word,
 
     op_type_void_id: Word,
+
+    /// Map from each function's ID to its index in `functions`.
+    func_id_to_idx: FxHashMap<Word, usize>,
 
     /// Pre-collected `OpName`s, that can be used to find any function's name
     /// during inlining (to be able to generate debuginfo that uses names).
@@ -485,13 +483,12 @@ struct Inliner<'m, 'map> {
     annotations: &'m mut Vec<Instruction>,
     types_global_values: &'m mut Vec<Instruction>,
 
-    functions: &'map FunctionMap,
-    legal_globals: &'map FxHashMap<Word, LegalGlobal>,
-    functions_that_may_abort: &'map FxHashSet<Word>,
+    legal_globals: FxHashMap<Word, LegalGlobal>,
+    functions_that_may_abort: FxHashSet<Word>,
     // rewrite_rules: FxHashMap<Word, Word>,
 }
 
-impl Inliner<'_, '_> {
+impl Inliner<'_> {
     fn id(&mut self) -> Word {
         next_id(self.header)
     }
@@ -536,19 +533,29 @@ impl Inliner<'_, '_> {
         inst_id
     }
 
-    fn inline_fn(&mut self, function: &mut Function) {
+    fn inline_fn(
+        &mut self,
+        function: &mut Function,
+        functions: &[Result<Function, FuncIsBeingInlined>],
+    ) {
         let mut block_idx = 0;
         while block_idx < function.blocks.len() {
             // If we successfully inlined a block, then repeat processing on the same block, in
             // case the newly inlined block has more inlined calls.
             // TODO: This is quadratic
-            if !self.inline_block(function, block_idx) {
+            if !self.inline_block(function, block_idx, functions) {
+                // TODO(eddyb) skip past the inlined callee without rescanning it.
                 block_idx += 1;
             }
         }
     }
 
-    fn inline_block(&mut self, caller: &mut Function, block_idx: usize) -> bool {
+    fn inline_block(
+        &mut self,
+        caller: &mut Function,
+        block_idx: usize,
+        functions: &[Result<Function, FuncIsBeingInlined>],
+    ) -> bool {
         // Find the first inlined OpFunctionCall
         let call = caller.blocks[block_idx]
             .instructions
@@ -559,8 +566,8 @@ impl Inliner<'_, '_> {
                 (
                     index,
                     inst,
-                    self.functions
-                        .get(&inst.operands[0].id_ref_any().unwrap())
+                    functions[self.func_id_to_idx[&inst.operands[0].id_ref_any().unwrap()]]
+                        .as_ref()
                         .unwrap(),
                 )
             })
@@ -570,8 +577,8 @@ impl Inliner<'_, '_> {
                     call_inst: inst,
                 };
                 match should_inline(
-                    self.legal_globals,
-                    self.functions_that_may_abort,
+                    &self.legal_globals,
+                    &self.functions_that_may_abort,
                     f,
                     Some(call_site),
                 ) {
@@ -583,6 +590,16 @@ impl Inliner<'_, '_> {
             None => return false,
             Some(call) => call,
         };
+
+        // Propagate "may abort" from callee to caller (i.e. as aborts get inlined).
+        if self
+            .functions_that_may_abort
+            .contains(&callee.def_id().unwrap())
+        {
+            self.functions_that_may_abort
+                .insert(caller.def_id().unwrap());
+        }
+
         let call_result_type = {
             let ty = call_inst.result_type.unwrap();
             if ty == self.op_type_void_id {
@@ -594,6 +611,7 @@ impl Inliner<'_, '_> {
         let call_result_id = call_inst.result_id.unwrap();
 
         // Get the debuginfo instructions that apply to the call.
+        // TODO(eddyb) only one instruction should be necessary here w/ bottom-up.
         let custom_ext_inst_set_import = self.custom_ext_inst_set_import;
         let call_debug_insts = caller.blocks[block_idx].instructions[..call_index]
             .iter()
@@ -868,6 +886,7 @@ impl Inliner<'_, '_> {
             ..
         } = *self;
 
+        // TODO(eddyb) kill this as it shouldn't be needed for bottom-up inline.
         // HACK(eddyb) this is terrible, but we have to deal with it because of
         // how this inliner is outside-in, instead of inside-out, meaning that
         // context builds up "outside" of the callee blocks, inside the caller.

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -94,7 +94,6 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
         header,
         debug_string_source: &mut module.debug_string_source,
         annotations: &mut module.annotations,
-        types_global_values: &mut module.types_global_values,
 
         legal_globals,
 
@@ -493,7 +492,6 @@ struct Inliner<'a, 'b> {
     header: &'b mut ModuleHeader,
     debug_string_source: &'b mut Vec<Instruction>,
     annotations: &'b mut Vec<Instruction>,
-    types_global_values: &'b mut Vec<Instruction>,
 
     legal_globals: FxHashMap<Word, LegalGlobal>,
     functions_that_may_abort: FxHashSet<Word>,
@@ -521,29 +519,6 @@ impl Inliner<'_, '_> {
                 }
             }
         }
-    }
-
-    fn ptr_ty(&mut self, pointee: Word) -> Word {
-        // TODO: This is horribly slow, fix this
-        let existing = self.types_global_values.iter().find(|inst| {
-            inst.class.opcode == Op::TypePointer
-                && inst.operands[0].unwrap_storage_class() == StorageClass::Function
-                && inst.operands[1].unwrap_id_ref() == pointee
-        });
-        if let Some(existing) = existing {
-            return existing.result_id.unwrap();
-        }
-        let inst_id = self.id();
-        self.types_global_values.push(Instruction::new(
-            Op::TypePointer,
-            None,
-            Some(inst_id),
-            vec![
-                Operand::StorageClass(StorageClass::Function),
-                Operand::IdRef(pointee),
-            ],
-        ));
-        inst_id
     }
 
     fn inline_fn(
@@ -622,15 +597,19 @@ impl Inliner<'_, '_> {
                 .insert(caller.def_id().unwrap());
         }
 
-        let call_result_type = {
+        let mut maybe_call_result_phi = {
             let ty = call_inst.result_type.unwrap();
             if ty == self.op_type_void_id {
                 None
             } else {
-                Some(ty)
+                Some(Instruction::new(
+                    Op::Phi,
+                    Some(ty),
+                    Some(call_inst.result_id.unwrap()),
+                    vec![],
+                ))
             }
         };
-        let call_result_id = call_inst.result_id.unwrap();
 
         // Get the debug "source location" instruction that applies to the call.
         let custom_ext_inst_set_import = self.custom_ext_inst_set_import;
@@ -667,17 +646,12 @@ impl Inliner<'_, '_> {
         });
         let mut rewrite_rules = callee_parameters.zip(call_arguments).collect();
 
-        let return_variable = if call_result_type.is_some() {
-            Some(self.id())
-        } else {
-            None
-        };
         let return_jump = self.id();
         // Rewrite OpReturns of the callee.
         let mut inlined_callee_blocks = self.get_inlined_blocks(
             callee,
             call_debug_src_loc_inst,
-            return_variable,
+            maybe_call_result_phi.as_mut(),
             return_jump,
         );
         // Clone the IDs of the callee, because otherwise they'd be defined multiple times if the
@@ -685,6 +659,55 @@ impl Inliner<'_, '_> {
         self.add_clone_id_rules(&mut rewrite_rules, &inlined_callee_blocks);
         apply_rewrite_rules(&rewrite_rules, &mut inlined_callee_blocks);
         self.apply_rewrite_for_decorations(&rewrite_rules);
+
+        if let Some(call_result_phi) = &mut maybe_call_result_phi {
+            // HACK(eddyb) new IDs should be generated earlier, to avoid pushing
+            // callee IDs to `call_result_phi.operands` only to rewrite them here.
+            for op in &mut call_result_phi.operands {
+                if let Some(id) = op.id_ref_any_mut() {
+                    if let Some(&rewrite) = rewrite_rules.get(id) {
+                        *id = rewrite;
+                    }
+                }
+            }
+
+            // HACK(eddyb) this special-casing of the single-return case is
+            // really necessary for passes like `mem2reg` which are not capable
+            // of skipping through the extraneous `OpPhi`s on their own.
+            if let [returned_value, _return_block] = &call_result_phi.operands[..] {
+                let call_result_id = call_result_phi.result_id.unwrap();
+                let returned_value_id = returned_value.unwrap_id_ref();
+
+                maybe_call_result_phi = None;
+
+                // HACK(eddyb) this is a conservative approximation of all the
+                // instructions that could potentially reference the call result.
+                let reaching_insts = {
+                    let (pre_call_blocks, call_and_post_call_blocks) =
+                        caller.blocks.split_at_mut(block_idx);
+                    (pre_call_blocks.iter_mut().flat_map(|block| {
+                        block
+                            .instructions
+                            .iter_mut()
+                            .take_while(|inst| inst.class.opcode == Op::Phi)
+                    }))
+                    .chain(
+                        call_and_post_call_blocks
+                            .iter_mut()
+                            .flat_map(|block| &mut block.instructions),
+                    )
+                };
+                for reaching_inst in reaching_insts {
+                    for op in &mut reaching_inst.operands {
+                        if let Some(id) = op.id_ref_any_mut() {
+                            if *id == call_result_id {
+                                *id = returned_value_id;
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         // Split the block containing the `OpFunctionCall` into pre-call vs post-call.
         let pre_call_block_idx = block_idx;
@@ -701,18 +724,6 @@ impl Inliner<'_, '_> {
             .unwrap();
         assert!(call.class.opcode == Op::FunctionCall);
 
-        if let Some(call_result_type) = call_result_type {
-            // Generate the storage space for the return value: Do this *after* the split above,
-            // because if block_idx=0, inserting a variable here shifts call_index.
-            let ret_var_inst = Instruction::new(
-                Op::Variable,
-                Some(self.ptr_ty(call_result_type)),
-                Some(return_variable.unwrap()),
-                vec![Operand::StorageClass(StorageClass::Function)],
-            );
-            self.insert_opvariables(&mut caller.blocks[0], [ret_var_inst]);
-        }
-
         // Insert non-entry inlined callee blocks just after the pre-call block.
         let non_entry_inlined_callee_blocks = inlined_callee_blocks.drain(1..);
         let num_non_entry_inlined_callee_blocks = non_entry_inlined_callee_blocks.len();
@@ -721,18 +732,9 @@ impl Inliner<'_, '_> {
             non_entry_inlined_callee_blocks,
         );
 
-        if let Some(call_result_type) = call_result_type {
-            // Add the load of the result value after the inlined function. Note there's guaranteed no
-            // OpPhi instructions since we just split this block.
-            post_call_block_insts.insert(
-                0,
-                Instruction::new(
-                    Op::Load,
-                    Some(call_result_type),
-                    Some(call_result_id),
-                    vec![Operand::IdRef(return_variable.unwrap())],
-                ),
-            );
+        if let Some(call_result_phi) = maybe_call_result_phi {
+            // Add the `OpPhi` for the call result value, after the inlined function.
+            post_call_block_insts.insert(0, call_result_phi);
         }
 
         // Insert the post-call block, after all the inlined callee blocks.
@@ -899,7 +901,7 @@ impl Inliner<'_, '_> {
         &mut self,
         callee: &Function,
         call_debug_src_loc_inst: Option<&Instruction>,
-        return_variable: Option<Word>,
+        mut maybe_call_result_phi: Option<&mut Instruction>,
         return_jump: Word,
     ) -> Vec<Block> {
         let Self {
@@ -997,17 +999,13 @@ impl Inliner<'_, '_> {
             if let Op::Return | Op::ReturnValue = terminator.class.opcode {
                 if Op::ReturnValue == terminator.class.opcode {
                     let return_value = terminator.operands[0].id_ref_any().unwrap();
-                    block.instructions.push(Instruction::new(
-                        Op::Store,
-                        None,
-                        None,
-                        vec![
-                            Operand::IdRef(return_variable.unwrap()),
-                            Operand::IdRef(return_value),
-                        ],
-                    ));
+                    let call_result_phi = maybe_call_result_phi.as_deref_mut().unwrap();
+                    call_result_phi.operands.extend([
+                        Operand::IdRef(return_value),
+                        Operand::IdRef(block.label_id().unwrap()),
+                    ]);
                 } else {
-                    assert!(return_variable.is_none());
+                    assert!(maybe_call_result_phi.is_none());
                 }
                 terminator =
                     Instruction::new(Op::Branch, None, None, vec![Operand::IdRef(return_jump)]);

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -8,13 +8,15 @@ use super::apply_rewrite_rules;
 use super::ipo::CallGraph;
 use super::simple_passes::outgoing_edges;
 use super::{get_name, get_names};
+use crate::custom_decorations::SpanRegenerator;
 use crate::custom_insts::{self, CustomInst, CustomOp};
 use rspirv::dr::{Block, Function, Instruction, Module, ModuleHeader, Operand};
 use rspirv::spirv::{FunctionControl, Op, StorageClass, Word};
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_errors::ErrorGuaranteed;
 use rustc_session::Session;
 use smallvec::SmallVec;
+use std::cmp::Ordering;
 use std::mem;
 
 // FIXME(eddyb) this is a bit silly, but this keeps being repeated everywhere.
@@ -40,40 +42,10 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
         })
         .map(|inst| inst.result_id.unwrap());
 
-    /*
-    // Drop all the functions we'll be inlining. (This also means we won't waste time processing
-    // inlines in functions that will get inlined)
-    let mut dropped_ids = FxHashSet::default();
-    let mut inlined_to_legalize_dont_inlines = Vec::new();
-    module.functions.retain(|f| {
-        let should_inline_f = should_inline(&legal_globals, &functions_that_may_abort, f, None);
-        if should_inline_f != Ok(false) {
-            if should_inline_f == Err(MustInlineToLegalize) && has_dont_inline(f) {
-                inlined_to_legalize_dont_inlines.push(f.def_id().unwrap());
-            }
-            // TODO: We should insert all defined IDs in this function.
-            dropped_ids.insert(f.def_id().unwrap());
-            false
-        } else {
-            true
-        }
-    });
-
-    if !inlined_to_legalize_dont_inlines.is_empty() {
-        let names = get_names(module);
-        for f in inlined_to_legalize_dont_inlines {
-            sess.dcx().warn(format!(
-                "`#[inline(never)]` function `{}` needs to be inlined \
-                 because it has illegal argument or return types",
-                get_name(&names, f)
-            ));
-        }
-    }
-     */
-
     let legal_globals = LegalGlobal::gather_from_module(module);
 
     let header = module.header.as_mut().unwrap();
+
     // FIXME(eddyb) clippy false positive (separate `map` required for borrowck).
     #[allow(clippy::map_unwrap_or)]
     let mut inliner = Inliner {
@@ -153,6 +125,8 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
                     .then_some(func.def_id().unwrap())
             })
             .collect(),
+
+        inlined_dont_inlines_to_cause_and_callers: FxIndexMap::default(),
     };
 
     let mut functions: Vec<_> = mem::take(&mut module.functions)
@@ -171,14 +145,52 @@ pub fn inline(sess: &Session, module: &mut Module) -> super::Result<()> {
 
     module.functions = functions.into_iter().map(|func| func.unwrap()).collect();
 
-    /*
-    // Drop OpName etc. for inlined functions
-    module.debug_names.retain(|inst| {
-        !inst.operands.iter().any(|op| {
-            op.id_ref_any()
-                .map_or(false, |id| dropped_ids.contains(&id))
-        })
-    });*/
+    let Inliner {
+        id_to_name,
+        inlined_dont_inlines_to_cause_and_callers,
+        ..
+    } = inliner;
+
+    let mut span_regen = SpanRegenerator::new(sess.source_map(), module);
+    for (callee_id, (cause, callers)) in inlined_dont_inlines_to_cause_and_callers {
+        let callee_name = get_name(&id_to_name, callee_id);
+
+        // HACK(eddyb) `libcore` hides panics behind `#[inline(never)]` `fn`s,
+        // making this too noisy and useless (since it's an impl detail).
+        if cause == "panicking" && callee_name.starts_with("core::") {
+            continue;
+        }
+
+        let callee_span = span_regen
+            .src_loc_for_id(callee_id)
+            .and_then(|src_loc| span_regen.src_loc_to_rustc(src_loc))
+            .unwrap_or_default();
+        sess.dcx()
+            .struct_span_warn(
+                callee_span,
+                format!("`#[inline(never)]` function `{callee_name}` has been inlined"),
+            )
+            .with_note(format!("inlining was required due to {cause}"))
+            .with_note(format!(
+                "called from {}",
+                callers
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, &caller_id)| {
+                        // HACK(eddyb) avoid showing too many names.
+                        match i.cmp(&4) {
+                            Ordering::Less => {
+                                Some(format!("`{}`", get_name(&id_to_name, caller_id)))
+                            }
+                            Ordering::Equal => Some(format!("and {} more", callers.len() - i)),
+                            Ordering::Greater => None,
+                        }
+                    })
+                    .collect::<SmallVec<[_; 5]>>()
+                    .join(", ")
+            ))
+            .emit();
+    }
 
     Ok(())
 }
@@ -361,42 +373,42 @@ fn has_dont_inline(function: &Function) -> bool {
 
 /// Helper error type for `should_inline` (see its doc comment).
 #[derive(Copy, Clone, PartialEq, Eq)]
-struct MustInlineToLegalize;
+struct MustInlineToLegalize(&'static str);
 
-/// Returns `Ok(true)`/`Err(MustInlineToLegalize)` if `callee` should/must be
+/// Returns `Ok(true)`/`Err(MustInlineToLegalize(_))` if `callee` should/must be
 /// inlined (either in general, or specifically from `call_site`, if provided).
 ///
-/// The distinction made is that `Err(MustInlineToLegalize)` is not a heuristic,
-/// and inlining is *mandatory* due to an illegal signature/arguments.
+/// The distinction made here is that `Err(MustInlineToLegalize(cause))` is
+/// very much *not* a heuristic, and inlining is *mandatory* due to `cause`
+/// (usually illegal signature/arguments, but also the panicking mechanism).
+//
+// FIXME(eddyb) the causes here are not fine-grained enough.
 fn should_inline(
     legal_globals: &FxHashMap<Word, LegalGlobal>,
     functions_that_may_abort: &FxHashSet<Word>,
     callee: &Function,
-    call_site: Option<CallSite<'_>>,
+    call_site: CallSite<'_>,
 ) -> Result<bool, MustInlineToLegalize> {
     let callee_def = callee.def.as_ref().unwrap();
     let callee_control = callee_def.operands[0].unwrap_function_control();
 
-    // HACK(eddyb) this "has a call-site" check ensures entry-points don't get
-    // accidentally removed as "must inline to legalize" function, but can still
-    // be inlined into other entry-points (if such an unusual situation arises).
-    if call_site.is_some() && functions_that_may_abort.contains(&callee.def_id().unwrap()) {
-        return Err(MustInlineToLegalize);
+    if functions_that_may_abort.contains(&callee.def_id().unwrap()) {
+        return Err(MustInlineToLegalize("panicking"));
     }
 
     let ret_ty = legal_globals
         .get(&callee_def.result_type.unwrap())
-        .ok_or(MustInlineToLegalize)?;
+        .ok_or(MustInlineToLegalize("illegal return type"))?;
     if !ret_ty.legal_as_fn_ret_ty() {
-        return Err(MustInlineToLegalize);
+        return Err(MustInlineToLegalize("illegal (pointer) return type"));
     }
 
     for (i, param) in callee.parameters.iter().enumerate() {
         let param_ty = legal_globals
             .get(param.result_type.as_ref().unwrap())
-            .ok_or(MustInlineToLegalize)?;
+            .ok_or(MustInlineToLegalize("illegal parameter type"))?;
         if !param_ty.legal_as_fn_param_ty() {
-            return Err(MustInlineToLegalize);
+            return Err(MustInlineToLegalize("illegal (pointer) parameter type"));
         }
 
         // If the call isn't passing a legal pointer argument (a "memory object",
@@ -404,13 +416,13 @@ fn should_inline(
         // then inlining is required to have a chance at producing legal SPIR-V.
         //
         // FIXME(eddyb) rewriting away the pointer could be another alternative.
-        if let (LegalGlobal::TypePointer(_), Some(call_site)) = (param_ty, call_site) {
+        if let LegalGlobal::TypePointer(_) = param_ty {
             let ptr_arg = call_site.call_inst.operands[i + 1].unwrap_id_ref();
             match legal_globals.get(&ptr_arg) {
                 Some(LegalGlobal::Variable) => {}
 
                 // FIXME(eddyb) should some constants (undef/null) be allowed?
-                Some(_) => return Err(MustInlineToLegalize),
+                Some(_) => return Err(MustInlineToLegalize("illegal (pointer) argument")),
 
                 None => {
                     let mut caller_param_and_var_ids = call_site
@@ -436,7 +448,7 @@ fn should_inline(
                         .map(|caller_inst| caller_inst.result_id.unwrap());
 
                     if !caller_param_and_var_ids.any(|id| ptr_arg == id) {
-                        return Err(MustInlineToLegalize);
+                        return Err(MustInlineToLegalize("illegal (pointer) argument"));
                     }
                 }
             }
@@ -457,7 +469,7 @@ struct FuncIsBeingInlined;
 // Renumber IDs
 // Insert blocks
 
-struct Inliner<'m> {
+struct Inliner<'a, 'b> {
     /// ID of `OpExtInstImport` for our custom "extended instruction set"
     /// (see `crate::custom_insts` for more details).
     custom_ext_inst_set_import: Word,
@@ -469,26 +481,27 @@ struct Inliner<'m> {
 
     /// Pre-collected `OpName`s, that can be used to find any function's name
     /// during inlining (to be able to generate debuginfo that uses names).
-    id_to_name: FxHashMap<Word, &'m str>,
+    id_to_name: FxHashMap<Word, &'a str>,
 
     /// `OpString` cache (for deduplicating `OpString`s for the same string).
     //
     // FIXME(eddyb) currently this doesn't reuse existing `OpString`s, but since
     // this is mostly for inlined callee names, it's expected almost no overlap
     // exists between existing `OpString`s and new ones, anyway.
-    cached_op_strings: FxHashMap<&'m str, Word>,
+    cached_op_strings: FxHashMap<&'a str, Word>,
 
-    header: &'m mut ModuleHeader,
-    debug_string_source: &'m mut Vec<Instruction>,
-    annotations: &'m mut Vec<Instruction>,
-    types_global_values: &'m mut Vec<Instruction>,
+    header: &'b mut ModuleHeader,
+    debug_string_source: &'b mut Vec<Instruction>,
+    annotations: &'b mut Vec<Instruction>,
+    types_global_values: &'b mut Vec<Instruction>,
 
     legal_globals: FxHashMap<Word, LegalGlobal>,
     functions_that_may_abort: FxHashSet<Word>,
+    inlined_dont_inlines_to_cause_and_callers: FxIndexMap<Word, (&'static str, FxIndexSet<Word>)>,
     // rewrite_rules: FxHashMap<Word, Word>,
 }
 
-impl Inliner<'_> {
+impl Inliner<'_, '_> {
     fn id(&mut self) -> Word {
         next_id(self.header)
     }
@@ -580,10 +593,19 @@ impl Inliner<'_> {
                     &self.legal_globals,
                     &self.functions_that_may_abort,
                     f,
-                    Some(call_site),
+                    call_site,
                 ) {
                     Ok(inline) => inline,
-                    Err(MustInlineToLegalize) => true,
+                    Err(MustInlineToLegalize(cause)) => {
+                        if has_dont_inline(f) {
+                            self.inlined_dont_inlines_to_cause_and_callers
+                                .entry(f.def_id().unwrap())
+                                .or_insert_with(|| (cause, Default::default()))
+                                .1
+                                .insert(caller.def_id().unwrap());
+                        }
+                        true
+                    }
                 }
             });
         let (call_index, call_inst, callee) = match call {
@@ -610,18 +632,28 @@ impl Inliner<'_> {
         };
         let call_result_id = call_inst.result_id.unwrap();
 
-        // Get the debuginfo instructions that apply to the call.
-        // TODO(eddyb) only one instruction should be necessary here w/ bottom-up.
+        // Get the debug "source location" instruction that applies to the call.
         let custom_ext_inst_set_import = self.custom_ext_inst_set_import;
-        let call_debug_insts = caller.blocks[block_idx].instructions[..call_index]
+        let call_debug_src_loc_inst = caller.blocks[block_idx].instructions[..call_index]
             .iter()
-            .filter(|inst| match inst.class.opcode {
-                Op::Line | Op::NoLine => true,
-                Op::ExtInst if inst.operands[0].unwrap_id_ref() == custom_ext_inst_set_import => {
-                    CustomOp::decode_from_ext_inst(inst).is_debuginfo()
-                }
-                _ => false,
-            });
+            .rev()
+            .find_map(|inst| {
+                Some(match inst.class.opcode {
+                    Op::Line => Some(inst),
+                    Op::NoLine => None,
+                    Op::ExtInst
+                        if inst.operands[0].unwrap_id_ref() == custom_ext_inst_set_import =>
+                    {
+                        match CustomOp::decode_from_ext_inst(inst) {
+                            CustomOp::SetDebugSrcLoc => Some(inst),
+                            CustomOp::ClearDebugSrcLoc => None,
+                            _ => return None,
+                        }
+                    }
+                    _ => return None,
+                })
+            })
+            .flatten();
 
         // Rewrite parameters to arguments
         let call_arguments = call_inst
@@ -642,9 +674,12 @@ impl Inliner<'_> {
         };
         let return_jump = self.id();
         // Rewrite OpReturns of the callee.
-        #[allow(clippy::needless_borrow)]
-        let (mut inlined_callee_blocks, extra_debug_insts_pre_call, extra_debug_insts_post_call) =
-            self.get_inlined_blocks(&callee, call_debug_insts, return_variable, return_jump);
+        let mut inlined_callee_blocks = self.get_inlined_blocks(
+            callee,
+            call_debug_src_loc_inst,
+            return_variable,
+            return_jump,
+        );
         // Clone the IDs of the callee, because otherwise they'd be defined multiple times if the
         // fn is inlined multiple times.
         self.add_clone_id_rules(&mut rewrite_rules, &inlined_callee_blocks);
@@ -665,13 +700,6 @@ impl Inliner<'_> {
             .pop()
             .unwrap();
         assert!(call.class.opcode == Op::FunctionCall);
-
-        // HACK(eddyb) inject the additional debuginfo instructions generated by
-        // `get_inlined_blocks`, so the inlined call frame "stack" isn't corrupted.
-        caller.blocks[pre_call_block_idx]
-            .instructions
-            .extend(extra_debug_insts_pre_call);
-        post_call_block_insts.splice(0..0, extra_debug_insts_post_call);
 
         if let Some(call_result_type) = call_result_type {
             // Generate the storage space for the return value: Do this *after* the split above,
@@ -867,58 +895,18 @@ impl Inliner<'_> {
         }
     }
 
-    // HACK(eddyb) the second and third return values are additional debuginfo
-    // instructions that need to be inserted just before/after the callsite.
-    fn get_inlined_blocks<'a>(
+    fn get_inlined_blocks(
         &mut self,
         callee: &Function,
-        call_debug_insts: impl Iterator<Item = &'a Instruction>,
+        call_debug_src_loc_inst: Option<&Instruction>,
         return_variable: Option<Word>,
         return_jump: Word,
-    ) -> (
-        Vec<Block>,
-        SmallVec<[Instruction; 8]>,
-        SmallVec<[Instruction; 8]>,
-    ) {
+    ) -> Vec<Block> {
         let Self {
             custom_ext_inst_set_import,
             op_type_void_id,
             ..
         } = *self;
-
-        // TODO(eddyb) kill this as it shouldn't be needed for bottom-up inline.
-        // HACK(eddyb) this is terrible, but we have to deal with it because of
-        // how this inliner is outside-in, instead of inside-out, meaning that
-        // context builds up "outside" of the callee blocks, inside the caller.
-        let mut enclosing_inlined_frames = SmallVec::<[_; 8]>::new();
-        let mut current_debug_src_loc_inst = None;
-        for inst in call_debug_insts {
-            match inst.class.opcode {
-                Op::Line => current_debug_src_loc_inst = Some(inst),
-                Op::NoLine => current_debug_src_loc_inst = None,
-                Op::ExtInst
-                    if inst.operands[0].unwrap_id_ref() == self.custom_ext_inst_set_import =>
-                {
-                    match CustomOp::decode_from_ext_inst(inst) {
-                        CustomOp::SetDebugSrcLoc => current_debug_src_loc_inst = Some(inst),
-                        CustomOp::ClearDebugSrcLoc => current_debug_src_loc_inst = None,
-                        CustomOp::PushInlinedCallFrame => {
-                            enclosing_inlined_frames
-                                .push((current_debug_src_loc_inst.take(), inst));
-                        }
-                        CustomOp::PopInlinedCallFrame => {
-                            if let Some((callsite_debug_src_loc_inst, _)) =
-                                enclosing_inlined_frames.pop()
-                            {
-                                current_debug_src_loc_inst = callsite_debug_src_loc_inst;
-                            }
-                        }
-                        CustomOp::Abort => {}
-                    }
-                }
-                _ => {}
-            }
-        }
 
         // Prepare the debuginfo insts to prepend/append to every block.
         // FIXME(eddyb) this could be more efficient if we only used one pair of
@@ -944,7 +932,7 @@ impl Inliner<'_> {
                 ));
                 id
             });
-        let mut mk_debuginfo_prefix_and_suffix = |include_callee_frame| {
+        let mut mk_debuginfo_prefix_and_suffix = || {
             // NOTE(eddyb) `OpExtInst`s have a result ID, even if unused, and
             // it has to be unique (same goes for the other instructions below).
             let instantiate_debuginfo = |this: &mut Self, inst: &Instruction| {
@@ -968,33 +956,18 @@ impl Inliner<'_> {
                     .collect(),
                 )
             };
-            // FIXME(eddyb) this only allocates to avoid borrow conflicts.
-            let mut prefix = SmallVec::<[_; 8]>::new();
-            let mut suffix = SmallVec::<[_; 8]>::new();
-            for &(callsite_debug_src_loc_inst, push_inlined_call_frame_inst) in
-                &enclosing_inlined_frames
-            {
-                prefix.extend(
-                    callsite_debug_src_loc_inst
-                        .into_iter()
-                        .chain([push_inlined_call_frame_inst])
-                        .map(|inst| instantiate_debuginfo(self, inst)),
-                );
-                suffix.push(custom_inst_to_inst(self, CustomInst::PopInlinedCallFrame));
-            }
-            prefix.extend(current_debug_src_loc_inst.map(|inst| instantiate_debuginfo(self, inst)));
 
-            if include_callee_frame {
-                prefix.push(custom_inst_to_inst(
-                    self,
-                    CustomInst::PushInlinedCallFrame {
-                        callee_name: Operand::IdRef(callee_name_id),
-                    },
-                ));
-                suffix.push(custom_inst_to_inst(self, CustomInst::PopInlinedCallFrame));
-            }
-
-            (prefix, suffix)
+            (
+                (call_debug_src_loc_inst.map(|inst| instantiate_debuginfo(self, inst)))
+                    .into_iter()
+                    .chain([custom_inst_to_inst(
+                        self,
+                        CustomInst::PushInlinedCallFrame {
+                            callee_name: Operand::IdRef(callee_name_id),
+                        },
+                    )]),
+                [custom_inst_to_inst(self, CustomInst::PopInlinedCallFrame)],
+            )
         };
 
         let mut blocks = callee.blocks.clone();
@@ -1048,7 +1021,7 @@ impl Inliner<'_> {
 
             // HACK(eddyb) avoid adding debuginfo to otherwise-empty blocks.
             if block.instructions.len() > num_phis {
-                let (debuginfo_prefix, debuginfo_suffix) = mk_debuginfo_prefix_and_suffix(true);
+                let (debuginfo_prefix, debuginfo_suffix) = mk_debuginfo_prefix_and_suffix();
                 // Insert the prefix debuginfo instructions after `OpPhi`s,
                 // which sadly can't be covered by them.
                 block
@@ -1062,13 +1035,7 @@ impl Inliner<'_> {
             block.instructions.push(terminator);
         }
 
-        let (caller_restore_debuginfo_after_call, calleer_reset_debuginfo_before_call) =
-            mk_debuginfo_prefix_and_suffix(false);
-        (
-            blocks,
-            calleer_reset_debuginfo_before_call,
-            caller_restore_debuginfo_after_call,
-        )
+        blocks
     }
 
     fn insert_opvariables(&self, block: &mut Block, insts: impl IntoIterator<Item = Instruction>) {

--- a/crates/rustc_codegen_spirv/src/linker/ipo.rs
+++ b/crates/rustc_codegen_spirv/src/linker/ipo.rs
@@ -4,7 +4,7 @@
 
 use indexmap::IndexSet;
 use rspirv::dr::Module;
-use rspirv::spirv::Op;
+use rspirv::spirv::{Op, Word};
 use rustc_data_structures::fx::FxHashMap;
 
 // FIXME(eddyb) use newtyped indices and `IndexVec`.
@@ -19,6 +19,9 @@ pub struct CallGraph {
 
 impl CallGraph {
     pub fn collect(module: &Module) -> Self {
+        Self::collect_with_func_id_to_idx(module).0
+    }
+    pub fn collect_with_func_id_to_idx(module: &Module) -> (Self, FxHashMap<Word, FuncIdx>) {
         let func_id_to_idx: FxHashMap<_, _> = module
             .functions
             .iter()
@@ -51,10 +54,13 @@ impl CallGraph {
                     .collect()
             })
             .collect();
-        Self {
-            entry_points,
-            callees,
-        }
+        (
+            Self {
+                entry_points,
+                callees,
+            },
+            func_id_to_idx,
+        )
     }
 
     /// Order functions using a post-order traversal, i.e. callees before callers.

--- a/crates/rustc_codegen_spirv/src/linker/mem2reg.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mem2reg.rs
@@ -13,9 +13,13 @@ use super::simple_passes::outgoing_edges;
 use super::{apply_rewrite_rules, id};
 use rspirv::dr::{Block, Function, Instruction, ModuleHeader, Operand};
 use rspirv::spirv::{Op, Word};
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_middle::bug;
 use std::collections::hash_map;
+
+// HACK(eddyb) newtype instead of type alias to avoid mistakes.
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+struct LabelId(Word);
 
 pub fn mem2reg(
     header: &mut ModuleHeader,
@@ -24,8 +28,16 @@ pub fn mem2reg(
     constants: &FxHashMap<Word, u32>,
     func: &mut Function,
 ) {
-    let reachable = compute_reachable(&func.blocks);
-    let preds = compute_preds(&func.blocks, &reachable);
+    // HACK(eddyb) this ad-hoc indexing might be useful elsewhere as well, but
+    // it's made completely irrelevant by SPIR-T so only applies to legacy code.
+    let mut blocks: FxIndexMap<_, _> = func
+        .blocks
+        .iter_mut()
+        .map(|block| (LabelId(block.label_id().unwrap()), block))
+        .collect();
+
+    let reachable = compute_reachable(&blocks);
+    let preds = compute_preds(&blocks, &reachable);
     let idom = compute_idom(&preds, &reachable);
     let dominance_frontier = compute_dominance_frontier(&preds, &idom);
     loop {
@@ -34,31 +46,27 @@ pub fn mem2reg(
             types_global_values,
             pointer_to_pointee,
             constants,
-            &mut func.blocks,
+            &mut blocks,
             &dominance_frontier,
         );
         if !changed {
             break;
         }
         // mem2reg produces minimal SSA form, not pruned, so DCE the dead ones
-        super::dce::dce_phi(func);
+        super::dce::dce_phi(&mut blocks);
     }
 }
 
-fn label_to_index(blocks: &[Block], id: Word) -> usize {
-    blocks
-        .iter()
-        .position(|b| b.label_id().unwrap() == id)
-        .unwrap()
-}
-
-fn compute_reachable(blocks: &[Block]) -> Vec<bool> {
-    fn recurse(blocks: &[Block], reachable: &mut [bool], block: usize) {
+fn compute_reachable(blocks: &FxIndexMap<LabelId, &mut Block>) -> Vec<bool> {
+    fn recurse(blocks: &FxIndexMap<LabelId, &mut Block>, reachable: &mut [bool], block: usize) {
         if !reachable[block] {
             reachable[block] = true;
-            for dest_id in outgoing_edges(&blocks[block]) {
-                let dest_idx = label_to_index(blocks, dest_id);
-                recurse(blocks, reachable, dest_idx);
+            for dest_id in outgoing_edges(blocks[block]) {
+                recurse(
+                    blocks,
+                    reachable,
+                    blocks.get_index_of(&LabelId(dest_id)).unwrap(),
+                );
             }
         }
     }
@@ -67,17 +75,19 @@ fn compute_reachable(blocks: &[Block]) -> Vec<bool> {
     reachable
 }
 
-fn compute_preds(blocks: &[Block], reachable_blocks: &[bool]) -> Vec<Vec<usize>> {
+fn compute_preds(
+    blocks: &FxIndexMap<LabelId, &mut Block>,
+    reachable_blocks: &[bool],
+) -> Vec<Vec<usize>> {
     let mut result = vec![vec![]; blocks.len()];
     // Do not count unreachable blocks as valid preds of blocks
     for (source_idx, source) in blocks
-        .iter()
+        .values()
         .enumerate()
         .filter(|&(b, _)| reachable_blocks[b])
     {
         for dest_id in outgoing_edges(source) {
-            let dest_idx = label_to_index(blocks, dest_id);
-            result[dest_idx].push(source_idx);
+            result[blocks.get_index_of(&LabelId(dest_id)).unwrap()].push(source_idx);
         }
     }
     result
@@ -161,7 +171,7 @@ fn insert_phis_all(
     types_global_values: &mut Vec<Instruction>,
     pointer_to_pointee: &FxHashMap<Word, Word>,
     constants: &FxHashMap<Word, u32>,
-    blocks: &mut [Block],
+    blocks: &mut FxIndexMap<LabelId, &mut Block>,
     dominance_frontier: &[FxHashSet<usize>],
 ) -> bool {
     let var_maps_and_types = blocks[0]
@@ -198,7 +208,11 @@ fn insert_phis_all(
             rewrite_rules: FxHashMap::default(),
         };
         renamer.rename(0, None);
-        apply_rewrite_rules(&renamer.rewrite_rules, blocks);
+        // FIXME(eddyb) shouldn't this full rescan of the function be done once?
+        apply_rewrite_rules(
+            &renamer.rewrite_rules,
+            blocks.values_mut().map(|block| &mut **block),
+        );
         remove_nops(blocks);
     }
     remove_old_variables(blocks, &var_maps_and_types);
@@ -216,7 +230,7 @@ struct VarInfo {
 fn collect_access_chains(
     pointer_to_pointee: &FxHashMap<Word, Word>,
     constants: &FxHashMap<Word, u32>,
-    blocks: &[Block],
+    blocks: &FxIndexMap<LabelId, &mut Block>,
     base_var: Word,
     base_var_ty: Word,
 ) -> Option<FxHashMap<Word, VarInfo>> {
@@ -249,7 +263,7 @@ fn collect_access_chains(
     // Loop in case a previous block references a later AccessChain
     loop {
         let mut changed = false;
-        for inst in blocks.iter().flat_map(|b| &b.instructions) {
+        for inst in blocks.values().flat_map(|b| &b.instructions) {
             for (index, op) in inst.operands.iter().enumerate() {
                 if let Operand::IdRef(id) = op {
                     if variables.contains_key(id) {
@@ -307,10 +321,10 @@ fn collect_access_chains(
 // same var map (e.g. `s.x = s.y;`).
 fn split_copy_memory(
     header: &mut ModuleHeader,
-    blocks: &mut [Block],
+    blocks: &mut FxIndexMap<LabelId, &mut Block>,
     var_map: &FxHashMap<Word, VarInfo>,
 ) {
-    for block in blocks {
+    for block in blocks.values_mut() {
         let mut inst_index = 0;
         while inst_index < block.instructions.len() {
             let inst = &block.instructions[inst_index];
@@ -369,7 +383,7 @@ fn has_store(block: &Block, var_map: &FxHashMap<Word, VarInfo>) -> bool {
 }
 
 fn insert_phis(
-    blocks: &[Block],
+    blocks: &FxIndexMap<LabelId, &mut Block>,
     dominance_frontier: &[FxHashSet<usize>],
     var_map: &FxHashMap<Word, VarInfo>,
 ) -> FxHashSet<usize> {
@@ -378,7 +392,7 @@ fn insert_phis(
     let mut ever_on_work_list = FxHashSet::default();
     let mut work_list = Vec::new();
     let mut blocks_with_phi = FxHashSet::default();
-    for (block_idx, block) in blocks.iter().enumerate() {
+    for (block_idx, block) in blocks.values().enumerate() {
         if has_store(block, var_map) {
             ever_on_work_list.insert(block_idx);
             work_list.push(block_idx);
@@ -423,10 +437,10 @@ fn top_stack_or_undef(
     }
 }
 
-struct Renamer<'a> {
+struct Renamer<'a, 'b> {
     header: &'a mut ModuleHeader,
     types_global_values: &'a mut Vec<Instruction>,
-    blocks: &'a mut [Block],
+    blocks: &'a mut FxIndexMap<LabelId, &'b mut Block>,
     blocks_with_phi: FxHashSet<usize>,
     base_var_type: Word,
     var_map: &'a FxHashMap<Word, VarInfo>,
@@ -436,7 +450,7 @@ struct Renamer<'a> {
     rewrite_rules: FxHashMap<Word, Word>,
 }
 
-impl Renamer<'_> {
+impl Renamer<'_, '_> {
     // Returns the phi definition.
     fn insert_phi_value(&mut self, block: usize, from_block: usize) -> Word {
         let from_block_label = self.blocks[from_block].label_id().unwrap();
@@ -558,9 +572,8 @@ impl Renamer<'_> {
             }
         }
 
-        for dest_id in outgoing_edges(&self.blocks[block]).collect::<Vec<_>>() {
-            // TODO: Don't do this find
-            let dest_idx = label_to_index(self.blocks, dest_id);
+        for dest_id in outgoing_edges(self.blocks[block]).collect::<Vec<_>>() {
+            let dest_idx = self.blocks.get_index_of(&LabelId(dest_id)).unwrap();
             self.rename(dest_idx, Some(block));
         }
 
@@ -570,8 +583,8 @@ impl Renamer<'_> {
     }
 }
 
-fn remove_nops(blocks: &mut [Block]) {
-    for block in blocks {
+fn remove_nops(blocks: &mut FxIndexMap<LabelId, &mut Block>) {
+    for block in blocks.values_mut() {
         block
             .instructions
             .retain(|inst| inst.class.opcode != Op::Nop);
@@ -579,7 +592,7 @@ fn remove_nops(blocks: &mut [Block]) {
 }
 
 fn remove_old_variables(
-    blocks: &mut [Block],
+    blocks: &mut FxIndexMap<LabelId, &mut Block>,
     var_maps_and_types: &[(FxHashMap<u32, VarInfo>, u32)],
 ) {
     blocks[0].instructions.retain(|inst| {
@@ -590,7 +603,7 @@ fn remove_old_variables(
                 .all(|(var_map, _)| !var_map.contains_key(&result_id))
         }
     });
-    for block in blocks {
+    for block in blocks.values_mut() {
         block.instructions.retain(|inst| {
             !matches!(inst.class.opcode, Op::AccessChain | Op::InBoundsAccessChain)
                 || inst.operands.iter().all(|op| {

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -88,7 +88,10 @@ fn id(header: &mut ModuleHeader) -> Word {
     result
 }
 
-fn apply_rewrite_rules(rewrite_rules: &FxHashMap<Word, Word>, blocks: &mut [Block]) {
+fn apply_rewrite_rules<'a>(
+    rewrite_rules: &FxHashMap<Word, Word>,
+    blocks: impl IntoIterator<Item = &'a mut Block>,
+) {
     let apply = |inst: &mut Instruction| {
         if let Some(ref mut id) = &mut inst.result_id {
             if let Some(&rewrite) = rewrite_rules.get(id) {

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -150,6 +150,31 @@ fn get_name<'a>(names: &FxHashMap<Word, &'a str>, id: Word) -> Cow<'a, str> {
     )
 }
 
+impl Options {
+    // FIXME(eddyb) using a method on this type seems a bit sketchy.
+    fn spirt_cleanup_for_dumping(&self, module: &mut spirt::Module) {
+        if self.spirt_strip_custom_debuginfo_from_dumps {
+            spirt_passes::debuginfo::convert_custom_debuginfo_to_spv(module);
+        }
+        if !self.spirt_keep_debug_sources_in_dumps {
+            const DOTS: &str = "⋯";
+            let dots_interned_str = module.cx().intern(DOTS);
+            let spirt::ModuleDebugInfo::Spv(debuginfo) = &mut module.debug_info;
+            for sources in debuginfo.source_languages.values_mut() {
+                for file in sources.file_contents.values_mut() {
+                    *file = DOTS.into();
+                }
+                sources.file_contents.insert(
+                    dots_interned_str,
+                    "sources hidden, to show them use \
+                     `RUSTGPU_CODEGEN_ARGS=--spirt-keep-debug-sources-in-dumps`"
+                        .into(),
+                );
+            }
+        }
+    }
+}
+
 pub fn link(
     sess: &Session,
     mut inputs: Vec<Module>,
@@ -157,6 +182,66 @@ pub fn link(
     outputs: &OutputFilenames,
     disambiguated_crate_name_for_dumps: &OsStr,
 ) -> Result<LinkResult> {
+    // HACK(eddyb) this is defined here to allow SPIR-T pretty-printing to apply
+    // to SPIR-V being dumped, outside of e.g. `--dump-spirt-passes`.
+    // FIXME(eddyb) this isn't used everywhere, sadly - to find those, search
+    // elsewhere for `.assemble()` and/or `spirv_tools::binary::from_binary`.
+    let spv_module_to_spv_words_and_spirt_module = |spv_module: &Module| {
+        let spv_words;
+        let spv_bytes = {
+            let _timer = sess.timer("assemble-to-spv_bytes-for-spirt");
+            spv_words = spv_module.assemble();
+            // FIXME(eddyb) this is wastefully cloning all the bytes, but also
+            // `spirt::Module` should have a method that takes `Vec<u32>`.
+            spirv_tools::binary::from_binary(&spv_words).to_vec()
+        };
+
+        // FIXME(eddyb) should've really been "spirt::Module::lower_from_spv_bytes".
+        let _timer = sess.timer("spirt::Module::lower_from_spv_file");
+        let cx = std::rc::Rc::new(spirt::Context::new());
+        crate::custom_insts::register_to_spirt_context(&cx);
+        (
+            spv_words,
+            spirt::Module::lower_from_spv_bytes(cx, spv_bytes),
+        )
+    };
+
+    let dump_spv_and_spirt = |spv_module: &Module, dump_file_path_stem: PathBuf| {
+        let (spv_words, spirt_module_or_err) = spv_module_to_spv_words_and_spirt_module(spv_module);
+        std::fs::write(
+            dump_file_path_stem.with_extension("spv"),
+            spirv_tools::binary::from_binary(&spv_words),
+        )
+        .unwrap();
+
+        // FIXME(eddyb) reify SPIR-V -> SPIR-T errors so they're easier to debug.
+        if let Ok(mut module) = spirt_module_or_err {
+            // HACK(eddyb) avoid pretty-printing massive amounts of unused SPIR-T.
+            spirt::passes::link::minimize_exports(&mut module, |export_key| {
+                matches!(export_key, spirt::ExportKey::SpvEntryPoint { .. })
+            });
+
+            opts.spirt_cleanup_for_dumping(&mut module);
+
+            let pretty = spirt::print::Plan::for_module(&module).pretty_print();
+
+            // FIXME(eddyb) don't allocate whole `String`s here.
+            std::fs::write(
+                dump_file_path_stem.with_extension("spirt"),
+                pretty.to_string(),
+            )
+            .unwrap();
+            std::fs::write(
+                dump_file_path_stem.with_extension("spirt.html"),
+                pretty
+                    .render_to_html()
+                    .with_dark_mode_support()
+                    .to_html_doc(),
+            )
+            .unwrap();
+        }
+    };
+
     let mut output = {
         let _timer = sess.timer("link_merge");
         // shift all the ids
@@ -193,12 +278,7 @@ pub fn link(
     };
 
     if let Some(dir) = &opts.dump_post_merge {
-        std::fs::write(
-            dir.join(disambiguated_crate_name_for_dumps)
-                .with_extension("spv"),
-            spirv_tools::binary::from_binary(&output.assemble()),
-        )
-        .unwrap();
+        dump_spv_and_spirt(&output, dir.join(disambiguated_crate_name_for_dumps));
     }
 
     // remove duplicates (https://github.com/KhronosGroup/SPIRV-Tools/blob/e7866de4b1dc2a7e8672867caeb0bdca49f458d3/source/opt/remove_duplicates_pass.cpp)
@@ -401,40 +481,22 @@ pub fn link(
             }
         };
 
-        let spv_words;
-        let spv_bytes = {
-            let _timer = sess.timer("assemble-to-spv_bytes-for-spirt");
-            spv_words = output.assemble();
-            // FIXME(eddyb) this is wastefully cloning all the bytes, but also
-            // `spirt::Module` should have a method that takes `Vec<u32>`.
-            spirv_tools::binary::from_binary(&spv_words).to_vec()
-        };
-        let cx = std::rc::Rc::new(spirt::Context::new());
-        crate::custom_insts::register_to_spirt_context(&cx);
-        let mut module = {
-            let _timer = sess.timer("spirt::Module::lower_from_spv_file");
-            match spirt::Module::lower_from_spv_bytes(cx.clone(), spv_bytes) {
-                Ok(module) => module,
-                Err(e) => {
-                    let spv_path = outputs.temp_path_ext("spirt-lower-from-spv-input.spv", None);
+        let (spv_words, module_or_err) = spv_module_to_spv_words_and_spirt_module(&output);
+        let mut module = module_or_err.map_err(|e| {
+            let spv_path = outputs.temp_path_ext("spirt-lower-from-spv-input.spv", None);
 
-                    let was_saved_msg = match std::fs::write(
-                        &spv_path,
-                        spirv_tools::binary::from_binary(&spv_words),
-                    ) {
-                        Ok(()) => format!("was saved to {}", spv_path.display()),
-                        Err(e) => format!("could not be saved: {e}"),
-                    };
+            let was_saved_msg =
+                match std::fs::write(&spv_path, spirv_tools::binary::from_binary(&spv_words)) {
+                    Ok(()) => format!("was saved to {}", spv_path.display()),
+                    Err(e) => format!("could not be saved: {e}"),
+                };
 
-                    return Err(sess
-                        .dcx()
-                        .struct_err(format!("{e}"))
-                        .with_note("while lowering SPIR-V module to SPIR-T (spirt::spv::lower)")
-                        .with_note(format!("input SPIR-V module {was_saved_msg}"))
-                        .emit());
-                }
-            }
-        };
+            sess.dcx()
+                .struct_err(format!("{e}"))
+                .with_note("while lowering SPIR-V module to SPIR-T (spirt::spv::lower)")
+                .with_note(format!("input SPIR-V module {was_saved_msg}"))
+                .emit()
+        })?;
         // HACK(eddyb) don't dump the unstructured state if not requested, as
         // after SPIR-T 0.4.0 it's extremely verbose (due to def-use hermeticity).
         if opts.spirt_keep_unstructured_cfg_in_dumps || !opts.structurize {
@@ -499,31 +561,12 @@ pub fn link(
         // NOTE(eddyb) this should be *before* `lift_to_spv` below,
         // so if that fails, the dump could be used to debug it.
         if let Some(dump_spirt_file_path) = &dump_spirt_file_path {
-            if opts.spirt_strip_custom_debuginfo_from_dumps {
-                for (_, module) in &mut per_pass_module_for_dumping {
-                    spirt_passes::debuginfo::convert_custom_debuginfo_to_spv(module);
-                }
-            }
-            if !opts.spirt_keep_debug_sources_in_dumps {
-                for (_, module) in &mut per_pass_module_for_dumping {
-                    let spirt::ModuleDebugInfo::Spv(debuginfo) = &mut module.debug_info;
-                    for sources in debuginfo.source_languages.values_mut() {
-                        const DOTS: &str = "⋯";
-                        for file in sources.file_contents.values_mut() {
-                            *file = DOTS.into();
-                        }
-                        sources.file_contents.insert(
-                            cx.intern(DOTS),
-                            "sources hidden, to show them use \
-                             `RUSTGPU_CODEGEN_ARGS=--spirt-keep-debug-sources-in-dumps`"
-                                .into(),
-                        );
-                    }
-                }
+            for (_, module) in &mut per_pass_module_for_dumping {
+                opts.spirt_cleanup_for_dumping(module);
             }
 
             let plan = spirt::print::Plan::for_versions(
-                &cx,
+                module.cx_ref(),
                 per_pass_module_for_dumping
                     .iter()
                     .map(|(pass, module)| (format!("after {pass}"), module)),
@@ -695,13 +738,8 @@ pub fn link(
                 file_name.push(".");
                 file_name.push(file_stem);
             }
-            file_name.push(".spv");
 
-            std::fs::write(
-                dir.join(file_name),
-                spirv_tools::binary::from_binary(&output.assemble()),
-            )
-            .unwrap();
+            dump_spv_and_spirt(output, dir.join(file_name));
         }
         // Run DCE again, even if module_output_type == ModuleOutputType::Multiple - the first DCE ran before
         // structurization and mem2reg (for perf reasons), and mem2reg may remove references to

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -62,6 +62,7 @@ pub struct Options {
     pub dump_spirt_passes: Option<PathBuf>,
     pub spirt_strip_custom_debuginfo_from_dumps: bool,
     pub spirt_keep_debug_sources_in_dumps: bool,
+    pub spirt_keep_unstructured_cfg_in_dumps: bool,
     pub specializer_debug: bool,
     pub specializer_dump_instances: Option<PathBuf>,
     pub print_all_zombie: bool,
@@ -434,7 +435,11 @@ pub fn link(
                 }
             }
         };
-        after_pass("lower_from_spv", &module);
+        // HACK(eddyb) don't dump the unstructured state if not requested, as
+        // after SPIR-T 0.4.0 it's extremely verbose (due to def-use hermeticity).
+        if opts.spirt_keep_unstructured_cfg_in_dumps || !opts.structurize {
+            after_pass("lower_from_spv", &module);
+        }
 
         // NOTE(eddyb) this *must* run on unstructured CFGs, to do its job.
         {

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -442,6 +442,9 @@ pub fn link(
         }
 
         // NOTE(eddyb) this *must* run on unstructured CFGs, to do its job.
+        // FIXME(eddyb) no longer relying on structurization, try porting this
+        // to replace custom aborts in `Block`s and inject `ExitInvocation`s
+        // after them (truncating the `Block` and/or parent region if necessary).
         {
             let _timer = sess.timer("spirt_passes::controlflow::convert_custom_aborts_to_unstructured_returns_in_entry_points");
             spirt_passes::controlflow::convert_custom_aborts_to_unstructured_returns_in_entry_points(opts, &mut module);

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -58,6 +58,8 @@ pub struct Options {
     // NOTE(eddyb) these are debugging options that used to be env vars
     // (for more information see `docs/src/codegen-args.md`).
     pub dump_post_merge: Option<PathBuf>,
+    pub dump_pre_inline: Option<PathBuf>,
+    pub dump_post_inline: Option<PathBuf>,
     pub dump_post_split: Option<PathBuf>,
     pub dump_spirt_passes: Option<PathBuf>,
     pub spirt_strip_custom_debuginfo_from_dumps: bool,
@@ -416,6 +418,10 @@ pub fn link(
         duplicates::remove_duplicate_debuginfo(&mut output);
     }
 
+    if let Some(dir) = &opts.dump_pre_inline {
+        dump_spv_and_spirt(&output, dir.join(disambiguated_crate_name_for_dumps));
+    }
+
     {
         let _timer = sess.timer("link_inline");
         inline::inline(sess, &mut output)?;
@@ -424,6 +430,11 @@ pub fn link(
     if opts.dce {
         let _timer = sess.timer("link_dce-after-inlining");
         dce::dce(&mut output);
+    }
+
+    // HACK(eddyb) this has to be after DCE, to not break SPIR-T w/ dead decorations.
+    if let Some(dir) = &opts.dump_post_inline {
+        dump_spv_and_spirt(&output, dir.join(disambiguated_crate_name_for_dumps));
     }
 
     {

--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -79,6 +79,14 @@ Dumps the merged module, to a file in `DIR`, immediately after merging, but befo
 similar to `--dump-pre-link`, except it outputs only a single file, which might make grepping through
 for stuff easier.
 
+### `--dump-pre-inline DIR`
+
+Dumps the module, to a file in `DIR`, immediately before the inliner pass runs.
+
+### `--dump-post-inline DIR`
+
+Dumps the module, to a file in `DIR`, immediately after the inliner pass runs.
+
 ### `--dump-post-split DIR`
 
 Dumps the modules, to files in `DIR`, immediately after multimodule splitting, but before final cleanup passes (e.g.

--- a/docs/src/codegen-args.md
+++ b/docs/src/codegen-args.md
@@ -208,3 +208,11 @@ all the "file contents debuginfo" (i.e. from SPIR-V `OpSource` instructions),
 which will end up being included, in full, at the start of the dump.
 
 The default (of hiding the file contents) is less verbose, but (arguably) lossier.
+
+### `--spirt-keep-unstructured-cfg-in-dumps`
+
+When dumping (pretty-printed) `SPIR-🇹` (e.g. with `--dump-spirt-passes`), include
+the initial unstructured state, as well (i.e. just after lowering from SPIR-V).
+
+The default (of only dumping structured SPIR-T) can have far less noisy dataflow,
+but unstructured SPIR-T may be needed for e.g. debugging the structurizer itself.

--- a/tests/ui/dis/entry-pass-mode-cast-array.stderr
+++ b/tests/ui/dis/entry-pass-mode-cast-array.stderr
@@ -8,6 +8,10 @@ OpNoLine
 OpSelectionMerge %13 None
 OpBranchConditional %9 %14 %15
 %14 = OpLabel
+OpBranch %13
+%15 = OpLabel
+OpReturn
+%13 = OpLabel
 OpLine %5 14 4
 %16 = OpCompositeExtract  %17  %6 0
 %18 = OpFAdd  %17  %16 %19
@@ -15,9 +19,5 @@ OpLine %5 14 4
 OpLine %5 15 4
 OpStore %21 %20
 OpNoLine
-OpBranch %13
-%15 = OpLabel
-OpBranch %13
-%13 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/index_user_dst.stderr
+++ b/tests/ui/dis/index_user_dst.stderr
@@ -9,13 +9,13 @@ OpNoLine
 OpSelectionMerge %14 None
 OpBranchConditional %12 %15 %16
 %15 = OpLabel
+OpBranch %14
+%16 = OpLabel
+OpReturn
+%14 = OpLabel
 OpLine %5 10 21
 %17 = OpInBoundsAccessChain  %18  %6 %9
 %19 = OpLoad  %20  %17
 OpNoLine
-OpBranch %14
-%16 = OpLabel
-OpBranch %14
-%14 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/issue-731.stderr
+++ b/tests/ui/dis/issue-731.stderr
@@ -8,6 +8,10 @@ OpNoLine
 OpSelectionMerge %13 None
 OpBranchConditional %9 %14 %15
 %14 = OpLabel
+OpBranch %13
+%15 = OpLabel
+OpReturn
+%13 = OpLabel
 OpLine %5 12 4
 %16 = OpCompositeExtract  %17  %6 0
 %18 = OpFAdd  %17  %16 %19
@@ -15,9 +19,5 @@ OpLine %5 12 4
 OpLine %5 13 4
 OpStore %21 %20
 OpNoLine
-OpBranch %13
-%15 = OpLabel
-OpBranch %13
-%13 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/panic_builtin_bounds_check.stderr
+++ b/tests/ui/dis/panic_builtin_bounds_check.stderr
@@ -32,7 +32,7 @@ OpBranch %14
 OpLine %4 275 4
 %17 = OpExtInst  %6  %1 1 %3 %11 %10
 OpNoLine
-OpBranch %14
+OpReturn
 %14 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/dis/panic_sequential_many.rs
+++ b/tests/ui/dis/panic_sequential_many.rs
@@ -1,0 +1,30 @@
+#![crate_name = "panic_sequential_many"]
+
+// Test a long sequence of conditional panics, which has historically generated
+// very nested structured control-flow (instead of a single merged chain).
+
+// build-pass
+// compile-flags: -C target-feature=+ext:SPV_KHR_non_semantic_info
+// compile-flags: -C llvm-args=--abort-strategy=debug-printf
+// compile-flags: -C llvm-args=--disassemble
+
+// FIXME(eddyb) consider using such replacements also for dealing
+// with `OpLine` changing all the time (esp. in libcore functions).
+//
+// normalize-stderr-test "; (SPIR-V|Generator: rspirv|Version: 1\.\d+|Bound: \d+)\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+// FIXME(eddyb) handle this one in the test runner.
+// normalize-stderr-test "\S*/lib/rustlib/" -> "$$SYSROOT/lib/rustlib/"
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(#[spirv(flat)] x: u32, #[spirv(flat)] y: u32, o: &mut u32) {
+    // HACK(eddyb) this might stop working if the checks get optimized out,
+    // after the first `y != 0` (which dominates the rest of the function).
+    *o = x / y / y / y / y / y / y / y / y / y / y / y / y / y / y / y / y / y;
+}

--- a/tests/ui/dis/panic_sequential_many.rs
+++ b/tests/ui/dis/panic_sequential_many.rs
@@ -7,7 +7,7 @@
 // compile-flags: -C target-feature=+ext:SPV_KHR_non_semantic_info
 // compile-flags: -C llvm-args=--abort-strategy=debug-printf
 // compile-flags: -C llvm-args=--disassemble
-
+//
 // FIXME(eddyb) consider using such replacements also for dealing
 // with `OpLine` changing all the time (esp. in libcore functions).
 //
@@ -16,7 +16,7 @@
 // normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
-
+// normalize-stderr-test "\S:\S*/panic_sequential_many.rs" -> "$$DIR/panic_sequential_many.rs"
 // FIXME(eddyb) handle this one in the test runner.
 // normalize-stderr-test "\S*/lib/rustlib/" -> "$$SYSROOT/lib/rustlib/"
 

--- a/tests/ui/dis/panic_sequential_many.stderr
+++ b/tests/ui/dis/panic_sequential_many.stderr
@@ -1,0 +1,281 @@
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_non_semantic_info"
+OpExtension "SPV_KHR_shader_clock"
+%1 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %2 "main" %3 %4 %5
+OpExecutionMode %2 OriginUpperLeft
+%6 = OpString "/n[Rust panicked at $DIR/panic_sequential_many.rs:29:10]/n attempt to divide by zero/n      in main()/n"
+%7 = OpString "$DIR/panic_sequential_many.rs"
+OpName %3 "x"
+OpName %4 "y"
+OpName %5 "o"
+OpDecorate %3 Flat
+OpDecorate %3 Location 0
+OpDecorate %4 Flat
+OpDecorate %4 Location 1
+OpDecorate %5 Location 0
+%8 = OpTypeInt 32 0
+%9 = OpTypePointer Input %8
+%10 = OpTypePointer Output %8
+%11 = OpTypeVoid
+%12 = OpTypeFunction %11
+%3 = OpVariable  %9  Input
+%4 = OpVariable  %9  Input
+%13 = OpTypeBool
+%14 = OpConstant  %8  0
+%5 = OpVariable  %10  Output
+%2 = OpFunction  %11  None %12
+%15 = OpLabel
+OpLine %7 26 12
+%16 = OpLoad  %8  %3
+OpLine %7 26 35
+%17 = OpLoad  %8  %4
+OpLine %7 29 9
+%18 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %19 None
+OpBranchConditional %18 %20 %21
+%20 = OpLabel
+OpLine %7 29 9
+%22 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %19
+%21 = OpLabel
+OpLine %7 29 9
+%23 = OpUDiv  %8  %16 %17
+%24 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %25 None
+OpBranchConditional %24 %26 %27
+%26 = OpLabel
+OpLine %7 29 9
+%28 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %25
+%27 = OpLabel
+OpLine %7 29 9
+%29 = OpUDiv  %8  %23 %17
+%30 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %31 None
+OpBranchConditional %30 %32 %33
+%32 = OpLabel
+OpLine %7 29 9
+%34 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %31
+%33 = OpLabel
+OpLine %7 29 9
+%35 = OpUDiv  %8  %29 %17
+%36 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %37 None
+OpBranchConditional %36 %38 %39
+%38 = OpLabel
+OpLine %7 29 9
+%40 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %37
+%39 = OpLabel
+OpLine %7 29 9
+%41 = OpUDiv  %8  %35 %17
+%42 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %43 None
+OpBranchConditional %42 %44 %45
+%44 = OpLabel
+OpLine %7 29 9
+%46 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %43
+%45 = OpLabel
+OpLine %7 29 9
+%47 = OpUDiv  %8  %41 %17
+%48 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %49 None
+OpBranchConditional %48 %50 %51
+%50 = OpLabel
+OpLine %7 29 9
+%52 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %49
+%51 = OpLabel
+OpLine %7 29 9
+%53 = OpUDiv  %8  %47 %17
+%54 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %55 None
+OpBranchConditional %54 %56 %57
+%56 = OpLabel
+OpLine %7 29 9
+%58 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %55
+%57 = OpLabel
+OpLine %7 29 9
+%59 = OpUDiv  %8  %53 %17
+%60 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %61 None
+OpBranchConditional %60 %62 %63
+%62 = OpLabel
+OpLine %7 29 9
+%64 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %61
+%63 = OpLabel
+OpLine %7 29 9
+%65 = OpUDiv  %8  %59 %17
+%66 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %67 None
+OpBranchConditional %66 %68 %69
+%68 = OpLabel
+OpLine %7 29 9
+%70 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %67
+%69 = OpLabel
+OpLine %7 29 9
+%71 = OpUDiv  %8  %65 %17
+%72 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %73 None
+OpBranchConditional %72 %74 %75
+%74 = OpLabel
+OpLine %7 29 9
+%76 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %73
+%75 = OpLabel
+OpLine %7 29 9
+%77 = OpUDiv  %8  %71 %17
+%78 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %79 None
+OpBranchConditional %78 %80 %81
+%80 = OpLabel
+OpLine %7 29 9
+%82 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %79
+%81 = OpLabel
+OpLine %7 29 9
+%83 = OpUDiv  %8  %77 %17
+%84 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %85 None
+OpBranchConditional %84 %86 %87
+%86 = OpLabel
+OpLine %7 29 9
+%88 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %85
+%87 = OpLabel
+OpLine %7 29 9
+%89 = OpUDiv  %8  %83 %17
+%90 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %91 None
+OpBranchConditional %90 %92 %93
+%92 = OpLabel
+OpLine %7 29 9
+%94 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %91
+%93 = OpLabel
+OpLine %7 29 9
+%95 = OpUDiv  %8  %89 %17
+%96 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %97 None
+OpBranchConditional %96 %98 %99
+%98 = OpLabel
+OpLine %7 29 9
+%100 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %97
+%99 = OpLabel
+OpLine %7 29 9
+%101 = OpUDiv  %8  %95 %17
+%102 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %103 None
+OpBranchConditional %102 %104 %105
+%104 = OpLabel
+OpLine %7 29 9
+%106 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %103
+%105 = OpLabel
+OpLine %7 29 9
+%107 = OpUDiv  %8  %101 %17
+%108 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %109 None
+OpBranchConditional %108 %110 %111
+%110 = OpLabel
+OpLine %7 29 9
+%112 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %109
+%111 = OpLabel
+OpLine %7 29 9
+%113 = OpUDiv  %8  %107 %17
+%114 = OpIEqual  %13  %17 %14
+OpNoLine
+OpSelectionMerge %115 None
+OpBranchConditional %114 %116 %117
+%116 = OpLabel
+OpLine %7 29 9
+%118 = OpExtInst  %11  %1 1 %6
+OpNoLine
+OpBranch %115
+%117 = OpLabel
+OpLine %7 29 4
+%119 = OpUDiv  %8  %113 %17
+OpStore %5 %119
+OpNoLine
+OpBranch %115
+%115 = OpLabel
+OpBranch %109
+%109 = OpLabel
+OpBranch %103
+%103 = OpLabel
+OpBranch %97
+%97 = OpLabel
+OpBranch %91
+%91 = OpLabel
+OpBranch %85
+%85 = OpLabel
+OpBranch %79
+%79 = OpLabel
+OpBranch %73
+%73 = OpLabel
+OpBranch %67
+%67 = OpLabel
+OpBranch %61
+%61 = OpLabel
+OpBranch %55
+%55 = OpLabel
+OpBranch %49
+%49 = OpLabel
+OpBranch %43
+%43 = OpLabel
+OpBranch %37
+%37 = OpLabel
+OpBranch %31
+%31 = OpLabel
+OpBranch %25
+%25 = OpLabel
+OpBranch %19
+%19 = OpLabel
+OpReturn
+OpFunctionEnd

--- a/tests/ui/dis/panic_sequential_many.stderr
+++ b/tests/ui/dis/panic_sequential_many.stderr
@@ -45,8 +45,10 @@ OpBranchConditional %18 %20 %21
 OpLine %7 29 9
 %22 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %19
+OpReturn
 %21 = OpLabel
+OpBranch %19
+%19 = OpLabel
 OpLine %7 29 9
 %23 = OpUDiv  %8  %16 %17
 %24 = OpIEqual  %13  %17 %14
@@ -57,8 +59,10 @@ OpBranchConditional %24 %26 %27
 OpLine %7 29 9
 %28 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %25
+OpReturn
 %27 = OpLabel
+OpBranch %25
+%25 = OpLabel
 OpLine %7 29 9
 %29 = OpUDiv  %8  %23 %17
 %30 = OpIEqual  %13  %17 %14
@@ -69,8 +73,10 @@ OpBranchConditional %30 %32 %33
 OpLine %7 29 9
 %34 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %31
+OpReturn
 %33 = OpLabel
+OpBranch %31
+%31 = OpLabel
 OpLine %7 29 9
 %35 = OpUDiv  %8  %29 %17
 %36 = OpIEqual  %13  %17 %14
@@ -81,8 +87,10 @@ OpBranchConditional %36 %38 %39
 OpLine %7 29 9
 %40 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %37
+OpReturn
 %39 = OpLabel
+OpBranch %37
+%37 = OpLabel
 OpLine %7 29 9
 %41 = OpUDiv  %8  %35 %17
 %42 = OpIEqual  %13  %17 %14
@@ -93,8 +101,10 @@ OpBranchConditional %42 %44 %45
 OpLine %7 29 9
 %46 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %43
+OpReturn
 %45 = OpLabel
+OpBranch %43
+%43 = OpLabel
 OpLine %7 29 9
 %47 = OpUDiv  %8  %41 %17
 %48 = OpIEqual  %13  %17 %14
@@ -105,8 +115,10 @@ OpBranchConditional %48 %50 %51
 OpLine %7 29 9
 %52 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %49
+OpReturn
 %51 = OpLabel
+OpBranch %49
+%49 = OpLabel
 OpLine %7 29 9
 %53 = OpUDiv  %8  %47 %17
 %54 = OpIEqual  %13  %17 %14
@@ -117,8 +129,10 @@ OpBranchConditional %54 %56 %57
 OpLine %7 29 9
 %58 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %55
+OpReturn
 %57 = OpLabel
+OpBranch %55
+%55 = OpLabel
 OpLine %7 29 9
 %59 = OpUDiv  %8  %53 %17
 %60 = OpIEqual  %13  %17 %14
@@ -129,8 +143,10 @@ OpBranchConditional %60 %62 %63
 OpLine %7 29 9
 %64 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %61
+OpReturn
 %63 = OpLabel
+OpBranch %61
+%61 = OpLabel
 OpLine %7 29 9
 %65 = OpUDiv  %8  %59 %17
 %66 = OpIEqual  %13  %17 %14
@@ -141,8 +157,10 @@ OpBranchConditional %66 %68 %69
 OpLine %7 29 9
 %70 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %67
+OpReturn
 %69 = OpLabel
+OpBranch %67
+%67 = OpLabel
 OpLine %7 29 9
 %71 = OpUDiv  %8  %65 %17
 %72 = OpIEqual  %13  %17 %14
@@ -153,8 +171,10 @@ OpBranchConditional %72 %74 %75
 OpLine %7 29 9
 %76 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %73
+OpReturn
 %75 = OpLabel
+OpBranch %73
+%73 = OpLabel
 OpLine %7 29 9
 %77 = OpUDiv  %8  %71 %17
 %78 = OpIEqual  %13  %17 %14
@@ -165,8 +185,10 @@ OpBranchConditional %78 %80 %81
 OpLine %7 29 9
 %82 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %79
+OpReturn
 %81 = OpLabel
+OpBranch %79
+%79 = OpLabel
 OpLine %7 29 9
 %83 = OpUDiv  %8  %77 %17
 %84 = OpIEqual  %13  %17 %14
@@ -177,8 +199,10 @@ OpBranchConditional %84 %86 %87
 OpLine %7 29 9
 %88 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %85
+OpReturn
 %87 = OpLabel
+OpBranch %85
+%85 = OpLabel
 OpLine %7 29 9
 %89 = OpUDiv  %8  %83 %17
 %90 = OpIEqual  %13  %17 %14
@@ -189,8 +213,10 @@ OpBranchConditional %90 %92 %93
 OpLine %7 29 9
 %94 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %91
+OpReturn
 %93 = OpLabel
+OpBranch %91
+%91 = OpLabel
 OpLine %7 29 9
 %95 = OpUDiv  %8  %89 %17
 %96 = OpIEqual  %13  %17 %14
@@ -201,8 +227,10 @@ OpBranchConditional %96 %98 %99
 OpLine %7 29 9
 %100 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %97
+OpReturn
 %99 = OpLabel
+OpBranch %97
+%97 = OpLabel
 OpLine %7 29 9
 %101 = OpUDiv  %8  %95 %17
 %102 = OpIEqual  %13  %17 %14
@@ -213,8 +241,10 @@ OpBranchConditional %102 %104 %105
 OpLine %7 29 9
 %106 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %103
+OpReturn
 %105 = OpLabel
+OpBranch %103
+%103 = OpLabel
 OpLine %7 29 9
 %107 = OpUDiv  %8  %101 %17
 %108 = OpIEqual  %13  %17 %14
@@ -225,8 +255,10 @@ OpBranchConditional %108 %110 %111
 OpLine %7 29 9
 %112 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %109
+OpReturn
 %111 = OpLabel
+OpBranch %109
+%109 = OpLabel
 OpLine %7 29 9
 %113 = OpUDiv  %8  %107 %17
 %114 = OpIEqual  %13  %17 %14
@@ -237,45 +269,13 @@ OpBranchConditional %114 %116 %117
 OpLine %7 29 9
 %118 = OpExtInst  %11  %1 1 %6
 OpNoLine
-OpBranch %115
+OpReturn
 %117 = OpLabel
+OpBranch %115
+%115 = OpLabel
 OpLine %7 29 4
 %119 = OpUDiv  %8  %113 %17
 OpStore %5 %119
 OpNoLine
-OpBranch %115
-%115 = OpLabel
-OpBranch %109
-%109 = OpLabel
-OpBranch %103
-%103 = OpLabel
-OpBranch %97
-%97 = OpLabel
-OpBranch %91
-%91 = OpLabel
-OpBranch %85
-%85 = OpLabel
-OpBranch %79
-%79 = OpLabel
-OpBranch %73
-%73 = OpLabel
-OpBranch %67
-%67 = OpLabel
-OpBranch %61
-%61 = OpLabel
-OpBranch %55
-%55 = OpLabel
-OpBranch %49
-%49 = OpLabel
-OpBranch %43
-%43 = OpLabel
-OpBranch %37
-%37 = OpLabel
-OpBranch %31
-%31 = OpLabel
-OpBranch %25
-%25 = OpLabel
-OpBranch %19
-%19 = OpLabel
 OpReturn
 OpFunctionEnd

--- a/tests/ui/lang/consts/nested-ref.stderr
+++ b/tests/ui/lang/consts/nested-ref.stderr
@@ -1,6 +1,20 @@
-warning: `#[inline(never)]` function `nested_ref::deep_load` needs to be inlined because it has illegal argument or return types
+warning: `#[inline(never)]` function `nested_ref::deep_load` has been inlined
+  --> $DIR/nested-ref.rs:12:4
+   |
+12 | fn deep_load(r: &'static &'static u32) -> u32 {
+   |    ^^^^^^^^^
+   |
+   = note: inlining was required due to illegal parameter type
+   = note: called from `nested_ref::main`
 
-warning: `#[inline(never)]` function `nested_ref::deep_transpose` needs to be inlined because it has illegal argument or return types
+warning: `#[inline(never)]` function `nested_ref::deep_transpose` has been inlined
+  --> $DIR/nested-ref.rs:19:4
+   |
+19 | fn deep_transpose(r: &'static &'static Mat2) -> Mat2 {
+   |    ^^^^^^^^^^^^^^
+   |
+   = note: inlining was required due to illegal parameter type
+   = note: called from `nested_ref::main`
 
 warning: 2 warnings emitted
 

--- a/tests/ui/lang/core/ref/member_ref_arg-broken.stderr
+++ b/tests/ui/lang/core/ref/member_ref_arg-broken.stderr
@@ -1,6 +1,38 @@
-warning: `#[inline(never)]` function `member_ref_arg_broken::h` needs to be inlined because it has illegal argument or return types
+warning: `#[inline(never)]` function `member_ref_arg_broken::f` has been inlined
+  --> $DIR/member_ref_arg-broken.rs:20:4
+   |
+20 | fn f(x: &u32) -> u32 {
+   |    ^
+   |
+   = note: inlining was required due to illegal (pointer) argument
+   = note: called from `member_ref_arg_broken::main`
 
-warning: `#[inline(never)]` function `member_ref_arg_broken::h_newtyped` needs to be inlined because it has illegal argument or return types
+warning: `#[inline(never)]` function `member_ref_arg_broken::g` has been inlined
+  --> $DIR/member_ref_arg-broken.rs:25:4
+   |
+25 | fn g(xy: (&u32, &u32)) -> (u32, u32) {
+   |    ^
+   |
+   = note: inlining was required due to illegal (pointer) argument
+   = note: called from `member_ref_arg_broken::main`
+
+warning: `#[inline(never)]` function `member_ref_arg_broken::h` has been inlined
+  --> $DIR/member_ref_arg-broken.rs:30:4
+   |
+30 | fn h(xyz: (&u32, &u32, &u32)) -> (u32, u32, u32) {
+   |    ^
+   |
+   = note: inlining was required due to illegal parameter type
+   = note: called from `member_ref_arg_broken::main`
+
+warning: `#[inline(never)]` function `member_ref_arg_broken::h_newtyped` has been inlined
+  --> $DIR/member_ref_arg-broken.rs:41:4
+   |
+41 | fn h_newtyped(xyz: ((&u32, &u32, &u32),)) -> (u32, u32, u32) {
+   |    ^^^^^^^^^^
+   |
+   = note: inlining was required due to illegal parameter type
+   = note: called from `member_ref_arg_broken::main`
 
 error: error:0:0 - OpLoad Pointer <id> '$ID[%$ID]' is not a logical pointer.
          %39 = OpLoad %uint %38
@@ -8,5 +40,5 @@ error: error:0:0 - OpLoad Pointer <id> '$ID[%$ID]' is not a logical pointer.
   = note: spirv-val failed
   = note: module `$TEST_BUILD_DIR/lang/core/ref/member_ref_arg-broken`
 
-error: aborting due to 1 previous error; 2 warnings emitted
+error: aborting due to 1 previous error; 4 warnings emitted
 

--- a/tests/ui/lang/core/ref/member_ref_arg.stderr
+++ b/tests/ui/lang/core/ref/member_ref_arg.stderr
@@ -1,0 +1,20 @@
+warning: `#[inline(never)]` function `member_ref_arg::f` has been inlined
+  --> $DIR/member_ref_arg.rs:14:4
+   |
+14 | fn f(x: &u32) {}
+   |    ^
+   |
+   = note: inlining was required due to illegal (pointer) argument
+   = note: called from `member_ref_arg::main`
+
+warning: `#[inline(never)]` function `member_ref_arg::g` has been inlined
+  --> $DIR/member_ref_arg.rs:17:4
+   |
+17 | fn g(xy: (&u32, &u32)) {}
+   |    ^
+   |
+   = note: inlining was required due to illegal (pointer) argument
+   = note: called from `member_ref_arg::main`
+
+warning: 2 warnings emitted
+

--- a/tests/ui/lang/core/unwrap_or.stderr
+++ b/tests/ui/lang/core/unwrap_or.stderr
@@ -15,17 +15,9 @@ OpBranch %18
 %20 = OpLabel
 OpBranch %18
 %18 = OpLabel
-%21 = OpPhi  %16  %22 %19 %23 %20
-%24 = OpPhi  %11  %25 %19 %10 %20
-OpSelectionMerge %26 None
-OpBranchConditional %21 %27 %28
-%27 = OpLabel
-OpBranch %26
-%28 = OpLabel
-OpBranch %26
-%26 = OpLabel
+%21 = OpPhi  %11  %22 %19 %10 %20
 OpLine %5 13 4
-OpStore %29 %24
+OpStore %23 %21
 OpNoLine
 OpReturn
 OpFunctionEnd

--- a/tests/ui/lang/panic/track_caller.stderr
+++ b/tests/ui/lang/panic/track_caller.stderr
@@ -1,0 +1,11 @@
+warning: `#[inline(never)]` function `track_caller::track_caller_maybe_panic::panic_cold_explicit` has been inlined
+  --> $DIR/track_caller.rs:10:9
+   |
+10 |         panic!();
+   |         ^^^^^^^^
+   |
+   = note: inlining was required due to panicking
+   = note: called from `track_caller::track_caller_maybe_panic`
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/20 to be merged first. Contains a lot of WIP commits.

Some improvements to the linker by @eddyb:
* mem2reg speedups, which has been known to be exponentially slow
* preserves debug info when the linker does inlining

This PR contains a lot of WIP commits, but it has worked flawlessly in tests and in my Project. 