### PR TITLE
Update mac target in CI to aarch64-apple-darwin.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
           - os: windows-2022
             target: x86_64-pc-windows-msvc
           - os: macOS-latest
-            target: x86_64-apple-darwin
+            target: aarch64-apple-darwin
           - os: ubuntu-24.04
             target: aarch64-linux-android
             host: x86_64-unknown-linux-gnu


### PR DESCRIPTION
The `macOS-latest` images on GitHub are arm:

```
Current runner version: '2.324.0'
Operating System
  macOS
  14.7.5
  23H527
Runner Image
  Image: macos-14-arm64
```