### PR TITLE
Added non release (dev) shader build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,12 @@ jobs:
           OUT_DIR: "target/tmp"
         run: cargo run -p example-runner-wgpu-builder --release --no-default-features --features "use-installed-tools"
 
+      - name: build example shaders dev
+        if: ${{ matrix.target != 'aarch64-linux-android' }}
+        env:
+          OUT_DIR: "target/tmp"
+        run: cargo run -p example-runner-wgpu-builder --no-default-features --features "use-installed-tools"
+
       - name: Build WGPU Example for Android
         if: ${{ matrix.target == 'aarch64-linux-android' }}
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
         run: cargo run -p example-runner-wgpu-builder --release --no-default-features --features "use-installed-tools"
 
       - name: build example shaders dev
-        if: ${{ matrix.target != 'aarch64-linux-android' }}
+        if: ${{ matrix.target != 'aarch64-linux-android' && matrix.target != 'x86_64-apple-darwin' }}
         env:
           OUT_DIR: "target/tmp"
         run: cargo run -p example-runner-wgpu-builder --no-default-features --features "use-installed-tools"


### PR DESCRIPTION
Hey all! First time contributor (to any open-source project!!!!)

I saw issue #40 and decided to try and see if I could get an action added. I've pretty much just added another example (also runs example-runner-wgpu-builder) but left out --release. 

I was a bit unsure about the OUT_DIR environment variable, and if it was necessary (not even sure why it's there for the existing example run?) but I assumed it should remain for consistency. 

On top of that, I was going to look at adding a dev profile build for android, but it seems that cargo-apk is outdated, and the maintainers of the project recommend [xbuild](https://github.com/rust-mobile/xbuild), though I am unsure if profiles (--release) are forwarded to cargo or not. Will have to play around with it.

I'm also unsure if I'm able to run actions on my fork of this repo for before submitting this, so its possible that it will return an error, but at first glance it seems fine. 

Thanks!