### PR TITLE
Fix C string char type to use portable type c_char.

### DIFF
--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -84,6 +84,7 @@ use std::{
     collections::HashMap,
     ffi::{CStr, CString},
     fs::File,
+    os::raw::c_char,
     sync::mpsc::{TryRecvError, TrySendError, sync_channel},
     thread,
 };
@@ -313,7 +314,7 @@ impl RenderBase {
             } else {
                 vec![]
             };
-            let layers_names_raw: Vec<*const i8> = layer_names
+            let layers_names_raw: Vec<*const c_char> = layer_names
                 .iter()
                 .map(|raw_name| raw_name.as_ptr())
                 .collect();


### PR DESCRIPTION
Hello,

Building the Vulkan runner failed on my ARM 64 Ubuntu virtual machine with the following error:
```
error[E0277]: a value of type `Vec<*const i8>` cannot be built from an iterator over elements of type `*const u8`
    --> examples/runners/ash/src/main.rs:319:18
     |
319  |                 .collect();
     |                  ^^^^^^^ value of type `Vec<*const i8>` cannot be built from `std::iter::Iterator<Item=*const u8>`
     |
     = help: the trait `FromIterator<*const u8>` is not implemented for `Vec<*const i8>`
             but trait `FromIterator<*const i8>` is implemented for it
     = help: for that trait implementation, expected `i8`, found `u8`
note: the method call chain might not have had the expected associated types
    --> examples/runners/ash/src/main.rs:318:18
     |
311  |               let layer_names = if options.debug_layer {
     |  _______________________________-
312  | |                 vec![CString::new("VK_LAYER_KHRONOS_validation").unwrap()]
313  | |             } else {
314  | |                 vec![]
315  | |             };
     | |_____________- this expression has type `Vec<CString>`
316  |               let layers_names_raw: Vec<*const i8> = layer_names
317  |                   .iter()
     |                    ------ `Iterator::Item` is `&CString` here
318  |                   .map(|raw_name| raw_name.as_ptr())
     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Iterator::Item` changed to `*const u8` here
note: required by a bound in `collect`
    --> /home/bvideau/.rustup/toolchains/nightly-2024-11-22-aarch64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:1967:19
     |
1967 |     fn collect<B: FromIterator<Self::Item>>(self) -> B
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Iterator::collect`


```
The c char type is unsigned on this platform.
This patch addresses the issue.