### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,7 @@ Welcome! We're glad you're interested in contributing! We welcome contributions 
 ## How to get help
 
 For questions, clarifications, and general help please first search [Github
-discussions](discussions) and then ask your question if you can't find the answer.
-
-[discussions]: https://github.com/rust-gpu/rust-gpu/discussions
+discussions](https://github.com/rust-gpu/rust-gpu/discussions) and then ask your question if you can't find the answer.
 
 ## Issues
 


### PR DESCRIPTION
Fix relative link in contributing.md

When viewed on GitHub's web interface, the relative link was interpreted as relative to the current file path, leading to the incorrect URL "https://github.com/Rust-GPU/rust-gpu/blob/main/discussions" instead of the intended Discussions tab.