### PR TITLE
Split compiletests and difftests into parallel CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,8 +55,8 @@ jobs:
       - name: rustc_codegen_spirv test
         run: cargo test -p rustc_codegen_spirv --release --no-default-features --features "use-installed-tools"
 
-      - name: workspace test (excluding examples)
-        run: cargo test --release --workspace --exclude "example-runner-*" --no-default-features --features "use-installed-tools"
+      - name: workspace test (excluding examples & difftest)
+        run: cargo test --release --workspace --exclude "example-runner-*" --exclude "difftest*" --no-default-features --features "use-installed-tools"
 
       # Examples
       - name: cargo check examples
@@ -187,6 +187,8 @@ jobs:
         run: cargo fetch --locked --target ${{ matrix.target }}
       - name: cargo fetch --locked difftests
         run: cargo fetch --locked --manifest-path=tests/difftests/tests/Cargo.toml --target ${{ matrix.target }}
+      - name: test difftest
+        run: cargo test -p "difftest*" --release --no-default-features --features "use-installed-tools"
       - name: difftests
         run: cargo run -p difftests --release --no-default-features --features "use-installed-tools"
 


### PR DESCRIPTION
We could have them kick off after the main job and reuse artifacts, but it seems better to just kick them all off at once?