### PR TITLE
ByteAddressableBuffer fixes

### DIFF
--- a/crates/spirv-std/src/byte_addressable_buffer.rs
+++ b/crates/spirv-std/src/byte_addressable_buffer.rs
@@ -70,14 +70,12 @@ fn bounds_check<T>(data: &[u32], byte_index: u32) {
     if byte_index % 4 != 0 {
         panic!("`byte_index` should be a multiple of 4");
     }
-    if byte_index + sizeof > data.len() as u32 {
-        let last_byte = byte_index + sizeof;
+    let last_byte = byte_index + sizeof;
+    let len = data.len() as u32;
+    if byte_index + sizeof > len {
         panic!(
             "index out of bounds: the len is {} but loading {} bytes at `byte_index` {} reads until {} (exclusive)",
-            data.len(),
-            sizeof,
-            byte_index,
-            last_byte,
+            len, sizeof, byte_index, last_byte,
         );
     }
 }

--- a/crates/spirv-std/src/byte_addressable_buffer.rs
+++ b/crates/spirv-std/src/byte_addressable_buffer.rs
@@ -71,7 +71,7 @@ fn bounds_check<T>(data: &[u32], byte_index: u32) {
         panic!("`byte_index` should be a multiple of 4");
     }
     let last_byte = byte_index + sizeof;
-    let len = data.len() as u32;
+    let len = data.len() as u32 * 4;
     if byte_index + sizeof > len {
         panic!(
             "index out of bounds: the len is {} but loading {} bytes at `byte_index` {} reads until {} (exclusive)",


### PR DESCRIPTION
* fix oob calculation thinking all buffers are only `len / 4` long
* fix debug printf mispile, segfaulting debug printf validation layer

android ci is broken right now, see https://github.com/Rust-GPU/rust-gpu/pull/180
