### PR TITLE
Remove long-obsolete `is_blocklisted_fn` mechanism.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -76,12 +76,6 @@ impl<'tcx> CodegenCx<'tcx> {
             other => bug!("fn_abi type {}", other.debug(function_type, self)),
         };
 
-        if crate::is_blocklisted_fn(self.tcx, &self.sym, instance) {
-            // This can happen if we call a blocklisted function in another crate.
-            let result = self.undef(function_type);
-            self.zombie_with_span(result.def_cx(self), span, "called blocklisted fn");
-            return result;
-        }
         let fn_id = {
             let mut emit = self.emit_global();
             let fn_id = emit

--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -13,9 +13,6 @@ use std::rc::Rc;
 /// already exists, deduplicating it if so. This makes things like comparison and cloning really cheap. So, this struct
 /// is to allocate all our keywords up front and intern them all, so we can do comparisons really easily and fast.
 pub struct Symbols {
-    // Used by `is_blocklisted_fn`.
-    pub fmt_decimal: Symbol,
-
     pub discriminant: Symbol,
     pub rust_gpu: Symbol,
     pub spirv: Symbol,
@@ -403,8 +400,6 @@ impl Symbols {
             assert!(old.is_none());
         }
         Self {
-            fmt_decimal: Symbol::intern("fmt_decimal"),
-
             discriminant: Symbol::intern("discriminant"),
             rust_gpu: Symbol::intern("rust_gpu"),
             spirv: Symbol::intern("spirv"),


### PR DESCRIPTION
Whatever it was meant to protect against, seems to be long gone, so this was just wastefully pattern-matching all monomorphic function instances against e.g. `<_ as core::fmt::Debug>::fmt`.

Ran into the zombie<sup>1</sup> it introduces when declaring a "blocklisted" function, and I was going to move that around so it at least always generates an `OpFunction`, but nothing broke when removing the check entirely.
<sub><sup>1</sup> (`OpUndef` of type `OpTypeFunction` is already pretty sketchy, but it's even worse when passed to instructions that expect the ID of an `OpFunction`, not just "some value of function type")</sub>