### PR TITLE
force `libm <=0.2.11`, as `0.2.12` has breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,6 +2664,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
  "glam",
+ "libm",
  "num-traits",
  "spirv-std-macros",
  "spirv-std-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ tracing-subscriber = { version = "0.3.3", features = ["env-filter", "json"] }
 # External dependencies that need to be mentioned more than once.
 num-traits = { version = "0.2.15", default-features = false }
 glam = { version = ">=0.22, <=0.30", default-features = false }
+# libm 0.2.12 is a breaking change with new intrinsics
+libm = { version = ">=0.2.5, <=0.2.11", default-features = false }
 
 # Enable incremental by default in release mode.
 [profile.release]

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -19,6 +19,7 @@ bytemuck = { version = "1.18.0", features = ["derive"], optional = true }
 [target.'cfg(target_arch = "spirv")'.dependencies]
 num-traits = { workspace = true, features = ["libm"] }
 glam = { workspace = true, features = ["libm"] }
+libm = { workspace = true }
 
 [target.'cfg(not(target_arch = "spirv"))'.dependencies]
 num-traits = { workspace = true, default-features = true }


### PR DESCRIPTION
closes https://github.com/Rust-GPU/rust-gpu/pull/243