### PR TITLE
add targets `vulkan1.3`, `vulkan1.4` and `spv1.6`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: compiletest
-        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1,vulkan1.2,vulkan1.3,vulkan1.4
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1,vulkan1.2,vulkan1.3,vulkan1.4,spv1.3
 
   difftest:
     name: Difftest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,7 +134,7 @@ jobs:
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: compiletest
-        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1,vulkan1.2,spv1.3
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1,vulkan1.2,vulkan1.3,vulkan1.4
 
   difftest:
     name: Difftest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2782,9 +2782,9 @@ version = "0.9.0"
 
 [[package]]
 name = "spirv-tools"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191e2df260dbaa79c5c334fb9e7b2d5372300d765f5b950c2b54f89d412db5e7"
+checksum = "aa073f1f465ad80b16f0e2b0151389c9fcfeee83c5daa4361fe8c1d24f0e0b0c"
 dependencies = [
  "memchr",
  "spirv-tools-sys",
@@ -2793,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools-sys"
-version = "0.9.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed89e04a14352154c6aca979f603bf8b59e16dafcf5e6c5f06e786b76c7daaf3"
+checksum = "f4c95b52623ba771b5172dea9f04799928ce53ebc2ffc360c69d0fea3c3248d8"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ spirv-builder = { path = "./crates/spirv-builder", version = "=0.9.0", default-f
 spirv-std = { path = "./crates/spirv-std", version = "=0.9.0" }
 spirv-std-types = { path = "./crates/spirv-std/shared", version = "=0.9.0" }
 spirv-std-macros = { path = "./crates/spirv-std/macros", version = "=0.9.0" }
-spirv-tools = { version = "0.11", default-features = false }
+spirv-tools = { version = "0.12", default-features = false }
 rustc_codegen_spirv = { path = "./crates/rustc_codegen_spirv", version = "=0.9.0", default-features = false }
 rustc_codegen_spirv-types = { path = "./crates/rustc_codegen_spirv-types", version = "=0.9.0" }
 rustc_codegen_spirv-target-specs = { path = "crates/rustc_codegen_spirv-target-specs", version = "=0.9.0" }

--- a/crates/rustc_codegen_spirv-target-specs/src/include_str.rs
+++ b/crates/rustc_codegen_spirv-target-specs/src/include_str.rs
@@ -45,6 +45,10 @@ pub const TARGET_SPECS: &[(&str, &str)] = &[
         include_str!("../target-specs/spirv-unknown-spv1.5.json"),
     ),
     (
+        "spirv-unknown-spv1.6.json",
+        include_str!("../target-specs/spirv-unknown-spv1.6.json"),
+    ),
+    (
         "spirv-unknown-vulkan1.0.json",
         include_str!("../target-specs/spirv-unknown-vulkan1.0.json"),
     ),
@@ -59,5 +63,13 @@ pub const TARGET_SPECS: &[(&str, &str)] = &[
     (
         "spirv-unknown-vulkan1.2.json",
         include_str!("../target-specs/spirv-unknown-vulkan1.2.json"),
+    ),
+    (
+        "spirv-unknown-vulkan1.3.json",
+        include_str!("../target-specs/spirv-unknown-vulkan1.3.json"),
+    ),
+    (
+        "spirv-unknown-vulkan1.4.json",
+        include_str!("../target-specs/spirv-unknown-vulkan1.4.json"),
     ),
 ];

--- a/crates/rustc_codegen_spirv-target-specs/target-specs/spirv-unknown-spv1.6.json
+++ b/crates/rustc_codegen_spirv-target-specs/target-specs/spirv-unknown-spv1.6.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "spv1.6",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-spv1.6",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/rustc_codegen_spirv-target-specs/target-specs/spirv-unknown-vulkan1.3.json
+++ b/crates/rustc_codegen_spirv-target-specs/target-specs/spirv-unknown-vulkan1.3.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "vulkan1.3",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-vulkan1.3",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/rustc_codegen_spirv-target-specs/target-specs/spirv-unknown-vulkan1.4.json
+++ b/crates/rustc_codegen_spirv-target-specs/target-specs/spirv-unknown-vulkan1.4.json
@@ -1,0 +1,26 @@
+{
+  "allows-weak-linkage": false,
+  "arch": "spirv",
+  "crt-objects-fallback": "false",
+  "crt-static-allows-dylibs": true,
+  "data-layout": "e-m:e-p:32:32:32-i64:64-n8:16:32:64",
+  "dll-prefix": "",
+  "dll-suffix": ".spv.json",
+  "dynamic-linking": true,
+  "emit-debug-gdb-scripts": false,
+  "env": "vulkan1.4",
+  "linker-flavor": "unix",
+  "linker-is-gnu": false,
+  "llvm-target": "spirv-unknown-vulkan1.4",
+  "main-needs-argc-argv": false,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
+  "os": "unknown",
+  "panic-strategy": "abort",
+  "simd-types-indirect": false,
+  "target-pointer-width": "32"
+}

--- a/crates/rustc_codegen_spirv/src/target.rs
+++ b/crates/rustc_codegen_spirv/src/target.rs
@@ -17,7 +17,8 @@ impl SpirvTarget {
             | TargetEnv::Universal_1_2
             | TargetEnv::Universal_1_3
             | TargetEnv::Universal_1_4
-            | TargetEnv::Universal_1_5 => MemoryModel::Simple,
+            | TargetEnv::Universal_1_5
+            | TargetEnv::Universal_1_6 => MemoryModel::Simple,
 
             TargetEnv::OpenGL_4_0
             | TargetEnv::OpenGL_4_1
@@ -38,41 +39,14 @@ impl SpirvTarget {
             | TargetEnv::Vulkan_1_1
             | TargetEnv::WebGPU_0
             | TargetEnv::Vulkan_1_1_Spirv_1_4
-            | TargetEnv::Vulkan_1_2 => MemoryModel::Vulkan,
+            | TargetEnv::Vulkan_1_2
+            | TargetEnv::Vulkan_1_3
+            | TargetEnv::Vulkan_1_4 => MemoryModel::Vulkan,
         }
     }
 
     pub fn spirv_version(&self) -> (u8, u8) {
-        #[allow(clippy::match_same_arms)]
-        match self.env {
-            TargetEnv::Universal_1_0 => (1, 0),
-            TargetEnv::Universal_1_1 => (1, 1),
-            TargetEnv::Universal_1_2 => (1, 2),
-            TargetEnv::Universal_1_3 => (1, 3),
-            TargetEnv::Universal_1_4 => (1, 4),
-            TargetEnv::Universal_1_5 => (1, 5),
-
-            TargetEnv::OpenGL_4_0 => (1, 0),
-            TargetEnv::OpenGL_4_1 => (1, 0),
-            TargetEnv::OpenGL_4_2 => (1, 0),
-            TargetEnv::OpenGL_4_3 => (1, 0),
-            TargetEnv::OpenGL_4_5 => (1, 0),
-
-            TargetEnv::OpenCL_1_2 => (1, 0),
-            TargetEnv::OpenCL_2_0 => (1, 0),
-            TargetEnv::OpenCL_2_1 => (1, 0),
-            TargetEnv::OpenCL_2_2 => (1, 2),
-            TargetEnv::OpenCLEmbedded_1_2 => (1, 0),
-            TargetEnv::OpenCLEmbedded_2_0 => (1, 0),
-            TargetEnv::OpenCLEmbedded_2_1 => (1, 0),
-            TargetEnv::OpenCLEmbedded_2_2 => (1, 2),
-
-            TargetEnv::Vulkan_1_0 => (1, 0),
-            TargetEnv::Vulkan_1_1 => (1, 3),
-            TargetEnv::WebGPU_0 => (1, 3),
-            TargetEnv::Vulkan_1_1_Spirv_1_4 => (1, 4),
-            TargetEnv::Vulkan_1_2 => (1, 5),
-        }
+        self.env.spirv_version()
     }
 
     fn init_target_opts(&self) -> TargetOptions {

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -782,9 +782,10 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
             //
             // FIXME(eddyb) consider moving this list, or even `target-specs`,
             // into `rustc_codegen_spirv_types`'s code/source.
-            "spv1.0" | "spv1.1" | "spv1.2" | "spv1.3" | "spv1.4" | "spv1.5" => {}
+            "spv1.0" | "spv1.1" | "spv1.2" | "spv1.3" | "spv1.4" | "spv1.5" | "spv1.6" => {}
             "opengl4.0" | "opengl4.1" | "opengl4.2" | "opengl4.3" | "opengl4.5" => {}
-            "vulkan1.0" | "vulkan1.1" | "vulkan1.1spv1.4" | "vulkan1.2" => {}
+            "vulkan1.0" | "vulkan1.1" | "vulkan1.1spv1.4" | "vulkan1.2" | "vulkan1.3"
+            | "vulkan1.4" => {}
 
             _ => {
                 return Err(SpirvBuilderError::UnsupportedSpirvTargetEnv {

--- a/docs/src/platform-support.md
+++ b/docs/src/platform-support.md
@@ -33,6 +33,7 @@ The `rust-gpu` project currently supports a limited number of platforms and grap
 - `spirv-unknown-spv1.3`
 - `spirv-unknown-spv1.4`
 - `spirv-unknown-spv1.5`
+- `spirv-unknown-spv1.6`
 
 ### Vulkan Targets
 
@@ -40,6 +41,8 @@ The `rust-gpu` project currently supports a limited number of platforms and grap
 - `spirv-unknown-vulkan1.1`
 - `spirv-unknown-vulkan1.1spv1.4`
 - `spirv-unknown-vulkan1.2`
+- `spirv-unknown-vulkan1.3`
+- `spirv-unknown-vulkan1.4`
 
 ### WebGPU Targets
 

--- a/tests/compiletests/ui/dis/asm_op_decorate.rs
+++ b/tests/compiletests/ui/dis/asm_op_decorate.rs
@@ -12,6 +12,8 @@
 // and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
 // are not supported in `compiletest-rs`.
 // ignore-vulkan1.2
+// ignore-vulkan1.3
+// ignore-vulkan1.4
 
 use core::arch::asm;
 use spirv_std::spirv;

--- a/tests/compiletests/ui/dis/non-writable-storage_buffer.rs
+++ b/tests/compiletests/ui/dis/non-writable-storage_buffer.rs
@@ -13,6 +13,8 @@
 // and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
 // are not supported in `compiletest-rs`.
 // ignore-vulkan1.2
+// ignore-vulkan1.3
+// ignore-vulkan1.4
 
 use spirv_std::spirv;
 

--- a/tests/compiletests/ui/image/gather.rs
+++ b/tests/compiletests/ui/image/gather.rs
@@ -23,7 +23,9 @@ pub fn main(
     target_env = "vulkan1.0",
     target_env = "vulkan1.1",
     target_env = "vulkan1.1spv1.4",
-    target_env = "vulkan1.2"
+    target_env = "vulkan1.2",
+    target_env = "vulkan1.3",
+    target_env = "vulkan1.4"
 )))]
 #[spirv(fragment)]
 pub fn main_rect(

--- a/tests/compiletests/ui/image/query/rect_image_query_size.rs
+++ b/tests/compiletests/ui/image/query/rect_image_query_size.rs
@@ -4,6 +4,8 @@
 // ignore-vulkan1.1
 // ignore-vulkan1.1spv1.4
 // ignore-vulkan1.2
+// ignore-vulkan1.3
+// ignore-vulkan1.4
 
 use spirv_std::spirv;
 use spirv_std::{Image, arch};

--- a/tests/compiletests/ui/image/query/sampled_image_rect_query_size_lod_err.rs
+++ b/tests/compiletests/ui/image/query/sampled_image_rect_query_size_lod_err.rs
@@ -5,6 +5,8 @@
 // ignore-vulkan1.1
 // ignore-vulkan1.1spv1.4
 // ignore-vulkan1.2
+// ignore-vulkan1.3
+// ignore-vulkan1.4
 
 use spirv_std::{Image, arch, image::SampledImage, spirv};
 

--- a/tests/compiletests/ui/image/sample_depth_reference/sample_gradient.rs
+++ b/tests/compiletests/ui/image/sample_depth_reference/sample_gradient.rs
@@ -27,7 +27,9 @@ pub fn main(
     target_env = "vulkan1.0",
     target_env = "vulkan1.1",
     target_env = "vulkan1.1spv1.4",
-    target_env = "vulkan1.2"
+    target_env = "vulkan1.2",
+    target_env = "vulkan1.3",
+    target_env = "vulkan1.4"
 )))]
 #[spirv(fragment)]
 pub fn main_cubemap(

--- a/tests/compiletests/ui/image/sample_depth_reference/sample_lod.rs
+++ b/tests/compiletests/ui/image/sample_depth_reference/sample_lod.rs
@@ -25,7 +25,9 @@ pub fn main(
     target_env = "vulkan1.0",
     target_env = "vulkan1.1",
     target_env = "vulkan1.1spv1.4",
-    target_env = "vulkan1.2"
+    target_env = "vulkan1.2",
+    target_env = "vulkan1.3",
+    target_env = "vulkan1.4"
 )))]
 #[spirv(fragment)]
 pub fn main_cubemap(


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/279, https://github.com/Rust-GPU/spirv-tools-rs/pull/11

~~I thought it'll be easy going, but it seems like spv1.6 introduced some new validation we're now failing.~~ Nope, just some tests excluded for vulkan that need their target list extended.