### PR TITLE
Add WorkgroupSize builtin support

### DIFF
--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -59,7 +59,7 @@ const BUILTINS: &[(&str, BuiltIn)] = {
         ("frag_depth", FragDepth),
         ("helper_invocation", HelperInvocation),
         ("num_workgroups", NumWorkgroups),
-        // ("workgroup_size", WorkgroupSize), -- constant
+        ("workgroup_size", WorkgroupSize),
         ("workgroup_id", WorkgroupId),
         ("local_invocation_id", LocalInvocationId),
         ("global_invocation_id", GlobalInvocationId),

--- a/tests/compiletests/ui/dis/workgroup-size.rs
+++ b/tests/compiletests/ui/dis/workgroup-size.rs
@@ -1,0 +1,20 @@
+#![crate_name = "workgroup_size"]
+
+// Tests that the WorkgroupSize builtin is correctly generated as a constant.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+#[spirv(compute(threads(8, 4, 2)))]
+pub fn main(#[spirv(workgroup_size)] size: UVec3, #[spirv(local_invocation_id)] local_id: UVec3) {
+    // The workgroup_size should be (8, 4, 2)
+    // Using the size parameter ensures it's included in the generated SPIR-V
+    let _total = size.x + size.y + size.z + local_id.x;
+}

--- a/tests/compiletests/ui/dis/workgroup-size.stderr
+++ b/tests/compiletests/ui/dis/workgroup-size.stderr
@@ -1,0 +1,27 @@
+OpCapability Shader
+OpCapability Float64
+OpCapability Int64
+OpCapability Int16
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint GLCompute %1 "main" %2
+OpExecutionMode %1 LocalSize 8 4 2
+%3 = OpString "$OPSTRING_FILENAME/workgroup-size.rs"
+OpName %2 "local_id"
+OpName %4 "size"
+OpName %5 "workgroup_size::main"
+OpDecorate %2 BuiltIn LocalInvocationId
+OpDecorate %4 BuiltIn WorkgroupSize
+%6 = OpTypeInt 32 0
+%7 = OpTypeVector %6 3
+%8 = OpTypePointer Input %7
+%9 = OpTypeVoid
+%10 = OpTypeFunction %9
+%2 = OpVariable  %8  Input
+%11 = OpTypeFunction %9 %7 %7
+%12 = OpConstant  %6  8
+%13 = OpConstant  %6  4
+%14 = OpConstant  %6  2
+%4 = OpConstantComposite  %7  %12 %13 %14

--- a/tests/compiletests/ui/spirv-attr/all-builtins.rs
+++ b/tests/compiletests/ui/spirv-attr/all-builtins.rs
@@ -35,6 +35,7 @@ pub fn compute(
     #[spirv(num_workgroups)] num_workgroups: UVec3,
     #[spirv(subgroup_id)] subgroup_id: u32,
     #[spirv(workgroup_id)] workgroup_id: UVec3,
+    #[spirv(workgroup_size)] workgroup_size: UVec3,
     #[spirv(workgroup)] workgroup_local_memory: &mut [u32; 256],
 ) {
 }

--- a/tests/compiletests/ui/spirv-attr/workgroup-size.rs
+++ b/tests/compiletests/ui/spirv-attr/workgroup-size.rs
@@ -1,0 +1,12 @@
+// build-pass
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+#[spirv(compute(threads(8, 4, 2)))]
+pub fn main(#[spirv(workgroup_size)] size: UVec3, #[spirv(local_invocation_id)] local_id: UVec3) {
+    // The workgroup_size should be (8, 4, 2)
+    assert!(size.x == 8);
+    assert!(size.y == 4);
+    assert!(size.z == 2);
+}

--- a/tests/difftests/tests/Cargo.lock
+++ b/tests/difftests/tests/Cargo.lock
@@ -1401,6 +1401,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "workgroup-size-rust"
+version = "0.0.0"
+dependencies = [
+ "difftest",
+ "spirv-std",
+]
+
+[[package]]
+name = "workgroup-size-wgsl"
+version = "0.0.0"
+dependencies = [
+ "difftest",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/difftests/tests/Cargo.toml
+++ b/tests/difftests/tests/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "simple-compute/simple-compute-rust",
     "simple-compute/simple-compute-wgsl",
+    "workgroup-size/workgroup-size-rust",
+    "workgroup-size/workgroup-size-wgsl",
 ]
 
 [workspace.package]

--- a/tests/difftests/tests/workgroup-size/workgroup-size-rust/Cargo.toml
+++ b/tests/difftests/tests/workgroup-size/workgroup-size-rust/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "workgroup-size-rust"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["dylib"]
+
+# Common deps
+[dependencies]
+
+# GPU deps
+spirv-std.workspace = true
+
+# CPU deps
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true

--- a/tests/difftests/tests/workgroup-size/workgroup-size-rust/src/lib.rs
+++ b/tests/difftests/tests/workgroup-size/workgroup-size-rust/src/lib.rs
@@ -1,0 +1,30 @@
+#![no_std]
+
+use spirv_std::glam::UVec3;
+use spirv_std::spirv;
+
+#[spirv(compute(threads(8, 4, 2)))]
+pub fn main_cs(
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] output: &mut [u32],
+    #[spirv(workgroup_size)] workgroup_size: UVec3,
+    #[spirv(global_invocation_id)] global_id: UVec3,
+    #[spirv(local_invocation_id)] local_id: UVec3,
+) {
+    let idx = global_id.x as usize;
+
+    if idx < output.len() {
+        // Store a value that encodes the workgroup dimensions
+        // This allows us to verify that the workgroup_size builtin is working correctly
+        let encoded = (workgroup_size.x << 16) | (workgroup_size.y << 8) | workgroup_size.z;
+
+        // Also encode the local invocation ID to show it's within the workgroup bounds
+        let local_encoded = (local_id.x << 16) | (local_id.y << 8) | local_id.z;
+
+        // Store: encoded workgroup size in even indices, local ID in odd indices
+        if idx % 2 == 0 {
+            output[idx] = encoded; // Should be (8 << 16) | (4 << 8) | 2 = 0x080402
+        } else {
+            output[idx] = local_encoded;
+        }
+    }
+}

--- a/tests/difftests/tests/workgroup-size/workgroup-size-rust/src/main.rs
+++ b/tests/difftests/tests/workgroup-size/workgroup-size-rust/src/main.rs
@@ -1,0 +1,15 @@
+use difftest::config::Config;
+use difftest::scaffold::compute::{RustComputeShader, WgpuComputeTest};
+
+fn main() {
+    // Load the config from the harness.
+    let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
+
+    // Define test parameters, loading the rust shader from the current crate.
+    // Dispatch 2x2x1 workgroups with workgroup size [8, 4, 2]
+    // This gives us a total of 2*2*1 * 8*4*2 = 256 invocations
+    let test = WgpuComputeTest::new(RustComputeShader::default(), [2, 2, 1], 1024);
+
+    // Run the test and write the output to a file.
+    test.run_test(&config).unwrap();
+}

--- a/tests/difftests/tests/workgroup-size/workgroup-size-wgsl/Cargo.toml
+++ b/tests/difftests/tests/workgroup-size/workgroup-size-wgsl/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "workgroup-size-wgsl"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "workgroup-size-wgsl"
+path = "src/main.rs"
+
+[dependencies]
+difftest.workspace = true

--- a/tests/difftests/tests/workgroup-size/workgroup-size-wgsl/shader.wgsl
+++ b/tests/difftests/tests/workgroup-size/workgroup-size-wgsl/shader.wgsl
@@ -1,0 +1,33 @@
+@group(0) @binding(0)
+var<storage, read_write> output: array<u32>;
+
+// Define workgroup dimensions as named constants
+const WORKGROUP_SIZE_X: u32 = 8u;
+const WORKGROUP_SIZE_Y: u32 = 4u;
+const WORKGROUP_SIZE_Z: u32 = 2u;
+
+@compute @workgroup_size(WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y, WORKGROUP_SIZE_Z)
+fn main_cs(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>
+) {
+    let idx = global_id.x;
+    
+    if (idx < arrayLength(&output)) {
+        // Use the named constants to create the workgroup_size vector
+        let workgroup_size = vec3<u32>(WORKGROUP_SIZE_X, WORKGROUP_SIZE_Y, WORKGROUP_SIZE_Z);
+        
+        // Store a value that encodes the workgroup dimensions
+        let encoded = (workgroup_size.x << 16u) | (workgroup_size.y << 8u) | workgroup_size.z;
+        
+        // Also encode the local invocation ID
+        let local_encoded = (local_id.x << 16u) | (local_id.y << 8u) | local_id.z;
+        
+        // Store: encoded workgroup size in even indices, local ID in odd indices
+        if (idx % 2u == 0u) {
+            output[idx] = encoded; // Should be (8 << 16) | (4 << 8) | 2 = 0x080402
+        } else {
+            output[idx] = local_encoded;
+        }
+    }
+}

--- a/tests/difftests/tests/workgroup-size/workgroup-size-wgsl/src/main.rs
+++ b/tests/difftests/tests/workgroup-size/workgroup-size-wgsl/src/main.rs
@@ -1,0 +1,15 @@
+use difftest::config::Config;
+use difftest::scaffold::compute::{WgpuComputeTest, WgslComputeShader};
+
+fn main() {
+    // Load the config from the harness.
+    let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
+
+    // Define test parameters, loading the wgsl shader from the crate directory.
+    // Dispatch 2x2x1 workgroups with workgroup size [8, 4, 2]
+    // This gives us a total of 2*2*1 * 8*4*2 = 256 invocations
+    let test = WgpuComputeTest::new(WgslComputeShader::default(), [2, 2, 1], 1024);
+
+    // Run the test and write the output to a file.
+    test.run_test(&config).unwrap();
+}


### PR DESCRIPTION
Implement `#[spirv(workgroup_size)]` builtin that provides workgroup dimensions as a constant to compute shaders. The constant is created from the LocalSize execution mode values.

See https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#BuiltIn and https://github.com/KhronosGroup/SPIRV-Guide/blob/main/chapters/local_size_and_workgroup_size.md