### PR TITLE
make vector and scalar traits imply `Send + Sync + 'static`

### DIFF
--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -9,7 +9,7 @@ use glam::{Vec3Swizzles, Vec4Swizzles};
 /// # Safety
 /// Implementing this trait on non-scalar or non-vector types may break assumptions about other
 /// unsafe code, and should not be done.
-pub unsafe trait VectorOrScalar: Default {
+pub unsafe trait VectorOrScalar: Default + Send + Sync + 'static {
     /// Either the scalar component type of the vector or the scalar itself.
     type Scalar: Scalar;
 


### PR DESCRIPTION
This makes the traits `VectorOrScalar`, `Vector`, `Scalar` and `image::params::SampleType` implicitly be `Send + Sync + 'static`. This has always been true for all impl anyway, and as these are all sealed traits, this change is *not* breaking. 

This mostly helps me with my bindless API where I always have to do `Generic: SampleType + Send + Sync + 'static` and now I can just do `Generic: SampleType`.