### PR TITLE
Generic compile result

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -88,8 +88,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use thiserror::Error;
 
-pub use rustc_codegen_spirv_types::Capability;
-pub use rustc_codegen_spirv_types::{CompileResult, ModuleResult};
+pub use rustc_codegen_spirv_types::*;
 
 #[cfg(feature = "include-target-specs")]
 pub use rustc_codegen_spirv_target_specs::TARGET_SPEC_DIR_PATH;


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/256

This enables us to emit wgsl and naga modules the same way as we do spv.
Needed by https://github.com/Rust-GPU/cargo-gpu/pull/76