### PR TITLE
Fix typo swapping logical operations on bools

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -2144,7 +2144,8 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                     self.emit().logical_or(b, None, lhs.def(self), rhs)
                 }
                 // x < y  =>  !x && y
-                IntULE => {
+                IntULT => {
+                    // intel-compute-runtime doesn't like OpLogicalNot
                     let true_ = self.constant_bool(self.span(), true);
                     let lhs = self
                         .emit()
@@ -2153,7 +2154,8 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                     self.emit().logical_and(b, None, lhs, rhs.def(self))
                 }
                 // x <= y  =>  !x || y
-                IntULT => {
+                IntULE => {
+                    // intel-compute-runtime doesn't like OpLogicalNot
                     let true_ = self.constant_bool(self.span(), true);
                     let lhs = self
                         .emit()


### PR DESCRIPTION
I don't really know when this applies, just saw it while reading the code.