### PR TITLE
Undef zombie and some other code cleanups

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/intrinsics.rs
@@ -292,14 +292,10 @@ impl<'a, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'tcx> {
                         let res3 = self.or(res3, res4);
                         self.or(res1, res3)
                     }
-                    other => {
-                        let undef = self.undef(ret_ty);
-                        self.zombie(
-                            undef.def(self),
-                            &format!("bswap not implemented for int width {other}"),
-                        );
-                        undef
-                    }
+                    other => self.undef_zombie(
+                        ret_ty,
+                        &format!("bswap not implemented for int width {other}"),
+                    ),
                 };
 
                 // Cast back to the original signed type if necessary
@@ -310,11 +306,7 @@ impl<'a, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'tcx> {
                 }
             }
 
-            sym::compare_bytes => {
-                let undef = self.undef(ret_ty);
-                self.zombie(undef.def(self), "memcmp not implemented");
-                undef
-            }
+            sym::compare_bytes => self.undef_zombie(ret_ty, "memcmp not implemented"),
 
             _ => {
                 // Call the fallback body instead of generating the intrinsic code
@@ -397,12 +389,10 @@ impl Builder<'_, '_> {
                             .unwrap()
                     }
                     _ => {
-                        let undef = self.undef(ty).def(self);
-                        self.zombie(
-                            undef,
+                        return self.undef_zombie(
+                            ty,
                             &format!("count_ones() on unsupported {ty:?} bit integer type"),
                         );
-                        undef
                     }
                 }
                 .with_type(u32)
@@ -461,12 +451,10 @@ impl Builder<'_, '_> {
                             .unwrap()
                     }
                     _ => {
-                        let undef = self.undef(ty).def(self);
-                        self.zombie(
-                            undef,
+                        return self.undef_zombie(
+                            ty,
                             &format!("bit_reverse() on unsupported {ty:?} bit integer type"),
                         );
-                        undef
                     }
                 }
                 .with_type(ty)
@@ -559,11 +547,9 @@ impl Builder<'_, '_> {
                         }
                     }
                     _ => {
-                        let undef = self.undef(ty).def(self);
-                        self.zombie(undef, &format!(
+                        return self.undef_zombie(ty, &format!(
                             "count_leading_trailing_zeros() on unsupported {ty:?} bit integer type"
                         ));
-                        undef
                     }
                 };
 

--- a/crates/rustc_codegen_spirv/src/builder/libm_intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/libm_intrinsics.rs
@@ -261,94 +261,58 @@ impl Builder<'_, '_> {
                 self.sub(exp, one)
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Erf) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Erf not supported yet");
-                undef
+                self.undef_zombie(result_type, "Erf not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Erfc) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Erfc not supported yet");
-                undef
+                self.undef_zombie(result_type, "Erfc not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Fdim) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Fdim not supported yet");
-                undef
+                self.undef_zombie(result_type, "Fdim not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Hypot) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Hypot not supported yet");
-                undef
+                self.undef_zombie(result_type, "Hypot not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Ilogb) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Ilogb not supported yet");
-                undef
+                self.undef_zombie(result_type, "Ilogb not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::J0) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "J0 not supported yet");
-                undef
+                self.undef_zombie(result_type, "J0 not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Y0) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Y0 not supported yet");
-                undef
+                self.undef_zombie(result_type, "Y0 not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::J1) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "J1 not supported yet");
-                undef
+                self.undef_zombie(result_type, "J1 not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Y1) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Y1 not supported yet");
-                undef
+                self.undef_zombie(result_type, "Y1 not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Jn) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Jn not supported yet");
-                undef
+                self.undef_zombie(result_type, "Jn not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Yn) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Yn not supported yet");
-                undef
+                self.undef_zombie(result_type, "Yn not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Lgamma) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Lgamma not supported yet");
-                undef
+                self.undef_zombie(result_type, "Lgamma not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::LgammaR) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "LgammaR not supported yet");
-                undef
+                self.undef_zombie(result_type, "LgammaR not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Tgamma) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Tgamma not supported yet");
-                undef
+                self.undef_zombie(result_type, "Tgamma not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::NextAfter) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "NextAfter not supported yet");
-                undef
+                self.undef_zombie(result_type, "NextAfter not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Remainder) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Remainder not supported yet");
-                undef
+                self.undef_zombie(result_type, "Remainder not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::RemQuo) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "RemQuo not supported yet");
-                undef
+                self.undef_zombie(result_type, "RemQuo not supported yet")
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Scalbn) => {
-                let undef = self.undef(result_type);
-                self.zombie(undef.def(self), "Scalbn not supported yet");
-                undef
+                self.undef_zombie(result_type, "Scalbn not supported yet")
             }
         }
     }

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -60,6 +60,24 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         }
     }
 
+    pub fn undef_zombie(&self, word: Word, reason: &str) -> SpirvValue {
+        if let Some(current_span) = self.current_span {
+            self.undef_zombie_with_span(word, current_span, reason)
+        } else {
+            self.undef_zombie_no_span(word, reason)
+        }
+    }
+    pub fn undef_zombie_with_span(&self, ty: Word, span: Span, reason: &str) -> SpirvValue {
+        let undef = self.undef(ty);
+        self.zombie_with_span(undef.def(self), span, reason);
+        undef
+    }
+    pub fn undef_zombie_no_span(&self, ty: Word, reason: &str) -> SpirvValue {
+        let undef = self.undef(ty);
+        self.zombie_no_span(undef.def(self), reason);
+        undef
+    }
+
     pub fn validate_atomic(&self, ty: Word, to_zombie: Word) {
         if !self.i8_i16_atomics_allowed {
             match self.lookup_type(ty) {

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -54,7 +54,7 @@ impl<'tcx> CodegenCx<'tcx> {
 
     fn constant_int_from_native_signed(&self, span: Span, val: impl Into<i128>) -> SpirvValue {
         let size = Size::from_bytes(std::mem::size_of_val(&val));
-        let ty = SpirvType::Integer(size.bits() as u32, false).def(span, self);
+        let ty = SpirvType::Integer(size.bits() as u32, true).def(span, self);
         self.constant_int(ty, val.into() as u128)
     }
 


### PR DESCRIPTION
**best reviewed commit by commit**

I see this quite commonly:
```rust
let undef = self.undef(ret_ty);
self.zombie(undef.def(self), "memcmp not implemented");
undef
```

And I replaced it with this:
```rust
self.undef_zombie(ret_ty, "memcmp not implemented")
```

Among other smaller cleanups