### PR TITLE
feat: added image access qualifier, fixes #28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79faae4620f45232f599d9bc7b290f88247a0834162c4495ab2f02d60004adfb"
+checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
+checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -959,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -984,15 +984,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1001,15 +1001,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1018,21 +1018,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1806,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490d3a563d3122bf7c911a59b0add9389e5ec0f5f0c3ac6b91ff235a0e6a7f90"
+checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
 dependencies = [
  "ttf-parser",
 ]
@@ -1881,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "plist"
@@ -1970,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.1"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
 ]
@@ -2728,9 +2728,9 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.21"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.5.0",
  "toml_datetime",
@@ -2755,9 +2755,9 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "ttf-parser"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
+checksum = "5902c5d130972a0000f60860bfbf46f7ca3db5391eddfedd1b8728bd9dc96c0e"
 
 [[package]]
 name = "unicode-ident"
@@ -2779,9 +2779,9 @@ checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -2819,9 +2819,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2830,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -2845,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2857,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2867,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2880,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wayland-backend"
@@ -3039,7 +3039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.36.1",
+ "quick-xml 0.36.2",
  "quote",
 ]
 
@@ -3068,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3514,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -883,6 +883,7 @@ fn trans_intrinsic_type<'tcx>(
             let multisampled = const_int_value(cx, args.const_at(4))?;
             let sampled = const_int_value(cx, args.const_at(5))?;
             let image_format = const_int_value(cx, args.const_at(6))?;
+            let access_qualifier = const_int_value(cx, args.const_at(7)).ok();
 
             let ty = SpirvType::Image {
                 sampled_type,
@@ -892,6 +893,7 @@ fn trans_intrinsic_type<'tcx>(
                 multisampled,
                 sampled,
                 image_format,
+                access_qualifier,
             };
             Ok(ty.def(span, cx))
         }

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -883,25 +883,17 @@ fn trans_intrinsic_type<'tcx>(
             let multisampled = const_int_value(cx, args.const_at(4))?;
             let sampled = const_int_value(cx, args.const_at(5))?;
             let image_format = const_int_value(cx, args.const_at(6))?;
-
-            let access_qualifier_ty = args.type_at(8);
-            let access_qualifier: Option<AccessQualifier> = if let TyKind::Adt(def, _) =
-                access_qualifier_ty.kind()
-            {
-                match cx.tcx.def_path_str(def.did()).as_str() {
-                    "spirv_std::image::ImageAccessReadOnly" => Some(AccessQualifier::ReadOnly),
-                    "spirv_std::image::ImageAccessWriteOnly" => Some(AccessQualifier::WriteOnly),
-                    "spirv_std::image::ImageAccessReadWrite" => Some(AccessQualifier::ReadWrite),
-                    "spirv_std::image::ImageAccessUnknown" => None,
-                    s => {
-                        return Err(cx
-                            .tcx
-                            .dcx()
-                            .err(format!("Invalid image access qualifier: '{s}'")));
-                    }
+            let access_qualifier = match const_int_value(cx, args.const_at(8))? {
+                0u32 => Some(AccessQualifier::ReadOnly),
+                1u32 => Some(AccessQualifier::WriteOnly),
+                2u32 => Some(AccessQualifier::ReadWrite),
+                3u32 => None,
+                n => {
+                    return Err(cx
+                        .tcx
+                        .dcx()
+                        .err(format!("Invalid value for Image access qualifier: {n}")));
                 }
-            } else {
-                return Err(cx.tcx.dcx().err("Invalid image access qualifier"));
             };
 
             let ty = SpirvType::Image {

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -329,6 +329,10 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                 multisampled: inst.operands[4].unwrap_literal_int32(),
                 sampled: inst.operands[5].unwrap_literal_int32(),
                 image_format: inst.operands[6].unwrap_image_format(),
+                access_qualifier: inst
+                    .operands
+                    .get(7)
+                    .map(rspirv::dr::Operand::unwrap_access_qualifier),
             }
             .def(self.span(), self),
             Op::TypeSampledImage => SpirvType::SampledImage {

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -3,7 +3,9 @@ use crate::builder_spirv::SpirvValue;
 use crate::codegen_cx::CodegenCx;
 use indexmap::IndexSet;
 use rspirv::dr::Operand;
-use rspirv::spirv::{Capability, Decoration, Dim, ImageFormat, StorageClass, Word};
+use rspirv::spirv::{
+    AccessQualifier, Capability, Decoration, Dim, ImageFormat, StorageClass, Word,
+};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::span_bug;
 use rustc_span::def_id::DefId;
@@ -74,6 +76,7 @@ pub enum SpirvType<'tcx> {
         multisampled: u32,
         sampled: u32,
         image_format: ImageFormat,
+        access_qualifier: Option<AccessQualifier>,
     },
     Sampler,
     SampledImage {
@@ -241,6 +244,7 @@ impl SpirvType<'_> {
                 multisampled,
                 sampled,
                 image_format,
+                access_qualifier,
             } => cx.emit_global().type_image_id(
                 id,
                 sampled_type,
@@ -250,7 +254,7 @@ impl SpirvType<'_> {
                 multisampled,
                 sampled,
                 image_format,
-                None,
+                access_qualifier,
             ),
             Self::Sampler => cx.emit_global().type_sampler_id(id),
             Self::AccelerationStructureKhr => {
@@ -416,6 +420,7 @@ impl SpirvType<'_> {
                 multisampled,
                 sampled,
                 image_format,
+                access_qualifier,
             } => SpirvType::Image {
                 sampled_type,
                 dim,
@@ -424,6 +429,7 @@ impl SpirvType<'_> {
                 multisampled,
                 sampled,
                 image_format,
+                access_qualifier,
             },
             SpirvType::Sampler => SpirvType::Sampler,
             SpirvType::SampledImage { image_type } => SpirvType::SampledImage { image_type },
@@ -579,6 +585,7 @@ impl fmt::Debug for SpirvTypePrinter<'_, '_> {
                 multisampled,
                 sampled,
                 image_format,
+                access_qualifier,
             } => f
                 .debug_struct("Image")
                 .field("id", &self.id)
@@ -589,6 +596,7 @@ impl fmt::Debug for SpirvTypePrinter<'_, '_> {
                 .field("multisampled", &multisampled)
                 .field("sampled", &sampled)
                 .field("image_format", &image_format)
+                .field("access_qualifier", &access_qualifier)
                 .finish(),
             SpirvType::Sampler => f.debug_struct("Sampler").field("id", &self.id).finish(),
             SpirvType::SampledImage { image_type } => f
@@ -734,6 +742,7 @@ impl SpirvTypePrinter<'_, '_> {
                 multisampled,
                 sampled,
                 image_format,
+                access_qualifier,
             } => f
                 .debug_struct("Image")
                 .field("sampled_type", &self.cx.debug_type(sampled_type))
@@ -743,6 +752,7 @@ impl SpirvTypePrinter<'_, '_> {
                 .field("multisampled", &multisampled)
                 .field("sampled", &sampled)
                 .field("image_format", &image_format)
+                .field("access_qualifier", &access_qualifier)
                 .finish(),
             SpirvType::Sampler => f.write_str("Sampler"),
             SpirvType::SampledImage { image_type } => f

--- a/crates/spirv-std/macros/src/image.rs
+++ b/crates/spirv-std/macros/src/image.rs
@@ -413,7 +413,7 @@ impl quote::ToTokens for ImageType {
         let sampled = params::sampled_to_tokens(&self.sampled);
         let sampled_type = &self.sampled_type;
         let components = self.components;
-        let access = params::image_access_to_tokens(self.access);
+        let access = params::image_access_to_const_u32(self.access);
 
         tokens.append_all(quote::quote! {
             #crate_root::image::Image<
@@ -425,7 +425,7 @@ impl quote::ToTokens for ImageType {
                 { #crate_root::image::#sampled as u32 },
                 { #crate_root::image::#format as u32 },
                 { #components as u32 },
-                #crate_root::image::__private::#access
+                #access
             >
         });
     }
@@ -573,12 +573,12 @@ mod params {
         }
     }
 
-    pub fn image_access_to_tokens(access: Option<AccessQualifier>) -> proc_macro2::TokenStream {
+    pub fn image_access_to_const_u32(access: Option<AccessQualifier>) -> proc_macro2::TokenStream {
         match access {
-            Some(AccessQualifier::ReadOnly) => quote!(ImageAccessReadOnly),
-            Some(AccessQualifier::WriteOnly) => quote!(ImageAccessWriteOnly),
-            Some(AccessQualifier::ReadWrite) => quote!(ImageAccessReadWrite),
-            None => quote!(ImageAccessUnknown),
+            Some(AccessQualifier::ReadOnly) => quote!(AccessQualifier::ReadOnly as u32),
+            Some(AccessQualifier::WriteOnly) => quote!(AccessQualifier::WriteOnly as u32),
+            Some(AccessQualifier::ReadWrite) => quote!(AccessQualifier::ReadWrite as u32),
+            None => quote!(3),
         }
     }
 

--- a/crates/spirv-std/macros/src/image.rs
+++ b/crates/spirv-std/macros/src/image.rs
@@ -574,11 +574,11 @@ mod params {
     }
 
     pub fn image_access_to_const_u32(access: Option<AccessQualifier>) -> proc_macro2::TokenStream {
-        match access {
-            Some(AccessQualifier::ReadOnly) => quote!(AccessQualifier::ReadOnly as u32),
-            Some(AccessQualifier::WriteOnly) => quote!(AccessQualifier::WriteOnly as u32),
-            Some(AccessQualifier::ReadWrite) => quote!(AccessQualifier::ReadWrite as u32),
-            None => quote!(3),
+        if let Some(aq) = access {
+            let n = aq as u32;
+            quote!(#n)
+        } else {
+            quote!(3)
         }
     }
 

--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -94,6 +94,7 @@ use std::fmt::Write;
 ///     [multisampled[=<true|false>],]
 ///     [arrayed[=<true|false>],]
 ///     [depth[=<true|false>],]
+///     [access[=<readonly|writeonly|readwrite>],]
 /// )
 /// ```
 ///

--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -123,6 +123,8 @@ use std::fmt::Write;
 ///    Accepted values: `true` or `false`. Default: `false`.
 /// - `depth` — Whether it is known that the image is a depth image.
 ///    Accepted values: `true` or `false`. Default: `unknown`.
+/// - `access` — The access qualifier of the image, if known.
+///    Accepted values: `readonly`, `writeonly` or `readwrite`.
 ///
 /// [`ImageFormat`]: spirv_std_types::image_params::ImageFormat
 ///

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -10,10 +10,7 @@ mod params;
 /// Contains extra image operands
 pub mod sample_with;
 
-pub use self::params::{
-    ImageAccessQualifier, ImageAccessReadOnly, ImageAccessReadWrite, ImageAccessUnknown,
-    ImageAccessWriteOnly, ImageCoordinate, ImageCoordinateSubpassData, SampleType,
-};
+pub use self::params::{ImageCoordinate, ImageCoordinateSubpassData, SampleType};
 pub use crate::macros::Image;
 pub use spirv_std_types::image_params::{
     AccessQualifier, Arrayed, Dimensionality, ImageDepth, ImageFormat, Multisampled, Sampled,
@@ -27,10 +24,7 @@ use crate::{float::Float, integer::Integer, vector::Vector, Sampler};
 /// to the right type.
 #[doc(hidden)]
 pub mod __private {
-    pub use {
-        super::ImageAccessReadOnly, super::ImageAccessReadWrite, super::ImageAccessUnknown, f32,
-        f64, i16, i32, i64, i8, u16, u32, u64, u8,
-    };
+    pub use {f32, f64, i16, i32, i64, i8, u16, u32, u64, u8};
 }
 
 /// A 1d image used with a sampler.
@@ -115,12 +109,12 @@ pub struct Image<
     const SAMPLED: u32,      // Sampled,
     const FORMAT: u32,       // ImageFormat,
     const COMPONENTS: u32,   // NumberOfComponents,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > {
     // HACK(eddyb) avoids the layout becoming ZST (and being elided in one way
     // or another, before `#[spirv(generic_image_type)]` can special-case it).
     _anti_zst_padding: core::mem::MaybeUninit<u32>,
-    _marker: core::marker::PhantomData<(SampledType, Access)>,
+    _marker: core::marker::PhantomData<SampledType>,
 }
 
 impl<
@@ -131,7 +125,7 @@ impl<
     const MULTISAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -142,7 +136,7 @@ impl<
         { Sampled::Yes as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     /// Fetch a single texel with a sampler set at compile time
@@ -179,7 +173,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -190,7 +184,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     // Note: #[inline] is needed because in vulkan, the component must be a constant expression.
@@ -472,7 +466,7 @@ impl<
     const SAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -483,7 +477,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     /// Sample the image with a project coordinate
@@ -697,7 +691,7 @@ impl<
     const MULTISAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -708,7 +702,7 @@ impl<
         { Sampled::No as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     /// Read a texel from an image without a sampler.
@@ -768,7 +762,7 @@ impl<
     const ARRAYED: u32,
     const MULTISAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -779,7 +773,7 @@ impl<
         { Sampled::Unknown as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     /// Read a texel from an image without a sampler.
@@ -838,7 +832,7 @@ impl<
     const MULTISAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -849,7 +843,7 @@ impl<
         { Sampled::No as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     /// Read a texel from subpass input attachment.
@@ -890,8 +884,19 @@ impl<
     const SAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
-> Image<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+    const ACCESS_QUALIFIER: u32,
+>
+    Image<
+        SampledType,
+        DIM,
+        DEPTH,
+        ARRAYED,
+        MULTISAMPLED,
+        SAMPLED,
+        FORMAT,
+        COMPONENTS,
+        ACCESS_QUALIFIER,
+    >
 {
     /// Query the number of mipmap levels.
     #[crate::macros::gpu_only]
@@ -979,7 +984,7 @@ impl<
     const SAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -990,7 +995,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     /// Query the dimensions of Image, with no level of detail.
@@ -1025,7 +1030,7 @@ impl<
     const SAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     Image<
         SampledType,
@@ -1036,7 +1041,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
     /// Query the number of samples available per texel fetch in a multisample image.
@@ -1075,7 +1080,7 @@ impl<
     const SAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     SampledImage<
         Image<
@@ -1087,7 +1092,7 @@ impl<
             SAMPLED,
             FORMAT,
             COMPONENTS,
-            Access,
+            ACCESS_QUALIFIER,
         >,
     >
 {
@@ -1236,7 +1241,7 @@ impl<
     const SAMPLED: u32,
     const FORMAT: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 >
     ImageWithMethods<
         SampledType,
@@ -1249,7 +1254,17 @@ impl<
         COMPONENTS,
         SampleParams,
     >
-    for Image<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+    for Image<
+        SampledType,
+        DIM,
+        DEPTH,
+        ARRAYED,
+        MULTISAMPLED,
+        SAMPLED,
+        FORMAT,
+        COMPONENTS,
+        ACCESS_QUALIFIER,
+    >
 {
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageFetch")]
@@ -1451,7 +1466,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasGather
     for Image<
         SampledType,
@@ -1462,7 +1477,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1473,7 +1488,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasGather
     for Image<
         SampledType,
@@ -1484,7 +1499,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1495,7 +1510,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasGather
     for Image<
         SampledType,
@@ -1506,7 +1521,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1524,7 +1539,7 @@ impl<
     const MULTISAMPLED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQueryLevels
     for Image<
         SampledType,
@@ -1535,7 +1550,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1547,7 +1562,7 @@ impl<
     const MULTISAMPLED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQueryLevels
     for Image<
         SampledType,
@@ -1558,7 +1573,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1570,7 +1585,7 @@ impl<
     const MULTISAMPLED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQueryLevels
     for Image<
         SampledType,
@@ -1581,7 +1596,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1593,7 +1608,7 @@ impl<
     const MULTISAMPLED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQueryLevels
     for Image<
         SampledType,
@@ -1604,7 +1619,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1622,7 +1637,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1633,7 +1648,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1643,7 +1658,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1654,7 +1669,7 @@ impl<
         { Sampled::Unknown as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1664,7 +1679,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1675,7 +1690,7 @@ impl<
         { Sampled::No as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1686,7 +1701,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1697,7 +1712,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1707,7 +1722,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1718,7 +1733,7 @@ impl<
         { Sampled::Unknown as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1728,7 +1743,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1739,7 +1754,7 @@ impl<
         { Sampled::No as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1750,7 +1765,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1761,7 +1776,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1771,7 +1786,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1782,7 +1797,7 @@ impl<
         { Sampled::Unknown as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1792,7 +1807,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1803,7 +1818,7 @@ impl<
         { Sampled::No as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1814,7 +1829,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1825,7 +1840,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1835,7 +1850,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1846,7 +1861,7 @@ impl<
         { Sampled::Unknown as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1856,7 +1871,7 @@ impl<
     const FORMAT: u32,
     const ARRAYED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1867,7 +1882,7 @@ impl<
         { Sampled::No as u32 },
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1879,7 +1894,7 @@ impl<
     const MULTISAMPLED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1890,7 +1905,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1902,7 +1917,7 @@ impl<
     const MULTISAMPLED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySize
     for Image<
         SampledType,
@@ -1913,7 +1928,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1930,7 +1945,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySizeLod
     for Image<
         SampledType,
@@ -1941,7 +1956,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1952,7 +1967,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySizeLod
     for Image<
         SampledType,
@@ -1963,7 +1978,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1974,7 +1989,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySizeLod
     for Image<
         SampledType,
@@ -1985,7 +2000,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }
@@ -1996,7 +2011,7 @@ impl<
     const ARRAYED: u32,
     const SAMPLED: u32,
     const COMPONENTS: u32,
-    Access: ImageAccessQualifier,
+    const ACCESS_QUALIFIER: u32,
 > HasQuerySizeLod
     for Image<
         SampledType,
@@ -2007,7 +2022,7 @@ impl<
         SAMPLED,
         FORMAT,
         COMPONENTS,
-        Access,
+        ACCESS_QUALIFIER,
     >
 {
 }

--- a/crates/spirv-std/src/image/params.rs
+++ b/crates/spirv-std/src/image/params.rs
@@ -1,6 +1,29 @@
 use super::{Arrayed, Dimensionality, ImageFormat};
 use crate::{integer::Integer, scalar::Scalar, vector::Vector, vector::VectorTruncateInto};
 
+/// Marker trait for image access type.
+pub trait ImageAccessQualifier: Clone + Copy {}
+
+/// Denotes a read-only image.
+#[derive(Clone, Copy)]
+pub struct ImageAccessReadOnly;
+impl ImageAccessQualifier for ImageAccessReadOnly {}
+
+/// Denotes a write-only image.
+#[derive(Clone, Copy)]
+pub struct ImageAccessWriteOnly;
+impl ImageAccessQualifier for ImageAccessWriteOnly {}
+
+/// Denotes a read+write image.
+#[derive(Clone, Copy)]
+pub struct ImageAccessReadWrite;
+impl ImageAccessQualifier for ImageAccessReadWrite {}
+
+/// Denotes that an image has an unknown access qualifier.
+#[derive(Clone, Copy)]
+pub struct ImageAccessUnknown;
+impl ImageAccessQualifier for ImageAccessUnknown {}
+
 /// Marker trait for arguments that accept single scalar values or vectors
 /// of scalars. Defines 2-, 3- and 4-component vector types based on the sample type.
 pub trait SampleType<const FORMAT: u32, const COMPONENTS: u32>: Scalar {

--- a/crates/spirv-std/src/image/params.rs
+++ b/crates/spirv-std/src/image/params.rs
@@ -1,29 +1,6 @@
 use super::{Arrayed, Dimensionality, ImageFormat};
 use crate::{integer::Integer, scalar::Scalar, vector::Vector, vector::VectorTruncateInto};
 
-/// Marker trait for image access type.
-pub trait ImageAccessQualifier: Clone + Copy {}
-
-/// Denotes a read-only image.
-#[derive(Clone, Copy)]
-pub struct ImageAccessReadOnly;
-impl ImageAccessQualifier for ImageAccessReadOnly {}
-
-/// Denotes a write-only image.
-#[derive(Clone, Copy)]
-pub struct ImageAccessWriteOnly;
-impl ImageAccessQualifier for ImageAccessWriteOnly {}
-
-/// Denotes a read+write image.
-#[derive(Clone, Copy)]
-pub struct ImageAccessReadWrite;
-impl ImageAccessQualifier for ImageAccessReadWrite {}
-
-/// Denotes that an image has an unknown access qualifier.
-#[derive(Clone, Copy)]
-pub struct ImageAccessUnknown;
-impl ImageAccessQualifier for ImageAccessUnknown {}
-
 /// Marker trait for arguments that accept single scalar values or vectors
 /// of scalars. Defines 2-, 3- and 4-component vector types based on the sample type.
 pub trait SampleType<const FORMAT: u32, const COMPONENTS: u32>: Scalar {

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -1,40 +1,40 @@
-error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasGather` is not satisfied
+error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4, 3>: HasGather` is not satisfied
    --> $DIR/gather_err.rs:15:34
     |
 15  |     let r1: glam::Vec4 = image1d.gather(*sampler, 0.0f32, 0);
-    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 0, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
+    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 0, 2, 0, 0, 1, 0, 4, 3>`
     |
     = help: the following other types implement trait `HasGather`:
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
-   --> $SPIRV_STD_SRC/image.rs:208:15
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::gather`
+   --> $SPIRV_STD_SRC/image.rs:202:15
     |
-201 |     pub fn gather<F>(
+195 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-208 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
+202 |         Self: HasGather,
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::gather`
 
-error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasGather` is not satisfied
+error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4, 3>: HasGather` is not satisfied
    --> $DIR/gather_err.rs:16:34
     |
 16  |     let r2: glam::Vec4 = image3d.gather(*sampler, v3, 0);
-    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 2, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
+    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 2, 2, 0, 0, 1, 0, 4, 3>`
     |
     = help: the following other types implement trait `HasGather`:
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
-   --> $SPIRV_STD_SRC/image.rs:208:15
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::gather`
+   --> $SPIRV_STD_SRC/image.rs:202:15
     |
-201 |     pub fn gather<F>(
+195 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-208 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
+202 |         Self: HasGather,
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::gather`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -1,40 +1,40 @@
-error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
+error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasGather` is not satisfied
    --> $DIR/gather_err.rs:15:34
     |
 15  |     let r1: glam::Vec4 = image1d.gather(*sampler, 0.0f32, 0);
-    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 0, 2, 0, 0, 1, 0, 4>`
+    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 0, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
     |
     = help: the following other types implement trait `HasGather`:
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:197:15
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
+   --> $SPIRV_STD_SRC/image.rs:208:15
     |
-190 |     pub fn gather<F>(
+201 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-197 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
+208 |         Self: HasGather,
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
 
-error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
+error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasGather` is not satisfied
    --> $DIR/gather_err.rs:16:34
     |
 16  |     let r2: glam::Vec4 = image3d.gather(*sampler, v3, 0);
-    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 2, 2, 0, 0, 1, 0, 4>`
+    |                                  ^^^^^^ the trait `HasGather` is not implemented for `Image<f32, 2, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
     |
     = help: the following other types implement trait `HasGather`:
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:197:15
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
+   --> $SPIRV_STD_SRC/image.rs:208:15
     |
-190 |     pub fn gather<F>(
+201 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-197 |         Self: HasGather,
-    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
+208 |         Self: HasGather,
+    |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::gather`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -1,7 +1,7 @@
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4, spirv_std::image::params::ImageAccessUnknown>>::sample::<f32, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4, 3>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::deeper_stack
           implicit_not_in_fragment::deep_stack
           implicit_not_in_fragment::main
@@ -10,7 +10,7 @@ error: ImageSampleImplicitLod cannot be used outside a fragment shader
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4, spirv_std::image::params::ImageAccessUnknown>>::sample::<f32, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4, 3>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::main
           main
 

--- a/tests/ui/image/implicit_not_in_fragment.stderr
+++ b/tests/ui/image/implicit_not_in_fragment.stderr
@@ -1,7 +1,7 @@
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4>>::sample::<f32, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4, spirv_std::image::params::ImageAccessUnknown>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::deeper_stack
           implicit_not_in_fragment::deep_stack
           implicit_not_in_fragment::main
@@ -10,7 +10,7 @@ error: ImageSampleImplicitLod cannot be used outside a fragment shader
 error: ImageSampleImplicitLod cannot be used outside a fragment shader
   |
   = note: Stack:
-          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4>>::sample::<f32, glam::f32::vec2::Vec2>
+          <spirv_std::image::Image<f32, 1, 2, 0, 0, 1, 0, 4, spirv_std::image::params::ImageAccessUnknown>>::sample::<f32, glam::f32::vec2::Vec2>
           implicit_not_in_fragment::main
           main
 

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -1,22 +1,22 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQueryLevels` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, 3>: HasQueryLevels` is not satisfied
    --> $DIR/query_levels_err.rs:12:21
     |
 12  |     *output = image.query_levels();
-    |                     ^^^^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
+    |                     ^^^^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, 3>`
     |
     = help: the following other types implement trait `HasQueryLevels`:
-              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:901:15
+              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_levels`
+   --> $SPIRV_STD_SRC/image.rs:906:15
     |
-899 |     pub fn query_levels(&self) -> u32
+904 |     pub fn query_levels(&self) -> u32
     |            ------------ required by a bound in this associated function
-900 |     where
-901 |         Self: HasQueryLevels,
-    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_levels`
+905 |     where
+906 |         Self: HasQueryLevels,
+    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_levels`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -1,22 +1,22 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQueryLevels` is not satisfied
    --> $DIR/query_levels_err.rs:12:21
     |
 12  |     *output = image.query_levels();
-    |                     ^^^^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
+    |                     ^^^^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
     |
     = help: the following other types implement trait `HasQueryLevels`:
-              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:881:15
+              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_levels`
+   --> $SPIRV_STD_SRC/image.rs:901:15
     |
-879 |     pub fn query_levels(&self) -> u32
+899 |     pub fn query_levels(&self) -> u32
     |            ------------ required by a bound in this associated function
-880 |     where
-881 |         Self: HasQueryLevels,
-    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
+900 |     where
+901 |         Self: HasQueryLevels,
+    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_levels`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -1,22 +1,22 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQueryLevels` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, 3>: HasQueryLevels` is not satisfied
    --> $DIR/query_lod_err.rs:13:21
     |
 13  |     *output = image.query_lod(*sampler, glam::Vec2::new(0.0, 1.0));
-    |                     ^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
+    |                     ^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, 3>`
     |
     = help: the following other types implement trait `HasQueryLevels`:
-              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:927:15
+              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_lod`
+   --> $SPIRV_STD_SRC/image.rs:932:15
     |
-921 |     pub fn query_lod(
+926 |     pub fn query_lod(
     |            --------- required by a bound in this associated function
 ...
-927 |         Self: HasQueryLevels,
-    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_lod`
+932 |         Self: HasQueryLevels,
+    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_lod`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -1,22 +1,22 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQueryLevels` is not satisfied
    --> $DIR/query_lod_err.rs:13:21
     |
 13  |     *output = image.query_lod(*sampler, glam::Vec2::new(0.0, 1.0));
-    |                     ^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
+    |                     ^^^^^^^^^ the trait `HasQueryLevels` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
     |
     = help: the following other types implement trait `HasQueryLevels`:
-              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:907:15
+              Image<SampledType, 0, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 1, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_lod`
+   --> $SPIRV_STD_SRC/image.rs:927:15
     |
-901 |     pub fn query_lod(
+921 |     pub fn query_lod(
     |            --------- required by a bound in this associated function
 ...
-907 |         Self: HasQueryLevels,
-    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
+927 |         Self: HasQueryLevels,
+    |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_lod`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -1,27 +1,27 @@
-error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4>: HasQuerySize` is not satisfied
+error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQuerySize` is not satisfied
    --> $DIR/query_size_err.rs:12:21
     |
 12  |     *output = image.query_size();
-    |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0, 4>`
+    |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
     |
     = help: the following other types implement trait `HasQuerySize`:
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
-              Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
+              Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, Access>
             and 6 others
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:938:15
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_size`
+   --> $SPIRV_STD_SRC/image.rs:958:15
     |
-936 |     pub fn query_size<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(&self) -> Size
+956 |     pub fn query_size<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(&self) -> Size
     |            ---------- required by a bound in this associated function
-937 |     where
-938 |         Self: HasQuerySize,
-    |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
+957 |     where
+958 |         Self: HasQuerySize,
+    |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_size`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -1,27 +1,27 @@
-error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQuerySize` is not satisfied
+error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4, 3>: HasQuerySize` is not satisfied
    --> $DIR/query_size_err.rs:12:21
     |
 12  |     *output = image.query_size();
-    |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
+    |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0, 4, 3>`
     |
     = help: the following other types implement trait `HasQuerySize`:
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, Access>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, Access>
+              Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
             and 6 others
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:958:15
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_size`
+   --> $SPIRV_STD_SRC/image.rs:963:15
     |
-956 |     pub fn query_size<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(&self) -> Size
+961 |     pub fn query_size<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(&self) -> Size
     |            ---------- required by a bound in this associated function
-957 |     where
-958 |         Self: HasQuerySize,
-    |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, Access>::query_size`
+962 |     where
+963 |         Self: HasQuerySize,
+    |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_size`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -1,22 +1,22 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod` is not satisfied
-   --> $DIR/query_size_lod_err.rs:12:21
-    |
-12  |     *output = image.query_size_lod(0);
-    |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
-    |
-    = help: the following other types implement trait `HasQuerySizeLod`:
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:982:15
-    |
-977 |     pub fn query_size_lod<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(
-    |            -------------- required by a bound in this associated function
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQuerySizeLod` is not satisfied
+    --> $DIR/query_size_lod_err.rs:12:21
+     |
+12   |     *output = image.query_size_lod(0);
+     |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
+     |
+     = help: the following other types implement trait `HasQuerySizeLod`:
+               Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+               Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::query_size_lod`
+    --> $SPIRV_STD_SRC/image.rs:1004:15
+     |
+999  |     pub fn query_size_lod<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(
+     |            -------------- required by a bound in this associated function
 ...
-982 |         Self: HasQuerySizeLod,
-    |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
+1004 |         Self: HasQuerySizeLod,
+     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::query_size_lod`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -1,22 +1,22 @@
-error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>: HasQuerySizeLod` is not satisfied
+error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4, 3>: HasQuerySizeLod` is not satisfied
     --> $DIR/query_size_lod_err.rs:12:21
      |
 12   |     *output = image.query_size_lod(0);
-     |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, ImageAccessUnknown>`
+     |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4, 3>`
      |
      = help: the following other types implement trait `HasQuerySizeLod`:
-               Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-               Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, Access>
-note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::query_size_lod`
-    --> $SPIRV_STD_SRC/image.rs:1004:15
+               Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+               Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>
+note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_size_lod`
+    --> $SPIRV_STD_SRC/image.rs:1009:15
      |
-999  |     pub fn query_size_lod<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(
+1004 |     pub fn query_size_lod<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(
      |            -------------- required by a bound in this associated function
 ...
-1004 |         Self: HasQuerySizeLod,
-     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, Access>::query_size_lod`
+1009 |         Self: HasQuerySizeLod,
+     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS, ACCESS_QUALIFIER>::query_size_lod`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
+++ b/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
@@ -15,7 +15,7 @@ warning: redundant storage class attribute, storage class is deduced from type
 9 |     #[spirv(uniform_constant)] warning: &Image!(2D, type=f32),
   |             ^^^^^^^^^^^^^^^^
 
-error: entry parameter type must be by-reference: `&spirv_std::image::Image<f32, 1, 2, 0, 0, 0, 0, 4, spirv_std::image::ImageAccessUnknown>`
+error: entry parameter type must be by-reference: `&spirv_std::image::Image<f32, 1, 2, 0, 0, 0, 0, 4, 3>`
   --> $DIR/bad-deduce-storage-class.rs:15:27
    |
 15 | pub fn issue_585(invalid: Image!(2D, type=f32)) {}

--- a/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
+++ b/tests/ui/spirv-attr/bad-deduce-storage-class.stderr
@@ -15,7 +15,7 @@ warning: redundant storage class attribute, storage class is deduced from type
 9 |     #[spirv(uniform_constant)] warning: &Image!(2D, type=f32),
   |             ^^^^^^^^^^^^^^^^
 
-error: entry parameter type must be by-reference: `&spirv_std::image::Image<f32, 1, 2, 0, 0, 0, 0, 4>`
+error: entry parameter type must be by-reference: `&spirv_std::image::Image<f32, 1, 2, 0, 0, 0, 0, 4, spirv_std::image::ImageAccessUnknown>`
   --> $DIR/bad-deduce-storage-class.rs:15:27
    |
 15 | pub fn issue_585(invalid: Image!(2D, type=f32)) {}


### PR DESCRIPTION
This adds the ability to specify the image access qualifier from the `Image!` macro, or from the `Image` type variables themselves. 

Fixes #28 . 