### PR TITLE
ci: enable GitHub Actions for merge queues.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 name: CI
 


### PR DESCRIPTION
See also:
- https://github.com/EmbarkStudios/spirt/pull/20
  - https://github.com/Rust-GPU/spirt/commit/af5445d366c932788d1b9fec36203f4371339d02
- [relevant GitHub docs](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues)