### PR TITLE
Update `indexmap` from 1.6 to 2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -1175,12 +1175,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1188,6 +1182,12 @@ dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "hassle-rs"
@@ -1253,22 +1253,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -1623,7 +1613,7 @@ dependencies = [
  "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
- "indexmap 2.5.0",
+ "indexmap",
  "log",
  "petgraph",
  "rustc-hash",
@@ -1841,7 +1831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1878,7 +1868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64",
- "indexmap 2.5.0",
+ "indexmap",
  "quick-xml 0.32.0",
  "serde",
  "time",
@@ -2146,7 +2136,7 @@ dependencies = [
  "ar",
  "either",
  "hashbrown 0.11.2",
- "indexmap 1.9.3",
+ "indexmap",
  "itertools",
  "lazy_static",
  "libc",
@@ -2427,7 +2417,7 @@ dependencies = [
  "bytemuck",
  "derive_more",
  "elsa",
- "indexmap 2.5.0",
+ "indexmap",
  "internal-iterator",
  "itertools",
  "lazy_static",
@@ -2708,7 +2698,7 @@ version = "0.22.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b072cee73c449a636ffd6f32bd8de3a9f7119139aff882f44943ce2986dc5cf"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -3099,7 +3089,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "document-features",
- "indexmap 2.5.0",
+ "indexmap",
  "log",
  "naga",
  "once_cell",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -49,7 +49,7 @@ regex = { version = "1", features = ["perf"] }
 # Normal dependencies.
 ar = "0.9.0"
 either = "1.8.0"
-indexmap = "1.6.0"
+indexmap = "2.6.0"
 rspirv = "0.12"
 rustc_codegen_spirv-types.workspace = true
 rustc-demangle = "0.1.21"


### PR DESCRIPTION
Updating indexmap because 1.6 depends on a ahash version that makes use of the `stdsimd` feature which no longer exists and was causing compile errors.