### PR TITLE
Non uniform for everything!

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
+++ b/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
@@ -1,7 +1,7 @@
 use super::Builder;
 use crate::builder_spirv::{SpirvValue, SpirvValueExt, SpirvValueKind};
 use crate::spirv_type::SpirvType;
-use rspirv::spirv::Word;
+use rspirv::spirv::{Decoration, Word};
 use rustc_codegen_ssa::traits::BuilderMethods;
 use rustc_errors::ErrorGuaranteed;
 use rustc_span::DUMMY_SP;
@@ -38,9 +38,14 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         };
         let u32_ty = SpirvType::Integer(32, false).def(DUMMY_SP, self);
         let u32_ptr = self.type_ptr_to(u32_ty);
+        let array = array.def(self);
+        let actual_index = actual_index.def(self);
+        self.emit().decorate(array, Decoration::NonUniform, []);
+        self.emit()
+            .decorate(actual_index, Decoration::NonUniform, []);
         let ptr = self
             .emit()
-            .in_bounds_access_chain(u32_ptr, None, array.def(self), [actual_index.def(self)])
+            .in_bounds_access_chain(u32_ptr, None, array, [actual_index])
             .unwrap()
             .with_type(u32_ptr);
         self.load(u32_ty, ptr, Align::ONE)

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -18,13 +18,13 @@ pub use spirv_std_types::image_params::{
 
 use sample_with::{NoneTy, SampleParams, SomeTy};
 
-use crate::{float::Float, integer::Integer, vector::Vector, Sampler};
+use crate::{Sampler, float::Float, integer::Integer, vector::Vector};
 
 /// Re-export of primitive types to ensure the `Image` proc macro always points
 /// to the right type.
 #[doc(hidden)]
 pub mod __private {
-    pub use {f32, f64, i16, i32, i64, i8, u16, u32, u64, u8};
+    pub use {f32, f64, i8, i16, i32, i64, u8, u16, u32, u64};
 }
 
 /// A 1d image used with a sampler.
@@ -149,6 +149,8 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%coordinate = OpLoad _ {coordinate}",
                 "%result = OpImageFetch typeof*{result} %image %coordinate",
@@ -200,6 +202,10 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%typeSampledImage = OpTypeSampledImage typeof*{this}",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
@@ -230,6 +236,10 @@ impl<
         unsafe {
             let mut result = SampledType::Vec4::default();
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%typeSampledImage = OpTypeSampledImage typeof*{1}",
                 "%image = OpLoad typeof*{1} {1}",
                 "%sampler = OpLoad typeof*{2} {2}",
@@ -262,6 +272,10 @@ impl<
             let mut result = SampledType::Vec4::default();
 
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%typeSampledImage = OpTypeSampledImage typeof*{1}",
                 "%image = OpLoad typeof*{1} {1}",
                 "%sampler = OpLoad typeof*{2} {2}",
@@ -295,6 +309,10 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -328,6 +346,10 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -362,6 +384,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -395,6 +421,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -432,6 +462,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -487,6 +521,10 @@ impl<
         unsafe {
             let mut result = SampledType::Vec4::default();
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%project_coordinate = OpLoad _ {project_coordinate}",
@@ -517,6 +555,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%project_coordinate = OpLoad _ {project_coordinate}",
@@ -550,6 +592,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%project_coordinate = OpLoad _ {project_coordinate}",
@@ -584,6 +630,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%project_coordinate = OpLoad _ {project_coordinate}",
@@ -617,6 +667,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -654,6 +708,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -710,6 +768,8 @@ impl<
 
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%coordinate = OpLoad _ {coordinate}",
                 "%result = OpImageRead typeof*{result} %image %coordinate",
@@ -733,14 +793,17 @@ impl<
     ) where
         I: Integer,
     {
-        asm! {
-            "%image = OpLoad _ {this}",
-            "%coordinate = OpLoad _ {coordinate}",
-            "%texels = OpLoad _ {texels}",
-            "OpImageWrite %image %coordinate %texels",
-            this = in(reg) self,
-            coordinate = in(reg) &coordinate,
-            texels = in(reg) &texels,
+        unsafe {
+            asm! {
+                "OpDecorate %image NonUniform",
+                "%image = OpLoad _ {this}",
+                "%coordinate = OpLoad _ {coordinate}",
+                "%texels = OpLoad _ {texels}",
+                "OpImageWrite %image %coordinate %texels",
+                this = in(reg) self,
+                coordinate = in(reg) &coordinate,
+                texels = in(reg) &texels,
+            }
         }
     }
 }
@@ -779,6 +842,8 @@ impl<
 
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%coordinate = OpLoad _ {coordinate}",
                 "%result = OpImageRead typeof*{result} %image %coordinate",
@@ -802,14 +867,17 @@ impl<
     ) where
         I: Integer,
     {
-        asm! {
-            "%image = OpLoad _ {this}",
-            "%coordinate = OpLoad _ {coordinate}",
-            "%texels = OpLoad _ {texels}",
-            "OpImageWrite %image %coordinate %texels",
-            this = in(reg) self,
-            coordinate = in(reg) &coordinate,
-            texels = in(reg) &texels,
+        unsafe {
+            asm! {
+                "OpDecorate %image NonUniform",
+                "%image = OpLoad _ {this}",
+                "%coordinate = OpLoad _ {coordinate}",
+                "%texels = OpLoad _ {texels}",
+                "OpImageWrite %image %coordinate %texels",
+                this = in(reg) self,
+                coordinate = in(reg) &coordinate,
+                texels = in(reg) &texels,
+            }
         }
     }
 }
@@ -848,13 +916,15 @@ impl<
 
         unsafe {
             asm! {
-            "%image = OpLoad _ {this}",
-            "%coordinate = OpLoad _ {coordinate}",
-            "%result = OpImageRead typeof*{result} %image %coordinate",
-            "OpStore {result} %result",
-            this = in(reg) self,
-            coordinate = in(reg) &coordinate,
-            result = in(reg) &mut result,
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
+                "%image = OpLoad _ {this}",
+                "%coordinate = OpLoad _ {coordinate}",
+                "%result = OpImageRead typeof*{result} %image %coordinate",
+                "OpStore {result} %result",
+                this = in(reg) self,
+                coordinate = in(reg) &coordinate,
+                result = in(reg) &mut result,
             }
         }
 
@@ -880,13 +950,16 @@ impl<
     where
         Self: HasQueryLevels,
     {
-        let result: u32;
+        let mut result = Default::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
-                "{result} = OpImageQueryLevels typeof{result} %image",
+                "%result = OpImageQueryLevels typeof*{result} %image",
+                "OpStore {result} %result",
                 this = in(reg) self,
-                result = out(reg) result,
+                result = in(reg) &mut result,
             }
         }
         result
@@ -940,6 +1013,8 @@ impl<
         let mut result: Size = Default::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%result = OpImageQuerySize typeof*{result} %image",
                 "OpStore {result} %result",
@@ -984,6 +1059,8 @@ impl<
         let mut result: Size = Default::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%result = OpImageQuerySizeLod typeof*{result} %image {lod}",
                 "OpStore {result} %result",
@@ -1019,13 +1096,16 @@ impl<
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageQuerySamples")]
     pub fn query_samples(&self) -> u32 {
-        let result: u32;
+        let mut result = Default::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
-                "{result} = OpImageQuerySamples typeof{result} %image",
+                "%result = OpImageQuerySamples typeof*{result} %image",
+                "OpStore {result} %result",
                 this = in(reg) self,
-                result = out(reg) result,
+                result = in(reg) &mut result,
             }
         }
         result
@@ -1065,6 +1145,7 @@ impl<
         >,
     >
 {
+    // FIXME
     /// Sample texels at `coord` from the sampled image with an implicit lod.
     #[crate::macros::gpu_only]
     pub fn sample<F>(
@@ -1077,6 +1158,8 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm!(
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%sampledImage = OpLoad typeof*{1} {1}",
                 "%coord = OpLoad typeof*{2} {2}",
                 "%result = OpImageSampleImplicitLod typeof*{0} %sampledImage %coord",
@@ -1102,6 +1185,8 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm!(
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%sampledImage = OpLoad typeof*{1} {1}",
                 "%coord = OpLoad typeof*{2} {2}",
                 "%lod = OpLoad typeof*{3} {3}",
@@ -1236,6 +1321,8 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%coordinate = OpLoad _ {coordinate}",
                 "%result = OpImageFetch typeof*{result} %image %coordinate $PARAMS",
@@ -1266,6 +1353,10 @@ impl<
         let mut result = SampledType::Vec4::default();
         unsafe {
             asm! {
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%typeSampledImage = OpTypeSampledImage typeof*{this}",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
@@ -1297,6 +1388,10 @@ impl<
         unsafe {
             let mut result = SampledType::Vec4::default();
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%typeSampledImage = OpTypeSampledImage typeof*{this}",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
@@ -1329,6 +1424,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%coordinate = OpLoad _ {coordinate}",
@@ -1361,6 +1460,10 @@ impl<
         unsafe {
             let mut result = SampledType::Vec4::default();
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%project_coordinate = OpLoad _ {project_coordinate}",
@@ -1392,6 +1495,10 @@ impl<
         let mut result = Default::default();
         unsafe {
             asm!(
+                "OpDecorate %image NonUniform",
+                "OpDecorate %sampler NonUniform",
+                "OpDecorate %sampledImage NonUniform",
+                "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%sampler = OpLoad _ {sampler}",
                 "%project_coordinate = OpLoad _ {project_coordinate}",

--- a/tests/ui/byte_addressable_buffer/arr.rs
+++ b/tests/ui/byte_addressable_buffer/arr.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{glam::Vec4, ByteAddressableBuffer};
+use spirv_std::{ByteAddressableBuffer, glam::Vec4};
 
 #[spirv(fragment)]
 pub fn load(

--- a/tests/ui/byte_addressable_buffer/big_struct.rs
+++ b/tests/ui/byte_addressable_buffer/big_struct.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::spirv;
 use spirv_std::ByteAddressableBuffer;
+use spirv_std::spirv;
 
 pub struct BigStruct {
     a: u32,

--- a/tests/ui/byte_addressable_buffer/complex.rs
+++ b/tests/ui/byte_addressable_buffer/complex.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{glam::Vec2, ByteAddressableBuffer};
+use spirv_std::{ByteAddressableBuffer, glam::Vec2};
 
 pub struct Complex {
     x: u32,

--- a/tests/ui/byte_addressable_buffer/f32.rs
+++ b/tests/ui/byte_addressable_buffer/f32.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::spirv;
 use spirv_std::ByteAddressableBuffer;
+use spirv_std::spirv;
 
 #[spirv(fragment)]
 pub fn load(#[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &[u32], out: &mut f32) {

--- a/tests/ui/byte_addressable_buffer/small_struct.rs
+++ b/tests/ui/byte_addressable_buffer/small_struct.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::spirv;
 use spirv_std::ByteAddressableBuffer;
+use spirv_std::spirv;
 
 pub struct SmallStruct {
     a: u32,

--- a/tests/ui/byte_addressable_buffer/u32.rs
+++ b/tests/ui/byte_addressable_buffer/u32.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::spirv;
 use spirv_std::ByteAddressableBuffer;
+use spirv_std::spirv;
 
 #[spirv(fragment)]
 pub fn load(#[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buf: &[u32], out: &mut u32) {

--- a/tests/ui/byte_addressable_buffer/vec.rs
+++ b/tests/ui/byte_addressable_buffer/vec.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{glam::Vec4, ByteAddressableBuffer};
+use spirv_std::{ByteAddressableBuffer, glam::Vec4};
 
 #[spirv(matrix)]
 pub struct Mat4 {

--- a/tests/ui/image/components.rs
+++ b/tests/ui/image/components.rs
@@ -1,9 +1,9 @@
 // build-pass
-// compile-flags: -Ctarget-feature=+StorageImageExtendedFormats
+// compile-flags: -Ctarget-feature=+StorageImageExtendedFormats,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use glam::{Vec2, Vec3, Vec4};
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/fetch.rs
+++ b/tests/ui/image/fetch.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/format.rs
+++ b/tests/ui/image/format.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/gather.rs
+++ b/tests/ui/image/gather.rs
@@ -1,9 +1,10 @@
 // Test `OpImageGather`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use core::arch::asm;
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/gather_err.rs
+++ b/tests/ui/image/gather_err.rs
@@ -1,8 +1,8 @@
 // build-fail
 // normalize-stderr-test "\S*/crates/spirv-std/src/" -> "$$SPIRV_STD_SRC/"
-// compile-flags: -Ctarget-feature=+Sampled1D
+// compile-flags: -Ctarget-feature=+Sampled1D,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::{arch, spirv, Image, Sampler};
+use spirv_std::{Image, Sampler, arch, spirv};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/gather_err.stderr
+++ b/tests/ui/image/gather_err.stderr
@@ -9,12 +9,12 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:197:15
+   --> $SPIRV_STD_SRC/image.rs:199:15
     |
-190 |     pub fn gather<F>(
+192 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-197 |         Self: HasGather,
+199 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
@@ -28,12 +28,12 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:197:15
+   --> $SPIRV_STD_SRC/image.rs:199:15
     |
-190 |     pub fn gather<F>(
+192 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-197 |         Self: HasGather,
+199 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/image/image_with.rs
+++ b/tests/ui/image/image_with.rs
@@ -1,7 +1,8 @@
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, image::sample_with, image::ImageWithMethods, Image, Sampler};
+use spirv_std::{Image, Sampler, arch, image::ImageWithMethods, image::sample_with};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/issue_527.rs
+++ b/tests/ui/image/issue_527.rs
@@ -1,5 +1,5 @@
 // build-pass
-// compile-flags: -C target-feature=+StorageImageWriteWithoutFormat
+// compile-flags: -C target-feature=+StorageImageWriteWithoutFormat,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use glam::*;
 use spirv_std::spirv;

--- a/tests/ui/image/query/query_levels.rs
+++ b/tests/ui/image/query/query_levels.rs
@@ -1,8 +1,8 @@
 // build-pass
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_levels_err.stderr
+++ b/tests/ui/image/query/query_levels_err.stderr
@@ -10,12 +10,12 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:881:15
+   --> $SPIRV_STD_SRC/image.rs:951:15
     |
-879 |     pub fn query_levels(&self) -> u32
+949 |     pub fn query_levels(&self) -> u32
     |            ------------ required by a bound in this associated function
-880 |     where
-881 |         Self: HasQueryLevels,
+950 |     where
+951 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
 
 error: aborting due to 1 previous error

--- a/tests/ui/image/query/query_lod.rs
+++ b/tests/ui/image/query/query_lod.rs
@@ -1,8 +1,8 @@
 // build-pass
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_lod_err.rs
+++ b/tests/ui/image/query/query_lod_err.rs
@@ -1,8 +1,8 @@
 // build-fail
 // normalize-stderr-test "\S*/crates/spirv-std/src/" -> "$$SPIRV_STD_SRC/"
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::{arch, spirv, Image, Sampler};
+use spirv_std::{Image, Sampler, arch, spirv};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_lod_err.stderr
+++ b/tests/ui/image/query/query_lod_err.stderr
@@ -10,12 +10,12 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:907:15
+   --> $SPIRV_STD_SRC/image.rs:980:15
     |
-901 |     pub fn query_lod(
+974 |     pub fn query_lod(
     |            --------- required by a bound in this associated function
 ...
-907 |         Self: HasQueryLevels,
+980 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
 
 error: aborting due to 1 previous error

--- a/tests/ui/image/query/query_samples.rs
+++ b/tests/ui/image/query/query_samples.rs
@@ -1,8 +1,8 @@
 // build-pass
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_size.rs
+++ b/tests/ui/image/query/query_size.rs
@@ -1,8 +1,8 @@
 // build-pass
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_size_err.rs
+++ b/tests/ui/image/query/query_size_err.rs
@@ -1,8 +1,8 @@
 // build-fail
 // normalize-stderr-test "\S*/crates/spirv-std/src/" -> "$$SPIRV_STD_SRC/"
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::{arch, spirv, Image};
+use spirv_std::{Image, arch, spirv};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_size_err.stderr
+++ b/tests/ui/image/query/query_size_err.stderr
@@ -1,27 +1,27 @@
 error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4>: HasQuerySize` is not satisfied
-   --> $DIR/query_size_err.rs:12:21
-    |
-12  |     *output = image.query_size();
-    |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0, 4>`
-    |
-    = help: the following other types implement trait `HasQuerySize`:
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
-              Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
-            and 6 others
+    --> $DIR/query_size_err.rs:12:21
+     |
+12   |     *output = image.query_size();
+     |                     ^^^^^^^^^^ the trait `HasQuerySize` is not implemented for `Image<f32, 1, 2, 0, 0, 1, 0, 4>`
+     |
+     = help: the following other types implement trait `HasQuerySize`:
+               Image<SampledType, 0, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
+               Image<SampledType, 0, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
+               Image<SampledType, 0, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
+               Image<SampledType, 1, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
+               Image<SampledType, 1, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
+               Image<SampledType, 1, DEPTH, ARRAYED, 1, SAMPLED, FORMAT, COMPONENTS>
+               Image<SampledType, 2, DEPTH, ARRAYED, 0, 0, FORMAT, COMPONENTS>
+               Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
+             and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
-   --> $SPIRV_STD_SRC/image.rs:938:15
-    |
-936 |     pub fn query_size<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(&self) -> Size
-    |            ---------- required by a bound in this associated function
-937 |     where
-938 |         Self: HasQuerySize,
-    |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
+    --> $SPIRV_STD_SRC/image.rs:1011:15
+     |
+1009 |     pub fn query_size<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(&self) -> Size
+     |            ---------- required by a bound in this associated function
+1010 |     where
+1011 |         Self: HasQuerySize,
+     |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/query/query_size_lod.rs
+++ b/tests/ui/image/query/query_size_lod.rs
@@ -1,8 +1,8 @@
 // build-pass
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_size_lod_err.rs
+++ b/tests/ui/image/query/query_size_lod_err.rs
@@ -1,8 +1,8 @@
 // build-fail
 // normalize-stderr-test "\S*/crates/spirv-std/src/" -> "$$SPIRV_STD_SRC/"
-// compile-flags: -C target-feature=+ImageQuery
+// compile-flags: -C target-feature=+ImageQuery,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
-use spirv_std::{arch, spirv, Image};
+use spirv_std::{Image, arch, spirv};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/ui/image/query/query_size_lod_err.stderr
@@ -1,22 +1,22 @@
 error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod` is not satisfied
-   --> $DIR/query_size_lod_err.rs:12:21
-    |
-12  |     *output = image.query_size_lod(0);
-    |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
-    |
-    = help: the following other types implement trait `HasQuerySizeLod`:
-              Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
-              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+    --> $DIR/query_size_lod_err.rs:12:21
+     |
+12   |     *output = image.query_size_lod(0);
+     |                     ^^^^^^^^^^^^^^ the trait `HasQuerySizeLod` is not implemented for `Image<f32, 4, 2, 0, 0, 1, 0, 4>`
+     |
+     = help: the following other types implement trait `HasQuerySizeLod`:
+               Image<SampledType, 0, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+               Image<SampledType, 1, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+               Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
+               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
-   --> $SPIRV_STD_SRC/image.rs:982:15
-    |
-977 |     pub fn query_size_lod<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(
-    |            -------------- required by a bound in this associated function
+    --> $SPIRV_STD_SRC/image.rs:1057:15
+     |
+1052 |     pub fn query_size_lod<Size: ImageCoordinate<u32, DIM, ARRAYED> + Default>(
+     |            -------------- required by a bound in this associated function
 ...
-982 |         Self: HasQuerySizeLod,
-    |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
+1057 |         Self: HasQuerySizeLod,
+     |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/image/read.rs
+++ b/tests/ui/image/read.rs
@@ -1,9 +1,9 @@
 // Test `OpImageRead`
 // build-pass
-// compile-flags: -C target-feature=+StorageImageReadWithoutFormat
+// compile-flags: -C target-feature=+StorageImageReadWithoutFormat,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/read_subpass.rs
+++ b/tests/ui/image/read_subpass.rs
@@ -1,8 +1,8 @@
 // build-pass
-// compile-flags: -C target-feature=+InputAttachment
+// compile-flags: -C target-feature=+InputAttachment,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample.rs
+++ b/tests/ui/image/sample.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleImplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample_bias.rs
+++ b/tests/ui/image/sample_bias.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleImplicitLod` Bias
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample_depth_reference/sample.rs
+++ b/tests/ui/image/sample_depth_reference/sample.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleDrefImplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample_depth_reference/sample_gradient.rs
+++ b/tests/ui/image/sample_depth_reference/sample_gradient.rs
@@ -1,5 +1,6 @@
 // Test `OpImageSampleDrefExplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
 use spirv_std::{Image, Sampler};

--- a/tests/ui/image/sample_depth_reference/sample_lod.rs
+++ b/tests/ui/image/sample_depth_reference/sample_lod.rs
@@ -1,5 +1,6 @@
 // Test `OpImageSampleDrefExplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
 use spirv_std::{Image, Sampler};

--- a/tests/ui/image/sample_depth_reference_with_project_coordinate/sample.rs
+++ b/tests/ui/image/sample_depth_reference_with_project_coordinate/sample.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleProjDrefImplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample_depth_reference_with_project_coordinate/sample_gradient.rs
+++ b/tests/ui/image/sample_depth_reference_with_project_coordinate/sample_gradient.rs
@@ -1,5 +1,6 @@
 // Test `OpImageSampleProjDrefExplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
 use spirv_std::{Image, Sampler};

--- a/tests/ui/image/sample_depth_reference_with_project_coordinate/sample_lod.rs
+++ b/tests/ui/image/sample_depth_reference_with_project_coordinate/sample_lod.rs
@@ -1,5 +1,6 @@
 // Test `OpImageSampleProjDrefExplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
 use spirv_std::{Image, Sampler};

--- a/tests/ui/image/sample_gradient.rs
+++ b/tests/ui/image/sample_gradient.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleExplicitLod` Grad
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample_lod.rs
+++ b/tests/ui/image/sample_lod.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleExplicitLod` Lod
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, image::SampledImage, Image, Sampler};
+use spirv_std::{Image, Sampler, arch, image::SampledImage};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample_with_project_coordinate/sample.rs
+++ b/tests/ui/image/sample_with_project_coordinate/sample.rs
@@ -1,5 +1,6 @@
 // Test `OpImageSampleProjImplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
 use spirv_std::{Image, Sampler};

--- a/tests/ui/image/sample_with_project_coordinate/sample_gradient.rs
+++ b/tests/ui/image/sample_with_project_coordinate/sample_gradient.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleProjExplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/sample_with_project_coordinate/sample_lod.rs
+++ b/tests/ui/image/sample_with_project_coordinate/sample_lod.rs
@@ -1,8 +1,9 @@
 // Test `OpImageSampleProjExplicitLod`
 // build-pass
+// compile-flags: -Ctarget-feature=+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image, Sampler};
+use spirv_std::{Image, Sampler, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/image/write.rs
+++ b/tests/ui/image/write.rs
@@ -1,9 +1,9 @@
 // Test `OpImageWrite`
 // build-pass
-// compile-flags: -C target-feature=+StorageImageWriteWithoutFormat
+// compile-flags: -C target-feature=+StorageImageWriteWithoutFormat,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
-use spirv_std::{arch, Image};
+use spirv_std::{Image, arch};
 
 #[spirv(fragment)]
 pub fn main(

--- a/tests/ui/storage_class/runtime_descriptor_array.rs
+++ b/tests/ui/storage_class/runtime_descriptor_array.rs
@@ -1,5 +1,5 @@
 // build-pass
-// compile-flags: -C target-feature=+RuntimeDescriptorArray,+ext:SPV_EXT_descriptor_indexing
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+ShaderNonUniform,+ext:SPV_EXT_descriptor_indexing
 
 use spirv_std::spirv;
 use spirv_std::{Image, RuntimeArray, Sampler};


### PR DESCRIPTION
Adds the NonUniform declaration to pretty much everything, even if it's not required. I don't think this will have a huge performance impact, as Nvidia and Intel don't seem to care about this flag, their accesses are always non-uniform, and Amd's driver is really good at figuring out whether something is uniform / scalar across the workgroup / subgroup or not. 

Feel free to cherry-pick these commits if you do need non-uniform now and can't wait until rust-gpu has figured out a proper solution.