### PR TITLE
Only decorate physically sized types with ArrayStride

### DIFF
--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -185,12 +185,12 @@ impl SpirvType<'_> {
                 let result = cx
                     .emit_global()
                     .type_array_id(id, element, count.def_cx(cx));
-                self.decorate_array_stride(result, element, cx);
+                Self::decorate_array_stride(result, element, cx);
                 result
             }
             Self::RuntimeArray { element } => {
                 let result = cx.emit_global().type_runtime_array_id(id, element);
-                self.decorate_array_stride(result, element, cx);
+                Self::decorate_array_stride(result, element, cx);
                 result
             }
             Self::Pointer { pointee } => {
@@ -258,7 +258,7 @@ impl SpirvType<'_> {
         result
     }
 
-    fn decorate_array_stride(self, result: u32, element: u32, cx: &CodegenCx<'_>) {
+    fn decorate_array_stride(result: u32, element: u32, cx: &CodegenCx<'_>) {
         let mut emit = cx.emit_global();
         let ty = cx.lookup_type(element);
         if let Some(element_size) = ty.physical_size(cx) {
@@ -380,12 +380,12 @@ impl SpirvType<'_> {
     }
 
     /// Get the physical size of the type needed for explicit layout decorations.
+    #[allow(clippy::match_same_arms)]
     pub fn physical_size(&self, cx: &CodegenCx<'_>) -> Option<Size> {
         match *self {
             // TODO(jwollen) Handle physical pointers (PhysicalStorageBuffer)
             Self::Pointer { .. } => None,
 
-            // TODO(jwollen) Handle unsized elements
             Self::Adt { size, .. } => size,
 
             Self::Array { element, count } => Some(

--- a/tests/ui/dis/asm_op_decorate.stderr
+++ b/tests/ui/dis/asm_op_decorate.stderr
@@ -13,17 +13,16 @@ OpExecutionMode %1 OriginUpperLeft
 %2 = OpString "$OPSTRING_FILENAME/asm_op_decorate.rs"
 OpName %3 "asm_op_decorate::main"
 OpName %4 "asm_op_decorate::add_decorate"
-OpDecorate %5 ArrayStride 4
-OpDecorate %6 Binding 0
-OpDecorate %6 DescriptorSet 0
-%7 = OpTypeVoid
-%8 = OpTypeFunction %7
-%9 = OpTypeFloat 32
-%10 = OpTypeImage %9 2D 0 0 0 1 Unknown
-%11 = OpTypeSampledImage %10
-%12 = OpTypePointer UniformConstant %11
-%5 = OpTypeRuntimeArray %11
-%13 = OpTypePointer UniformConstant %5
-%6 = OpVariable  %13  UniformConstant
+OpDecorate %5 Binding 0
+OpDecorate %5 DescriptorSet 0
+%6 = OpTypeVoid
+%7 = OpTypeFunction %6
+%8 = OpTypeFloat 32
+%9 = OpTypeImage %8 2D 0 0 0 1 Unknown
+%10 = OpTypeSampledImage %9
+%11 = OpTypePointer UniformConstant %10
+%12 = OpTypeRuntimeArray %10
+%13 = OpTypePointer UniformConstant %12
+%5 = OpVariable  %13  UniformConstant
 %14 = OpTypeInt 32 0
 %15 = OpConstant  %14  1


### PR DESCRIPTION
Stop decorating `RuntimeArrays` of unsized types with `ArrayStride`. Fixes the `spirv-val` rule:
```
Array containing a Block or BufferBlock must not be decorated with ArrayStride
```
This already works correctly when using `qptrs`.