### PR TITLE
Add support for PhysicalStorageBuffer

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -339,6 +339,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
                 PointeeDefState::Defining => {
                     let id = SpirvType::Pointer {
                         pointee: pointee_spv,
+                        storage_class: None, // TODO(jwollen): Do we need to cache by storage class?
                     }
                     .def(span, cx);
                     entry.insert(PointeeDefState::Defined(id));
@@ -350,6 +351,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
                     entry.insert(PointeeDefState::Defined(id));
                     SpirvType::Pointer {
                         pointee: pointee_spv,
+                        storage_class: None, // TODO(jwollen): Do we need to cache by storage class?
                     }
                     .def_with_id(cx, span, id)
                 }

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -3,7 +3,7 @@
 
 use crate::attr::{AggregatedSpirvAttributes, IntrinsicType};
 use crate::codegen_cx::CodegenCx;
-use crate::spirv_type::SpirvType;
+use crate::spirv_type::{SpirvType, StorageClassKind};
 use itertools::Itertools;
 use rspirv::spirv::{Dim, ImageFormat, StorageClass, Word};
 use rustc_data_structures::fx::FxHashMap;
@@ -339,7 +339,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
                 PointeeDefState::Defining => {
                     let id = SpirvType::Pointer {
                         pointee: pointee_spv,
-                        storage_class: None, // TODO(jwollen): Do we need to cache by storage class?
+                        storage_class: StorageClassKind::Inferred, // TODO(jwollen): Do we need to cache by storage class?
                     }
                     .def(span, cx);
                     entry.insert(PointeeDefState::Defined(id));
@@ -351,7 +351,7 @@ impl<'tcx> RecursivePointeeCache<'tcx> {
                     entry.insert(PointeeDefState::Defined(id));
                     SpirvType::Pointer {
                         pointee: pointee_spv,
-                        storage_class: None, // TODO(jwollen): Do we need to cache by storage class?
+                        storage_class: StorageClassKind::Inferred, // TODO(jwollen): Do we need to cache by storage class?
                     }
                     .def_with_id(cx, span, id)
                 }

--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -337,7 +337,7 @@ impl CheckSpirvAttrVisitor<'_> {
                                 "attribute is only valid on a parameter of an entry-point function",
                             );
                         } else {
-                            // FIXME(eddyb) should we just remove all 5 of these storage class
+                            // FIXME(eddyb) should we just remove all 6 of these storage class
                             // attributes, instead of disallowing them here?
                             if let SpirvAttribute::StorageClass(storage_class) = parsed_attr {
                                 let valid = match storage_class {
@@ -347,7 +347,8 @@ impl CheckSpirvAttrVisitor<'_> {
 
                                     StorageClass::Private
                                     | StorageClass::Function
-                                    | StorageClass::Generic => {
+                                    | StorageClass::Generic
+                                    | StorageClass::PhysicalStorageBuffer => {
                                         Err("can not be used as part of an entry's interface")
                                     }
 

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -407,14 +407,15 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         size: Size,
     ) -> Option<(SpirvValue, <Self as BackendTypes>::Type)> {
         let ptr = ptr.strip_ptrcasts();
-        let mut leaf_ty = match self.lookup_type(ptr.ty) {
-            SpirvType::Pointer { pointee } => pointee,
+        let pointee_ty = match self.lookup_type(ptr.ty) {
+            SpirvType::Pointer { pointee, .. } => pointee,
             other => self.fatal(format!("non-pointer type: {other:?}")),
         };
 
         // FIXME(eddyb) this isn't efficient, `recover_access_chain_from_offset`
         // could instead be doing all the extra digging itself.
         let mut indices = SmallVec::<[_; 8]>::new();
+        let mut leaf_ty = pointee_ty;
         while let Some((inner_indices, inner_ty)) = self.recover_access_chain_from_offset(
             leaf_ty,
             Size::ZERO,
@@ -429,7 +430,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             .then(|| self.type_ptr_to(leaf_ty))?;
 
         let leaf_ptr = if indices.is_empty() {
-            assert_ty_eq!(self, ptr.ty, leaf_ptr_ty);
+            // Compare pointee types instead of pointer  types as storage class might be different.
+            assert_ty_eq!(self, pointee_ty, leaf_ty);
             ptr
         } else {
             let indices = indices
@@ -586,7 +588,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         let ptr = ptr.strip_ptrcasts();
         let ptr_id = ptr.def(self);
         let original_pointee_ty = match self.lookup_type(ptr.ty) {
-            SpirvType::Pointer { pointee } => pointee,
+            SpirvType::Pointer { pointee, .. } => pointee,
             other => self.fatal(format!("gep called on non-pointer type: {other:?}")),
         };
 
@@ -1926,6 +1928,25 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             return ptr;
         }
 
+        // No cast is needed if only the storage class mismatches.
+        let ptr_pointee = match self.lookup_type(ptr.ty) {
+            SpirvType::Pointer { pointee, .. } => pointee,
+            other => self.fatal(format!(
+                "pointercast called on non-pointer source type: {other:?}"
+            )),
+        };
+        let dest_pointee = match self.lookup_type(dest_ty) {
+            SpirvType::Pointer { pointee, .. } => pointee,
+            other => self.fatal(format!(
+                "pointercast called on non-pointer dest type: {other:?}"
+            )),
+        };
+
+        // FIXME(jwollen) Do we need to choose `dest_ty` if it has a fixed storage class and `ptr` has none?
+        if ptr_pointee == dest_pointee {
+            return ptr;
+        }
+
         // Strip a previous `pointercast`, to reveal the original pointer type.
         let ptr = ptr.strip_ptrcasts();
 
@@ -1934,17 +1955,16 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         }
 
         let ptr_pointee = match self.lookup_type(ptr.ty) {
-            SpirvType::Pointer { pointee } => pointee,
+            SpirvType::Pointer { pointee, .. } => pointee,
             other => self.fatal(format!(
                 "pointercast called on non-pointer source type: {other:?}"
             )),
         };
-        let dest_pointee = match self.lookup_type(dest_ty) {
-            SpirvType::Pointer { pointee } => pointee,
-            other => self.fatal(format!(
-                "pointercast called on non-pointer dest type: {other:?}"
-            )),
-        };
+
+        if ptr_pointee == dest_pointee {
+            return ptr;
+        }
+
         let dest_pointee_size = self.lookup_type(dest_pointee).sizeof(self);
 
         if let Some((indices, _)) = self.recover_access_chain_from_offset(
@@ -2324,7 +2344,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
             .and_then(|size| Some(Size::from_bytes(u64::try_from(size).ok()?)));
 
         let elem_ty = match self.lookup_type(ptr.ty) {
-            SpirvType::Pointer { pointee } => pointee,
+            SpirvType::Pointer { pointee, .. } => pointee,
             _ => self.fatal(format!(
                 "memset called on non-pointer type: {}",
                 self.debug_type(ptr.ty)
@@ -2696,7 +2716,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                 (callee.def(self), return_type, arguments)
             }
 
-            SpirvType::Pointer { pointee } => match self.lookup_type(pointee) {
+            SpirvType::Pointer { pointee, .. } => match self.lookup_type(pointee) {
                 SpirvType::Function {
                     return_type,
                     arguments,

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -16,7 +16,7 @@ use crate::abi::ConvSpirvType;
 use crate::builder_spirv::{BuilderCursor, SpirvValue, SpirvValueExt};
 use crate::codegen_cx::CodegenCx;
 use crate::spirv_type::SpirvType;
-use rspirv::spirv::Word;
+use rspirv::spirv::{StorageClass, Word};
 use rustc_codegen_ssa::mir::operand::{OperandRef, OperandValue};
 use rustc_codegen_ssa::mir::place::PlaceRef;
 use rustc_codegen_ssa::traits::{
@@ -104,7 +104,23 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     // HACK(eddyb) like the `CodegenCx` method but with `self.span()` awareness.
     pub fn type_ptr_to(&self, ty: Word) -> Word {
-        SpirvType::Pointer { pointee: ty }.def(self.span(), self)
+        SpirvType::Pointer {
+            pointee: ty,
+            storage_class: None,
+        }
+        .def(self.span(), self)
+    }
+
+    pub fn type_ptr_with_storage_class_to(
+        &self,
+        ty: Word,
+        storage_class: Option<StorageClass>,
+    ) -> Word {
+        SpirvType::Pointer {
+            pointee: ty,
+            storage_class,
+        }
+        .def(self.span(), self)
     }
 
     // TODO: Definitely add tests to make sure this impl is right.

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -111,7 +111,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
         .def(self.span(), self)
     }
 
-    pub fn type_ptr_with_storage_class_to(
+    pub fn type_ptr_to_with_storage_class(
         &self,
         ty: Word,
         storage_class: StorageClassKind,

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -15,7 +15,7 @@ use crate::maybe_pqp_cg_ssa as rustc_codegen_ssa;
 use crate::abi::ConvSpirvType;
 use crate::builder_spirv::{BuilderCursor, SpirvValue, SpirvValueExt};
 use crate::codegen_cx::CodegenCx;
-use crate::spirv_type::SpirvType;
+use crate::spirv_type::{SpirvType, StorageClassKind};
 use rspirv::spirv::{StorageClass, Word};
 use rustc_codegen_ssa::mir::operand::{OperandRef, OperandValue};
 use rustc_codegen_ssa::mir::place::PlaceRef;
@@ -106,7 +106,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub fn type_ptr_to(&self, ty: Word) -> Word {
         SpirvType::Pointer {
             pointee: ty,
-            storage_class: None,
+            storage_class: StorageClassKind::Inferred,
         }
         .def(self.span(), self)
     }
@@ -114,7 +114,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub fn type_ptr_with_storage_class_to(
         &self,
         ty: Word,
-        storage_class: Option<StorageClass>,
+        storage_class: StorageClassKind,
     ) -> Word {
         SpirvType::Pointer {
             pointee: ty,

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -4,7 +4,7 @@ use crate::maybe_pqp_cg_ssa as rustc_codegen_ssa;
 use super::Builder;
 use crate::builder_spirv::{BuilderCursor, SpirvValue};
 use crate::codegen_cx::CodegenCx;
-use crate::spirv_type::SpirvType;
+use crate::spirv_type::{SpirvType, StorageClassKind};
 use rspirv::dr;
 use rspirv::grammar::{LogicalOperand, OperandKind, OperandQuantifier, reflect};
 use rspirv::spirv::{
@@ -309,8 +309,8 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             Op::TypePointer => {
                 // The storage class can be specified explicitly or inferred later by using StorageClass::Generic.
                 let storage_class = match inst.operands[0].unwrap_storage_class() {
-                    StorageClass::Generic => None,
-                    storage_class => Some(storage_class),
+                    StorageClass::Generic => StorageClassKind::Inferred,
+                    storage_class => StorageClassKind::Explicit(storage_class),
                 };
                 SpirvType::Pointer {
                     pointee: inst.operands[1].unwrap_id_ref(),
@@ -673,7 +673,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
                 TyPat::Pointer(_, pat) => SpirvType::Pointer {
                     pointee: subst_ty_pat(cx, pat, ty_vars, leftover_operands)?,
-                    storage_class: None,
+                    storage_class: StorageClassKind::Inferred,
                 }
                 .def(DUMMY_SP, cx),
 

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -307,19 +307,14 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
             }
             .def(self.span(), self),
             Op::TypePointer => {
-                let storage_class = inst.operands[0].unwrap_storage_class();
-                if storage_class != StorageClass::Generic {
-                    self.struct_err("TypePointer in asm! requires `Generic` storage class")
-                        .with_note(format!(
-                            "`{storage_class:?}` storage class was specified"
-                        ))
-                        .with_help(format!(
-                            "the storage class will be inferred automatically (e.g. to `{storage_class:?}`)"
-                        ))
-                        .emit();
-                }
+                // The storage class can be specified explicitly or inferred later by using StorageClass::Generic.
+                let storage_class = match inst.operands[0].unwrap_storage_class() {
+                    StorageClass::Generic => None,
+                    storage_class => Some(storage_class),
+                };
                 SpirvType::Pointer {
                     pointee: inst.operands[1].unwrap_id_ref(),
+                    storage_class,
                 }
                 .def(self.span(), self)
             }
@@ -678,6 +673,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
 
                 TyPat::Pointer(_, pat) => SpirvType::Pointer {
                     pointee: subst_ty_pat(cx, pat, ty_vars, leftover_operands)?,
+                    storage_class: None,
                 }
                 .def(DUMMY_SP, cx),
 
@@ -931,7 +927,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                     Some(match kind {
                         TypeofKind::Plain => ty,
                         TypeofKind::Dereference => match self.lookup_type(ty) {
-                            SpirvType::Pointer { pointee } => pointee,
+                            SpirvType::Pointer { pointee, .. } => pointee,
                             other => {
                                 self.tcx.dcx().span_err(
                                     span,
@@ -953,7 +949,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                     self.check_reg(span, reg);
                     if let Some(place) = place {
                         match self.lookup_type(place.val.llval.ty) {
-                            SpirvType::Pointer { pointee } => Some(pointee),
+                            SpirvType::Pointer { pointee, .. } => Some(pointee),
                             other => {
                                 self.tcx.dcx().span_err(
                                     span,

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -193,17 +193,20 @@ impl SpirvValue {
                 original_ptr_ty,
                 bitcast_result_id,
             } => {
-                cx.zombie_with_span(
-                    bitcast_result_id,
-                    span,
-                    &format!(
-                        "cannot cast between pointer types\
-                         \nfrom `{}`\
-                         \n  to `{}`",
-                        cx.debug_type(original_ptr_ty),
-                        cx.debug_type(self.ty)
-                    ),
-                );
+                // If physical poitners are supported, defer the error until after storage class inferrence.
+                if !cx.builder.has_capability(Capability::PhysicalStorageBufferAddresses) {
+                    cx.zombie_with_span(
+                        bitcast_result_id,
+                        span,
+                        &format!(
+                            "cannot cast between pointer types\
+                            \nfrom `{}`\
+                            \n  to `{}`",
+                            cx.debug_type(original_ptr_ty),
+                            cx.debug_type(self.ty)
+                        ),
+                    );
+                }
 
                 bitcast_result_id
             }

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -101,7 +101,7 @@ impl SpirvValue {
                 match entry.val {
                     SpirvConst::PtrTo { pointee } => {
                         let ty = match cx.lookup_type(self.ty) {
-                            SpirvType::Pointer { pointee } => pointee,
+                            SpirvType::Pointer { pointee, .. } => pointee,
                             ty => bug!("load called on value that wasn't a pointer: {:?}", ty),
                         };
                         // FIXME(eddyb) deduplicate this `if`-`else` and its other copies.

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -492,7 +492,14 @@ impl<'tcx> BuilderSpirv<'tcx> {
         // The linker will always be ran on this module
         add_cap(&mut builder, &mut enabled_capabilities, Capability::Linkage);
 
-        builder.memory_model(AddressingModel::Logical, memory_model);
+        let addressing_model =
+            if enabled_capabilities.contains(&Capability::PhysicalStorageBufferAddresses) {
+                AddressingModel::PhysicalStorageBuffer64
+            } else {
+                AddressingModel::Logical
+            };
+
+        builder.memory_model(addressing_model, memory_model);
 
         Self {
             source_map: tcx.sess.source_map(),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -239,7 +239,7 @@ impl<'tcx> ConstCodegenMethods<'tcx> for CodegenCx<'tcx> {
                 let (base_addr, _base_addr_space) = match self.tcx.global_alloc(alloc_id) {
                     GlobalAlloc::Memory(alloc) => {
                         let pointee = match self.lookup_type(ty) {
-                            SpirvType::Pointer { pointee } => pointee,
+                            SpirvType::Pointer { pointee, .. } => pointee,
                             other => self.tcx.dcx().fatal(format!(
                                 "GlobalAlloc::Memory type not implemented: {}",
                                 other.debug(ty, self)
@@ -259,7 +259,7 @@ impl<'tcx> ConstCodegenMethods<'tcx> for CodegenCx<'tcx> {
                             .global_alloc(self.tcx.vtable_allocation((vty, dyn_ty.principal())))
                             .unwrap_memory();
                         let pointee = match self.lookup_type(ty) {
-                            SpirvType::Pointer { pointee } => pointee,
+                            SpirvType::Pointer { pointee, .. } => pointee,
                             other => self.tcx.dcx().fatal(format!(
                                 "GlobalAlloc::VTable type not implemented: {}",
                                 other.debug(ty, self)
@@ -328,7 +328,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 if let Some(SpirvConst::ConstDataFromAlloc(alloc)) =
                     self.builder.lookup_const_by_id(pointee)
                 {
-                    if let SpirvType::Pointer { pointee } = self.lookup_type(ty) {
+                    if let SpirvType::Pointer { pointee, .. } = self.lookup_type(ty) {
                         let mut offset = Size::ZERO;
                         let init = self.read_from_const_alloc(alloc, &mut offset, pointee);
                         return self.static_addr_of(init, alloc.inner().align, None);

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -6,7 +6,7 @@ use crate::abi::ConvSpirvType;
 use crate::attr::AggregatedSpirvAttributes;
 use crate::builder_spirv::{SpirvConst, SpirvValue, SpirvValueExt};
 use crate::custom_decorations::{CustomDecoration, SrcLocDecoration};
-use crate::spirv_type::SpirvType;
+use crate::spirv_type::{SpirvType, StorageClassKind};
 use itertools::Itertools;
 use rspirv::spirv::{FunctionControl, LinkageType, StorageClass, Word};
 use rustc_attr::InlineAttr;
@@ -270,7 +270,7 @@ impl<'tcx> CodegenCx<'tcx> {
         // Could be explicitly StorageClass::Private but is inferred anyway.
         let ptr_ty = SpirvType::Pointer {
             pointee: ty,
-            storage_class: None,
+            storage_class: StorageClassKind::Inferred,
         }
         .def(span, self);
         // FIXME(eddyb) figure out what the correct storage class is.

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -267,7 +267,12 @@ impl<'tcx> CodegenCx<'tcx> {
     }
 
     fn declare_global(&self, span: Span, ty: Word) -> SpirvValue {
-        let ptr_ty = SpirvType::Pointer { pointee: ty }.def(span, self);
+        // Could be explicitly StorageClass::Private but is inferred anyway.
+        let ptr_ty = SpirvType::Pointer {
+            pointee: ty,
+            storage_class: None,
+        }
+        .def(span, self);
         // FIXME(eddyb) figure out what the correct storage class is.
         let result = self
             .emit_global()
@@ -353,7 +358,7 @@ impl<'tcx> StaticCodegenMethods for CodegenCx<'tcx> {
             Err(_) => return,
         };
         let value_ty = match self.lookup_type(g.ty) {
-            SpirvType::Pointer { pointee } => pointee,
+            SpirvType::Pointer { pointee, .. } => pointee,
             other => self.tcx.dcx().fatal(format!(
                 "global had non-pointer type {}",
                 other.debug(g.ty, self)

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -967,7 +967,7 @@ impl<'tcx> CodegenCx<'tcx> {
                 | SpirvType::Matrix { element, .. }
                 | SpirvType::Array { element, .. }
                 | SpirvType::RuntimeArray { element }
-                | SpirvType::Pointer { pointee: element }
+                | SpirvType::Pointer { pointee: element, .. }
                 | SpirvType::InterfaceBlock {
                     inner_type: element,
                 } => recurse(cx, element, has_bool, must_be_flat),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -6,7 +6,7 @@ mod type_;
 use crate::builder::{ExtInst, InstructionTable};
 use crate::builder_spirv::{BuilderCursor, BuilderSpirv, SpirvConst, SpirvValue, SpirvValueKind};
 use crate::custom_decorations::{CustomDecoration, SrcLocDecoration, ZombieDecoration};
-use crate::spirv_type::{SpirvType, SpirvTypePrinter, TypeCache};
+use crate::spirv_type::{SpirvType, SpirvTypePrinter, StorageClassKind, TypeCache};
 use crate::symbols::Symbols;
 use crate::target::SpirvTarget;
 
@@ -236,7 +236,7 @@ impl<'tcx> CodegenCx<'tcx> {
     pub fn type_ptr_to(&self, ty: Word) -> Word {
         SpirvType::Pointer {
             pointee: ty,
-            storage_class: None,
+            storage_class: StorageClassKind::Inferred,
         }
         .def(DUMMY_SP, self)
     }
@@ -244,7 +244,7 @@ impl<'tcx> CodegenCx<'tcx> {
     pub fn type_ptr_to_ext(&self, ty: Word, _address_space: AddressSpace) -> Word {
         SpirvType::Pointer {
             pointee: ty,
-            storage_class: None,
+            storage_class: StorageClassKind::Inferred,
         }
         .def(DUMMY_SP, self)
     }
@@ -874,7 +874,7 @@ impl<'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'tcx> {
 
         let ty = SpirvType::Pointer {
             pointee: function.ty,
-            storage_class: None,
+            storage_class: StorageClassKind::Inferred,
         }
         .def(span, self);
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -234,11 +234,19 @@ impl<'tcx> CodegenCx<'tcx> {
     }
 
     pub fn type_ptr_to(&self, ty: Word) -> Word {
-        SpirvType::Pointer { pointee: ty }.def(DUMMY_SP, self)
+        SpirvType::Pointer {
+            pointee: ty,
+            storage_class: None,
+        }
+        .def(DUMMY_SP, self)
     }
 
     pub fn type_ptr_to_ext(&self, ty: Word, _address_space: AddressSpace) -> Word {
-        SpirvType::Pointer { pointee: ty }.def(DUMMY_SP, self)
+        SpirvType::Pointer {
+            pointee: ty,
+            storage_class: None,
+        }
+        .def(DUMMY_SP, self)
     }
 
     /// Zombie system:
@@ -866,6 +874,7 @@ impl<'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'tcx> {
 
         let ty = SpirvType::Pointer {
             pointee: function.ty,
+            storage_class: None,
         }
         .def(span, self);
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/type_.rs
@@ -219,7 +219,7 @@ impl<'tcx> BaseTypeCodegenMethods<'tcx> for CodegenCx<'tcx> {
     }
     fn element_type(&self, ty: Self::Type) -> Self::Type {
         match self.lookup_type(ty) {
-            SpirvType::Pointer { pointee } => pointee,
+            SpirvType::Pointer { pointee, .. } => pointee,
             SpirvType::Vector { element, .. } => element,
             spirv_type => self.tcx.dcx().fatal(format!(
                 "element_type called on invalid type: {spirv_type:?}"

--- a/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
@@ -427,7 +427,10 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
         Op::ConvertPtrToU | Op::SatConvertSToU | Op::SatConvertUToS | Op::ConvertUToPtr => {}
         Op::PtrCastToGeneric | Op::GenericCastToPtr => sig! { (Pointer(_, T)) -> Pointer(_, T) },
         Op::GenericCastToPtrExplicit => sig! { {S} (Pointer(_, T)) -> Pointer(S, T) },
-        Op::Bitcast => {}
+        Op::Bitcast => sig! {
+            (Pointer(S, _)) -> Pointer(S, _) |
+            (_) -> _
+        },
 
         // 3.37.12. Composite Instructions
         Op::VectorExtractDynamic => sig! { (Vector(T), _) -> T },

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -98,6 +98,7 @@ pub mod indirect_command;
 pub mod integer;
 pub mod memory;
 pub mod number;
+pub mod ptr;
 pub mod ray_tracing;
 mod runtime_array;
 mod sampler;

--- a/crates/spirv-std/src/ptr.rs
+++ b/crates/spirv-std/src/ptr.rs
@@ -1,0 +1,118 @@
+//! Physical pointers
+
+#[cfg(target_arch = "spirv")]
+use core::arch::asm;
+use core::marker::PhantomData;
+
+/// A physical pointer in the `PhysicalStorageBuffer` storage class
+/// with semantics similar to `*mut T`.
+///
+/// This is similar to a raw pointer retrieved through `u64 as *mut T`, but
+/// provides utilities for pointer manipulation that are currently not
+/// supported on raw pointers due to the otherwise logical addressing model
+/// and 32-bit pointer size.
+pub struct PhysicalPtr<T> {
+    // Use uvec2 instead of u64 to avoid demepndency on the Int64 dependency.
+    addr: glam::UVec2,
+    //addr: u64,
+    _marker: PhantomData<*mut T>,
+}
+
+impl<T> Copy for PhysicalPtr<T> {}
+
+impl<T> Clone for PhysicalPtr<T> {
+    fn clone(&self) -> Self {
+        Self {
+            addr: self.addr,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> PhysicalPtr<T> {
+    /// Get a mutaple pointer to the physical address.
+    /// The same aliasing rules that apply to FFI, apply to the returned pointer.
+    #[crate::macros::gpu_only]
+    pub fn get(self) -> *mut T {
+        let result: *mut T;
+        unsafe {
+            // FIXME(jwollen) add a way to dereference the result type further
+            // or to pass type parameters
+            let dummy: T = core::mem::MaybeUninit::uninit().assume_init();
+            asm!(
+                "%ptr_type = OpTypePointer PhysicalStorageBuffer typeof*{dummy}",
+                "{result} = OpBitcast %ptr_type {addr}",
+                addr = in(reg) &self.addr,
+                dummy = in(reg) &dummy,
+                result = out(reg) result,
+            );
+            result
+        }
+    }
+
+    /// Creates a null physical pointer.
+    pub fn null() -> Self {
+        Self {
+            addr: glam::UVec2::ZERO,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns `true` if the pointer is null.
+    pub fn is_null(self) -> bool {
+        self.addr == glam::UVec2::ZERO
+    }
+
+    /// Casts to a pointer of another type.
+    pub fn cast<U>(self) -> PhysicalPtr<U> {
+        PhysicalPtr { addr: self.addr, _marker: PhantomData }
+    }
+
+    /// Returns `None` if the pointer is null, or else returns a shared reference to the value wrapped in `Some`.
+    pub unsafe fn as_ref<'a>(self) -> Option<&'a T> {
+        self.is_null().then_some(unsafe { self.as_ref_unchecked() })
+    }
+
+    /// Returns `None` if the pointer is null, or else returns a mutable reference to the value wrapped in `Some`.
+    pub unsafe fn as_mut<'a>(self) -> Option<&'a mut T> {
+        self.is_null().then_some(unsafe { self.as_mut_unchecked() })
+    }
+
+    /// Returns a shared reference to the value behind the pointer.
+    pub unsafe fn as_ref_unchecked<'a>(self) -> &'a T {
+        unsafe { &*self.get() }
+    }
+
+    /// Returns a mutable reference to the value behind the pointer.
+    pub unsafe fn as_mut_unchecked<'a>(self) -> &'a mut T {
+        unsafe { &mut *self.get() }
+    }
+
+    /// Gets the address portion of the pointer. All physical pointers are considered to have global provenance.
+    pub fn addr(self) -> u64 {
+        unsafe { core::mem::transmute(self.addr) }
+    }
+
+    /// Forms a physical pointer from an address. All physical pointers are considered to have global provenance.
+    pub fn from_addr(addr: u64) -> Self {
+        Self {
+            addr: unsafe { core::mem::transmute(addr) },
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a new pointer by mapping `self`’s address to a new one.
+    pub fn map_addr(self, f: impl FnOnce(u64) -> u64) -> Self {
+        Self::from_addr(f(self.addr()))
+    }
+
+    /// Adds a signed offset to a pointer.
+    pub unsafe fn offset(self, count: i64) -> Self {
+        unsafe { self.byte_offset(count * core::mem::size_of::<T>() as i64) }
+    }
+
+    /// Adds a signed offset in bytes to a pointer.
+    pub unsafe fn byte_offset(self, count: i64) -> Self {
+        self.map_addr(|addr| addr.overflowing_add_signed(count).0)
+    }
+}


### PR DESCRIPTION
## Summary

This adds support for `SPV_KHR_physical_storage_buffer` and the `PhysicalStorageBuffer64` addressing model and expands support for physical pointers.

Includes
- https://github.com/Rust-GPU/rust-gpu/pull/236

## Motivation

Allow taking advantage of physical buffer addresses (`VK_KHR_buffer_device_address`) for more flexible bindless storage buffer access.

While physical pointers are largely optional with increasing support for bindless storage buffers,
fully descriptor-less storage buffers remain very ergonomic, especially in pure compute and ray-tracing shaders.

This allows, for example:

```rust
struct Node {
    next: PhysicalPtr<T>,
    payload: f32,
}

#[spirv(fragment)]
fn main(
    #[push_constant] root_node: &PhysicalPtr<Node>,
    out: &mut f32,
) {
    unsafe {
        let mut next_node = *root_node;
        while let Some(node) = next_node.as_ref() {
            *out = *out + node.payload;
            next_node = node.next.as_ref();
        }
    }
}
```

## Implementation steps

- [x] [Allow expressing explicit storage classes](https://github.com/Rust-GPU/rust-gpu/pull/236)
- [x] Enable `PhysicalStorageBuffer64` when `PhysicalStorageBufferAddresses` is supported
- [ ] Support pointer casts
  - [x] Enable `u64 as *mut T` and vice versa
  - [ ] Defer pointer-cast errors until after storage class inferrnce
- [ ] `Aligned`
  - [x] Generate `Aligned` operands for all memory operations
  - [ ] Add a SPIR-T pass to strip alignment from non-physical operations
  - [ ] Allow memory operands in `qptr` `store`/`load` lowering/lifting
- [ ] Add `RestrictedPointer` if/where necessary
- [ ] Ensure raw pointer ops are correct or disallowed
- [ ] Add `spirv_std` utilities for working with physical pointers
  - [x] Add a `PhysicalPtr<T>` type that wraps physical addresses. **/bikeshed**
  - [ ] Parity with `*mut`

## Prior work

- https://github.com/Rust-GPU/rust-gpu/issues/119: As noted the `qptr` route is the most flexible and custom constraints for each instruction don't scale. For example supporting `OpBitcast` would be hard to model with custom constraints.

## Open questions 

- How safe/unsafe should the API be? Technically all interface variables are aliased.
- https://github.com/Rust-GPU/rust-gpu/issues/238
