### PR TITLE
refactor derivatives

### DIFF
--- a/crates/spirv-std/src/arch/derivative.rs
+++ b/crates/spirv-std/src/arch/derivative.rs
@@ -36,6 +36,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn ddx(self) -> Self {
         deriv_fn!(OpDPdx, self)
     }
@@ -48,6 +49,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn ddx_fine(self) -> Self {
         cap_deriv_control!();
         deriv_fn!(OpDPdxFine, self)
@@ -63,6 +65,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn ddx_coarse(self) -> Self {
         cap_deriv_control!();
         deriv_fn!(OpDPdxCoarse, self)
@@ -77,6 +80,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn ddy(self) -> Self {
         deriv_fn!(OpDPdy, self)
     }
@@ -89,6 +93,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn ddy_fine(self) -> Self {
         cap_deriv_control!();
         deriv_fn!(OpDPdyFine, self)
@@ -104,6 +109,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn ddy_coarse(self) -> Self {
         cap_deriv_control!();
         deriv_fn!(OpDPdyCoarse, self)
@@ -116,6 +122,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn fwidth(self) -> Self {
         deriv_fn!(OpFwidth, self)
     }
@@ -127,6 +134,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn fwidth_fine(self) -> Self {
         cap_deriv_control!();
         deriv_fn!(OpFwidthFine, self)
@@ -139,6 +147,7 @@ pub unsafe trait Derivative: Sealed + Default {
     ///
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
+    #[inline]
     fn fwidth_coarse(self) -> Self {
         cap_deriv_control!();
         deriv_fn!(OpFwidthCoarse, self)

--- a/crates/spirv-std/src/arch/derivative.rs
+++ b/crates/spirv-std/src/arch/derivative.rs
@@ -19,6 +19,9 @@ macro_rules! deriv_fn {
 }
 
 /// Types that can be derived by partial derivatives
+///
+/// # Safety
+/// Result Type must be a scalar or vector of floating-point type using the IEEE 754 encoding. The component width must be 32 bits.
 pub unsafe trait Derivative: Sealed + Default {
     /// Result is the partial derivative of `Self` with respect to the window x coordinate. Uses local differencing
     /// based on the value of `Self`. Same result as either [`Self::dfdx_fine`] or [`Self::dfdx_coarse`] on `Self`. Selection of which

--- a/crates/spirv-std/src/arch/derivative.rs
+++ b/crates/spirv-std/src/arch/derivative.rs
@@ -21,7 +21,7 @@ macro_rules! deriv_fn {
 /// Types that can be derived by partial derivatives
 pub unsafe trait Derivative: Sealed + Default {
     /// Result is the partial derivative of `Self` with respect to the window x coordinate. Uses local differencing
-    /// based on the value of `Self`. Same result as either [`ddx_fine`] or [`ddx_coarse`] on `Self`. Selection of which
+    /// based on the value of `Self`. Same result as either [`dfdx_fine`] or [`dfdx_coarse`] on `Self`. Selection of which
     /// one is based on external factors.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
@@ -30,7 +30,7 @@ pub unsafe trait Derivative: Sealed + Default {
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
     #[inline]
-    fn ddx(self) -> Self {
+    fn dfdx(self) -> Self {
         deriv_fn!(OpDPdx, self)
     }
 
@@ -43,14 +43,14 @@ pub unsafe trait Derivative: Sealed + Default {
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
     #[inline]
-    fn ddx_fine(self) -> Self {
+    fn dfdx_fine(self) -> Self {
         deriv_fn!(OpDPdxFine, self)
     }
 
     /// Result is the partial derivative of `Self` with respect to the window x coordinate. Uses local differencing
     /// based on the value of `Self` for the current fragment’s neighbors, and possibly, but not necessarily, includes
     /// the value of `Self` for the current fragment. That is, over a given area, the implementation can compute x
-    /// derivatives in fewer unique locations than would be allowed for [`ddx_fine`].
+    /// derivatives in fewer unique locations than would be allowed for [`dfdx_fine`].
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -58,12 +58,12 @@ pub unsafe trait Derivative: Sealed + Default {
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
     #[inline]
-    fn ddx_coarse(self) -> Self {
+    fn dfdx_coarse(self) -> Self {
         deriv_fn!(OpDPdxCoarse, self)
     }
 
     /// Result is the partial derivative of `Self` with respect to the window y coordinate. Uses local differencing
-    /// based on the value of `Self`. Same result as either [`ddy_fine`] or [`ddy_coarse`] on `Self`. Selection of which
+    /// based on the value of `Self`. Same result as either [`dfdy_fine`] or [`dfdy_coarse`] on `Self`. Selection of which
     /// one is based on external factors.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
@@ -72,7 +72,7 @@ pub unsafe trait Derivative: Sealed + Default {
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
     #[inline]
-    fn ddy(self) -> Self {
+    fn dfdy(self) -> Self {
         deriv_fn!(OpDPdy, self)
     }
 
@@ -85,14 +85,14 @@ pub unsafe trait Derivative: Sealed + Default {
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
     #[inline]
-    fn ddy_fine(self) -> Self {
+    fn dfdy_fine(self) -> Self {
         deriv_fn!(OpDPdyFine, self)
     }
 
     /// Result is the partial derivative of `Self` with respect to the window y coordinate. Uses local differencing
     /// based on the value of `Self` for the current fragment’s neighbors, and possibly, but not necessarily, includes
     /// the value of `Self` for the current fragment. That is, over a given area, the implementation can compute y
-    /// derivatives in fewer unique locations than would be allowed for [`ddy_fine`].
+    /// derivatives in fewer unique locations than would be allowed for [`dfdy_fine`].
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -100,11 +100,11 @@ pub unsafe trait Derivative: Sealed + Default {
     /// This instruction is only valid in the Fragment Execution Model.
     #[crate::macros::gpu_only]
     #[inline]
-    fn ddy_coarse(self) -> Self {
+    fn dfdy_coarse(self) -> Self {
         deriv_fn!(OpDPdyCoarse, self)
     }
 
-    /// Result is the same as computing the sum of the absolute values of [`ddx`] and [`ddy`] on P.
+    /// Result is the same as computing the sum of the absolute values of [`dfdx`] and [`dfdy`] on P.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -116,7 +116,7 @@ pub unsafe trait Derivative: Sealed + Default {
         deriv_fn!(OpFwidth, self)
     }
 
-    /// Result is the same as computing the sum of the absolute values of [`ddx_fine`] and [`ddy_fine`] on P.
+    /// Result is the same as computing the sum of the absolute values of [`dfdx_fine`] and [`dfdy_fine`] on P.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -128,7 +128,7 @@ pub unsafe trait Derivative: Sealed + Default {
         deriv_fn!(OpFwidthFine, self)
     }
 
-    /// Result is the same as computing the sum of the absolute values of [`ddx_coarse`] and [`ddy_coarse`] on P.
+    /// Result is the same as computing the sum of the absolute values of [`dfdx_coarse`] and [`dfdy_coarse`] on P.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.

--- a/crates/spirv-std/src/arch/derivative.rs
+++ b/crates/spirv-std/src/arch/derivative.rs
@@ -1,14 +1,7 @@
 use crate::sealed::Sealed;
 use glam::{Vec2, Vec3, Vec3A, Vec4};
 
-macro_rules! cap_deriv_control {
-    () => {
-        unsafe {
-            core::arch::asm!("OpCapability DerivativeControl");
-        }
-    };
-}
-
+#[cfg(target_arch = "spirv")]
 macro_rules! deriv_fn {
     ($inst:ident, $param:expr) => {
         unsafe {
@@ -51,7 +44,6 @@ pub unsafe trait Derivative: Sealed + Default {
     #[crate::macros::gpu_only]
     #[inline]
     fn ddx_fine(self) -> Self {
-        cap_deriv_control!();
         deriv_fn!(OpDPdxFine, self)
     }
 
@@ -67,7 +59,6 @@ pub unsafe trait Derivative: Sealed + Default {
     #[crate::macros::gpu_only]
     #[inline]
     fn ddx_coarse(self) -> Self {
-        cap_deriv_control!();
         deriv_fn!(OpDPdxCoarse, self)
     }
 
@@ -95,7 +86,6 @@ pub unsafe trait Derivative: Sealed + Default {
     #[crate::macros::gpu_only]
     #[inline]
     fn ddy_fine(self) -> Self {
-        cap_deriv_control!();
         deriv_fn!(OpDPdyFine, self)
     }
 
@@ -111,7 +101,6 @@ pub unsafe trait Derivative: Sealed + Default {
     #[crate::macros::gpu_only]
     #[inline]
     fn ddy_coarse(self) -> Self {
-        cap_deriv_control!();
         deriv_fn!(OpDPdyCoarse, self)
     }
 
@@ -136,7 +125,6 @@ pub unsafe trait Derivative: Sealed + Default {
     #[crate::macros::gpu_only]
     #[inline]
     fn fwidth_fine(self) -> Self {
-        cap_deriv_control!();
         deriv_fn!(OpFwidthFine, self)
     }
 
@@ -149,7 +137,6 @@ pub unsafe trait Derivative: Sealed + Default {
     #[crate::macros::gpu_only]
     #[inline]
     fn fwidth_coarse(self) -> Self {
-        cap_deriv_control!();
         deriv_fn!(OpFwidthCoarse, self)
     }
 }

--- a/crates/spirv-std/src/arch/derivative.rs
+++ b/crates/spirv-std/src/arch/derivative.rs
@@ -21,7 +21,7 @@ macro_rules! deriv_fn {
 /// Types that can be derived by partial derivatives
 pub unsafe trait Derivative: Sealed + Default {
     /// Result is the partial derivative of `Self` with respect to the window x coordinate. Uses local differencing
-    /// based on the value of `Self`. Same result as either [`dfdx_fine`] or [`dfdx_coarse`] on `Self`. Selection of which
+    /// based on the value of `Self`. Same result as either [`Self::dfdx_fine`] or [`Self::dfdx_coarse`] on `Self`. Selection of which
     /// one is based on external factors.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
@@ -50,7 +50,7 @@ pub unsafe trait Derivative: Sealed + Default {
     /// Result is the partial derivative of `Self` with respect to the window x coordinate. Uses local differencing
     /// based on the value of `Self` for the current fragment’s neighbors, and possibly, but not necessarily, includes
     /// the value of `Self` for the current fragment. That is, over a given area, the implementation can compute x
-    /// derivatives in fewer unique locations than would be allowed for [`dfdx_fine`].
+    /// derivatives in fewer unique locations than would be allowed for [`Self::dfdx_fine`].
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -63,7 +63,7 @@ pub unsafe trait Derivative: Sealed + Default {
     }
 
     /// Result is the partial derivative of `Self` with respect to the window y coordinate. Uses local differencing
-    /// based on the value of `Self`. Same result as either [`dfdy_fine`] or [`dfdy_coarse`] on `Self`. Selection of which
+    /// based on the value of `Self`. Same result as either [`Self::dfdy_fine`] or [`Self::dfdy_coarse`] on `Self`. Selection of which
     /// one is based on external factors.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
@@ -92,7 +92,7 @@ pub unsafe trait Derivative: Sealed + Default {
     /// Result is the partial derivative of `Self` with respect to the window y coordinate. Uses local differencing
     /// based on the value of `Self` for the current fragment’s neighbors, and possibly, but not necessarily, includes
     /// the value of `Self` for the current fragment. That is, over a given area, the implementation can compute y
-    /// derivatives in fewer unique locations than would be allowed for [`dfdy_fine`].
+    /// derivatives in fewer unique locations than would be allowed for [`Self::dfdy_fine`].
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -104,7 +104,7 @@ pub unsafe trait Derivative: Sealed + Default {
         deriv_fn!(OpDPdyCoarse, self)
     }
 
-    /// Result is the same as computing the sum of the absolute values of [`dfdx`] and [`dfdy`] on P.
+    /// Result is the same as computing the sum of the absolute values of [`Self::dfdx`] and [`Self::dfdy`] on P.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -116,7 +116,7 @@ pub unsafe trait Derivative: Sealed + Default {
         deriv_fn!(OpFwidth, self)
     }
 
-    /// Result is the same as computing the sum of the absolute values of [`dfdx_fine`] and [`dfdy_fine`] on P.
+    /// Result is the same as computing the sum of the absolute values of [`Self::dfdx_fine`] and [`Self::dfdy_fine`] on P.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.
@@ -128,7 +128,7 @@ pub unsafe trait Derivative: Sealed + Default {
         deriv_fn!(OpFwidthFine, self)
     }
 
-    /// Result is the same as computing the sum of the absolute values of [`dfdx_coarse`] and [`dfdy_coarse`] on P.
+    /// Result is the same as computing the sum of the absolute values of [`Self::dfdx_coarse`] and [`Self::dfdy_coarse`] on P.
     ///
     /// An invocation will not execute a dynamic instance of this instruction (X') until all invocations in its
     /// derivative group have executed all dynamic instances that are program-ordered before X'.

--- a/crates/spirv-std/src/sealed.rs
+++ b/crates/spirv-std/src/sealed.rs
@@ -13,3 +13,18 @@ impl Sealed for i8 {}
 impl Sealed for i16 {}
 impl Sealed for i32 {}
 impl Sealed for i64 {}
+
+impl Sealed for glam::Vec2 {}
+impl Sealed for glam::Vec3 {}
+impl Sealed for glam::Vec4 {}
+impl Sealed for glam::DVec2 {}
+impl Sealed for glam::DVec3 {}
+impl Sealed for glam::DVec4 {}
+impl Sealed for glam::UVec2 {}
+impl Sealed for glam::UVec3 {}
+impl Sealed for glam::UVec4 {}
+impl Sealed for glam::IVec2 {}
+impl Sealed for glam::IVec3 {}
+impl Sealed for glam::IVec4 {}
+
+impl Sealed for glam::Vec3A {}

--- a/tests/ui/arch/derivative.rs
+++ b/tests/ui/arch/derivative.rs
@@ -1,0 +1,16 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-fn=derivative::derivative
+
+use spirv_std::arch::Derivative;
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main() {
+    derivative();
+}
+
+pub fn derivative() {
+    Derivative::ddx(0.);
+    Derivative::ddy(0.);
+    Derivative::fwidth(0.);
+}

--- a/tests/ui/arch/derivative.rs
+++ b/tests/ui/arch/derivative.rs
@@ -10,7 +10,7 @@ pub fn main() {
 }
 
 pub fn derivative() {
-    Derivative::ddx(0.);
-    Derivative::ddy(0.);
+    Derivative::dfdx(0.);
+    Derivative::dfdy(0.);
     Derivative::fwidth(0.);
 }

--- a/tests/ui/arch/derivative.stderr
+++ b/tests/ui/arch/derivative.stderr
@@ -1,10 +1,10 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 41 8
+OpLine %5 34 8
 %6 = OpDPdx  %7  %8
-OpLine %5 85 8
+OpLine %5 76 8
 %9 = OpDPdy  %7  %8
-OpLine %5 127 8
+OpLine %5 116 8
 %10 = OpFwidth  %7  %8
 OpNoLine
 OpReturn

--- a/tests/ui/arch/derivative.stderr
+++ b/tests/ui/arch/derivative.stderr
@@ -1,10 +1,10 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 34 8
+OpLine %5 37 8
 %6 = OpDPdx  %7  %8
-OpLine %5 76 8
+OpLine %5 79 8
 %9 = OpDPdy  %7  %8
-OpLine %5 116 8
+OpLine %5 119 8
 %10 = OpFwidth  %7  %8
 OpNoLine
 OpReturn

--- a/tests/ui/arch/derivative.stderr
+++ b/tests/ui/arch/derivative.stderr
@@ -1,0 +1,11 @@
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 41 8
+%6 = OpDPdx  %7  %8
+OpLine %5 85 8
+%9 = OpDPdy  %7  %8
+OpLine %5 127 8
+%10 = OpFwidth  %7  %8
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/ui/arch/derivative_control.rs
+++ b/tests/ui/arch/derivative_control.rs
@@ -11,11 +11,11 @@ pub fn main() {
 }
 
 pub fn derivative() {
-    Derivative::ddx_fine(0.);
-    Derivative::ddy_fine(0.);
+    Derivative::dfdx_fine(0.);
+    Derivative::dfdy_fine(0.);
     Derivative::fwidth_fine(0.);
 
-    Derivative::ddx_coarse(0.);
-    Derivative::ddy_coarse(0.);
+    Derivative::dfdx_coarse(0.);
+    Derivative::dfdy_coarse(0.);
     Derivative::fwidth_coarse(0.);
 }

--- a/tests/ui/arch/derivative_control.rs
+++ b/tests/ui/arch/derivative_control.rs
@@ -1,0 +1,21 @@
+// build-pass
+// compile-flags: -C target-feature=+DerivativeControl
+// compile-flags: -C llvm-args=--disassemble-fn=derivative_control::derivative
+
+use spirv_std::arch::Derivative;
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main() {
+    derivative();
+}
+
+pub fn derivative() {
+    Derivative::ddx_fine(0.);
+    Derivative::ddy_fine(0.);
+    Derivative::fwidth_fine(0.);
+
+    Derivative::ddx_coarse(0.);
+    Derivative::ddy_coarse(0.);
+    Derivative::fwidth_coarse(0.);
+}

--- a/tests/ui/arch/derivative_control.stderr
+++ b/tests/ui/arch/derivative_control.stderr
@@ -1,16 +1,16 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 55 8
+OpLine %5 47 8
 %6 = OpDPdxFine  %7  %8
-OpLine %5 99 8
+OpLine %5 89 8
 %9 = OpDPdyFine  %7  %8
-OpLine %5 140 8
+OpLine %5 128 8
 %10 = OpFwidthFine  %7  %8
-OpLine %5 71 8
+OpLine %5 62 8
 %11 = OpDPdxCoarse  %7  %8
-OpLine %5 115 8
+OpLine %5 104 8
 %12 = OpDPdyCoarse  %7  %8
-OpLine %5 153 8
+OpLine %5 140 8
 %13 = OpFwidthCoarse  %7  %8
 OpNoLine
 OpReturn

--- a/tests/ui/arch/derivative_control.stderr
+++ b/tests/ui/arch/derivative_control.stderr
@@ -1,0 +1,17 @@
+%1 = OpFunction  %2  None %3
+%4 = OpLabel
+OpLine %5 55 8
+%6 = OpDPdxFine  %7  %8
+OpLine %5 99 8
+%9 = OpDPdyFine  %7  %8
+OpLine %5 140 8
+%10 = OpFwidthFine  %7  %8
+OpLine %5 71 8
+%11 = OpDPdxCoarse  %7  %8
+OpLine %5 115 8
+%12 = OpDPdyCoarse  %7  %8
+OpLine %5 153 8
+%13 = OpFwidthCoarse  %7  %8
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/ui/arch/derivative_control.stderr
+++ b/tests/ui/arch/derivative_control.stderr
@@ -1,16 +1,16 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 47 8
+OpLine %5 50 8
 %6 = OpDPdxFine  %7  %8
-OpLine %5 89 8
+OpLine %5 92 8
 %9 = OpDPdyFine  %7  %8
-OpLine %5 128 8
+OpLine %5 131 8
 %10 = OpFwidthFine  %7  %8
-OpLine %5 62 8
+OpLine %5 65 8
 %11 = OpDPdxCoarse  %7  %8
-OpLine %5 104 8
+OpLine %5 107 8
 %12 = OpDPdyCoarse  %7  %8
-OpLine %5 140 8
+OpLine %5 143 8
 %13 = OpFwidthCoarse  %7  %8
 OpNoLine
 OpReturn


### PR DESCRIPTION
Adds a new `trait Derivative` that is implemented for `f32`, `Vec2`, `Vec3`, `Vec3A` and `Vec4`. Disallows f64 to be derived, spec expects f32 only. Renamed derivatives from `ddx()` to `dfdx()` to better match glsl's `dFdx()`.

Spec section: https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_derivative_instructions