### PR TITLE
spirv-builder: add `RUSTGPU_CARGOFLAGS`, as a Cargo counterpart to `RUSTGPU_RUSTFLAGS` (for `rustc`).

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -805,6 +805,10 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         profile,
     ]);
 
+    if let Ok(extra_cargoflags) = tracked_env_var_get("RUSTGPU_CARGOFLAGS") {
+        cargo.args(extra_cargoflags.split_whitespace());
+    }
+
     // FIXME(eddyb) consider moving `target-specs` into `rustc_codegen_spirv_types`.
     // FIXME(eddyb) consider the `RUST_TARGET_PATH` env var alternative.
     cargo


### PR DESCRIPTION
Had this lying around intermixed with `-Zscript` experiments I never completed, and we keep running into situations where this simple addition would be useful.