### PR TITLE
fix: buff the help menu for the wgpu-runner

### DIFF
--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -72,7 +72,6 @@
 // #![allow()]
 
 use clap::Parser;
-use clap::builder::PossibleValue;
 use clap::ValueEnum;
 use std::borrow::Cow;
 use strum::{Display, EnumString};

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -159,7 +159,7 @@ fn maybe_watch(
             .iter()
             .copied()
             .collect::<PathBuf>();
-        
+
         let has_debug_printf = options.force_spirv_passthru;
 
         let builder = SpirvBuilder::new(crate_path, "spirv-unknown-vulkan1.1")

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -72,6 +72,8 @@
 // #![allow()]
 
 use clap::Parser;
+use clap::builder::PossibleValue;
+use clap::ValueEnum;
 use std::borrow::Cow;
 use strum::{Display, EnumString};
 
@@ -81,12 +83,22 @@ mod compute;
 
 mod graphics;
 
-#[derive(EnumString, Display, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, EnumString, Display, PartialEq, Eq, Copy, Clone, ValueEnum)]
 pub enum RustGPUShader {
     Simplest,
     Sky,
     Compute,
     Mouse,
+}
+
+impl RustGPUShader {
+    pub fn help_string() -> String {
+        let variants: Vec<String> = Self::value_variants()
+            .iter()
+            .map(|v| v.to_possible_value().unwrap().get_name().to_owned())
+            .collect();
+        format!("Shader to run [{}]", variants.join(", "))
+    }
 }
 
 struct CompiledShaderModules {
@@ -148,7 +160,7 @@ fn maybe_watch(
             .iter()
             .copied()
             .collect::<PathBuf>();
-
+        
         let has_debug_printf = options.force_spirv_passthru;
 
         let builder = SpirvBuilder::new(crate_path, "spirv-unknown-vulkan1.1")
@@ -224,7 +236,7 @@ fn maybe_watch(
 #[derive(Parser, Clone)]
 #[command()]
 pub struct Options {
-    #[arg(short, long, default_value = "Sky")]
+    #[arg(short, long, default_value = "Sky", help = RustGPUShader::help_string())]
     shader: RustGPUShader,
 
     #[arg(long)]

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -90,16 +90,6 @@ pub enum RustGPUShader {
     Mouse,
 }
 
-impl RustGPUShader {
-    pub fn help_string() -> String {
-        let variants: Vec<String> = Self::value_variants()
-            .iter()
-            .map(|v| v.to_possible_value().unwrap().get_name().to_owned())
-            .collect();
-        format!("Shader to run [{}]", variants.join(", "))
-    }
-}
-
 struct CompiledShaderModules {
     named_spv_modules: Vec<(Option<String>, wgpu::ShaderModuleDescriptorSpirV<'static>)>,
 }
@@ -235,7 +225,8 @@ fn maybe_watch(
 #[derive(Parser, Clone)]
 #[command()]
 pub struct Options {
-    #[arg(short, long, default_value = "Sky", help = RustGPUShader::help_string())]
+    /// which shader to run
+    #[arg(short, long, default_value = "sky")]
     shader: RustGPUShader,
 
     #[arg(long)]


### PR DESCRIPTION
Updates the help-menu on the `wgpu-runner` to avoid others making the mistake I made [here](https://github.com/Rust-GPU/rust-gpu/issues/253).

Before:
```sh
Usage: example-runner-wgpu.exe [OPTIONS]

Options:
  -s, --shader <SHADER>       [default: Sky]
      --force-spirv-passthru
  -h, --help                  Print help
```

After:
```sh
Usage: example-runner-wgpu.exe [OPTIONS]

Options:
  -s, --shader <SHADER>       which shader to run [default: sky] [possible values: simplest, sky, compute, mouse]
      --force-spirv-passthru
  -h, --help                  Print help
```

closes https://github.com/Rust-GPU/rust-gpu/issues/253