### PR TITLE
`spirv_builder` feature `compile_codegen` to disable building `rustc_codegen_spirv`

### DIFF
--- a/crates/spirv-builder/Cargo.toml
+++ b/crates/spirv-builder/Cargo.toml
@@ -18,10 +18,13 @@ no-default-features = true
 # that optional dependency, from being automatically created by Cargo, see:
 # https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies
 [features]
-# See `rustc_codegen_spirv/Cargo.toml` for details on these features.
 default = ["use-compiled-tools"]
-use-installed-tools = ["dep:rustc_codegen_spirv", "rustc_codegen_spirv?/use-installed-tools"]
-use-compiled-tools = ["dep:rustc_codegen_spirv", "rustc_codegen_spirv?/use-compiled-tools"]
+# Compile `rustc_codegen_spirv`, allows constructing SpirvBuilder without
+# explicitly passing in a path to a compiled `rustc_codegen_spirv.so` (or dll)
+compile_codegen = ["dep:rustc_codegen_spirv"]
+# See `rustc_codegen_spirv/Cargo.toml` for details on these features.
+use-installed-tools = ["compile_codegen", "rustc_codegen_spirv?/use-installed-tools"]
+use-compiled-tools = ["compile_codegen", "rustc_codegen_spirv?/use-compiled-tools"]
 skip-toolchain-check = ["rustc_codegen_spirv?/skip-toolchain-check"]
 
 watch = ["dep:notify"]

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -606,6 +606,7 @@ fn dylib_path() -> Vec<PathBuf> {
     }
 }
 
+#[cfg(feature = "compile_codegen")]
 fn find_rustc_codegen_spirv() -> PathBuf {
     let filename = format!(
         "{}rustc_codegen_spirv{}",
@@ -619,6 +620,13 @@ fn find_rustc_codegen_spirv() -> PathBuf {
         }
     }
     panic!("Could not find {filename} in library path");
+}
+
+#[cfg(not(feature = "compile_codegen"))]
+fn find_rustc_codegen_spirv() -> PathBuf {
+    panic!(
+        "Without feature `compile_codegen`, you need to set the path of the codegen dylib using `rustc_codegen_spirv_location(...)`"
+    );
 }
 
 /// Joins strings together while ensuring none of the strings contain the separator.

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -72,31 +72,6 @@
 // #![allow()]
 #![doc = include_str!("../README.md")]
 
-// HACK(eddyb) try to catch misuse of Cargo package features very early on
-// (see `spirv-builder/Cargo.toml` for why we go through all of this).
-#[cfg(all(
-    not(any(feature = "use-compiled-tools", feature = "use-installed-tools")),
-    not(doc)
-))]
-compile_error!(
-    "at least one of `use-compiled-tools` or `use-installed-tools` features must be enabled
-(outside of documentation builds, which require disabling both to build on stable)"
-);
-
-#[cfg(doc)]
-fn _ensure_cfg_doc_means_rustdoc() {
-    // HACK(eddyb) this relies on specific `rustdoc` behavior (i.e. it skips
-    // type-checking function bodies, so we trigger a compile-time `panic! from
-    // a type) to check that we're in fact under `rustdoc`, not just `--cfg doc`.
-    #[rustfmt::skip]
-    let _: [(); panic!("
-
-            `--cfg doc` was set outside of `rustdoc`
-            (if you are running `rustdoc` or `cargo doc`, please file an issue)
-
-")];
-}
-
 mod depfile;
 #[cfg(feature = "watch")]
 mod watch;


### PR DESCRIPTION
(copied from zulip)

An idea I just had: What if we make `spirv-builder` have a new `compile_codegen` feature that makes it depend on `rustc_codegen_spirv`? Without the feature, we can compile it on stable, but need to supply `SpirvBuilder` with a file path to the compiled `rustc_codegen_backend.so` file. Which allows us to use it as a direct dependency within `cargo gpu` and share the structs easily. 

Open Questions:
* Name suggestions for the feature? `compile_codegen`
* Should we make `compiled-tools` and `installed-tools` depend on this feature, preserving backwards compat, or error when they are used without `compile_codegen`? Former, preserve backwards compat