### PR TITLE
Optimize constant casts to avoid unnecessary capabilities

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -172,6 +172,30 @@ impl<'tcx> CodegenCx<'tcx> {
             }
         }
 
+        // Check if this is a From trait implementation
+        if let Some(impl_def_id) = self.tcx.impl_of_method(def_id) {
+            if let Some(trait_ref) = self.tcx.impl_trait_ref(impl_def_id) {
+                let trait_def_id = trait_ref.skip_binder().def_id;
+
+                // Check if this is the From trait.
+                let trait_path = self.tcx.def_path_str(trait_def_id);
+                if matches!(
+                    trait_path.as_str(),
+                    "core::convert::From" | "std::convert::From"
+                ) {
+                    // Extract the source and target types from the trait substitutions
+                    let trait_args = trait_ref.skip_binder().args;
+                    if let (Some(target_ty), Some(source_ty)) =
+                        (trait_args.types().nth(0), trait_args.types().nth(1))
+                    {
+                        self.from_trait_impls
+                            .borrow_mut()
+                            .insert(def_id, (source_ty, target_ty));
+                    }
+                }
+            }
+        }
+
         if [
             self.tcx.lang_items().panic_fn(),
             self.tcx.lang_items().panic_fmt(),

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -84,6 +84,10 @@ pub struct CodegenCx<'tcx> {
     /// Intrinsic for storing a `<T>` into a `&[u32]`. The `PassMode` is the mode of the `<T>`.
     pub buffer_store_intrinsics: RefCell<FxHashMap<DefId, &'tcx PassMode>>,
 
+    /// Maps `DefId`s of `From::from` method implementations to their source and target types.
+    /// Used to optimize constant conversions like `u32::from(42u8)` to avoid creating the source type.
+    pub from_trait_impls: RefCell<FxHashMap<DefId, (Ty<'tcx>, Ty<'tcx>)>>,
+
     /// Some runtimes (e.g. intel-compute-runtime) disallow atomics on i8 and i16, even though it's allowed by the spec.
     /// This enables/disables them.
     pub i8_i16_atomics_allowed: bool,
@@ -203,6 +207,7 @@ impl<'tcx> CodegenCx<'tcx> {
             fmt_rt_arg_new_fn_ids_to_ty_and_spec: Default::default(),
             buffer_load_intrinsics: Default::default(),
             buffer_store_intrinsics: Default::default(),
+            from_trait_impls: Default::default(),
             i8_i16_atomics_allowed: false,
             codegen_args,
         }

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -477,6 +477,16 @@ pub fn link(
         simple_passes::remove_non_uniform_decorations(sess, &mut output)?;
     }
 
+    {
+        let _timer = sess.timer("link_remove_unused_type_capabilities");
+        simple_passes::remove_unused_type_capabilities(&mut output);
+    }
+
+    {
+        let _timer = sess.timer("link_type_capability_check");
+        simple_passes::check_type_capabilities(sess, &output)?;
+    }
+
     // NOTE(eddyb) SPIR-T pipeline is entirely limited to this block.
     {
         let (spv_words, module_or_err, lower_from_spv_timer) =

--- a/crates/rustc_codegen_spirv/src/spirv_type.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type.rs
@@ -3,7 +3,7 @@ use crate::builder_spirv::SpirvValue;
 use crate::codegen_cx::CodegenCx;
 use indexmap::IndexSet;
 use rspirv::dr::Operand;
-use rspirv::spirv::{Capability, Decoration, Dim, ImageFormat, StorageClass, Word};
+use rspirv::spirv::{Decoration, Dim, ImageFormat, StorageClass, Word};
 use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::span_bug;
 use rustc_span::def_id::DefId;
@@ -105,21 +105,6 @@ impl SpirvType<'_> {
                 let result = cx.emit_global().type_int_id(id, width, signedness as u32);
                 let u_or_i = if signedness { "i" } else { "u" };
                 match width {
-                    8 if !cx.builder.has_capability(Capability::Int8) => cx.zombie_with_span(
-                        result,
-                        def_span,
-                        &format!("`{u_or_i}8` without `OpCapability Int8`"),
-                    ),
-                    16 if !cx.builder.has_capability(Capability::Int16) => cx.zombie_with_span(
-                        result,
-                        def_span,
-                        &format!("`{u_or_i}16` without `OpCapability Int16`"),
-                    ),
-                    64 if !cx.builder.has_capability(Capability::Int64) => cx.zombie_with_span(
-                        result,
-                        def_span,
-                        &format!("`{u_or_i}64` without `OpCapability Int64`"),
-                    ),
                     8 | 16 | 32 | 64 => {}
                     w => cx.zombie_with_span(
                         result,
@@ -132,16 +117,6 @@ impl SpirvType<'_> {
             Self::Float(width) => {
                 let result = cx.emit_global().type_float_id(id, width);
                 match width {
-                    16 if !cx.builder.has_capability(Capability::Float16) => cx.zombie_with_span(
-                        result,
-                        def_span,
-                        "`f16` without `OpCapability Float16`",
-                    ),
-                    64 if !cx.builder.has_capability(Capability::Float64) => cx.zombie_with_span(
-                        result,
-                        def_span,
-                        "`f64` without `OpCapability Float64`",
-                    ),
                     16 | 32 | 64 => (),
                     other => cx.zombie_with_span(
                         result,

--- a/tests/compiletests/ui/dis/asm_op_decorate.stderr
+++ b/tests/compiletests/ui/dis/asm_op_decorate.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpCapability RuntimeDescriptorArray
 OpExtension "SPV_EXT_descriptor_indexing"

--- a/tests/compiletests/ui/dis/const-float-cast-optimized.rs
+++ b/tests/compiletests/ui/dis/const-float-cast-optimized.rs
@@ -1,0 +1,19 @@
+// Test that constant float widening casts are optimized to avoid creating
+// the smaller float type when not needed elsewhere.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(output: &mut f64) {
+    // This should optimize away the f32 type since it's widening
+    const SMALL: f32 = 20.5;
+    let widened = SMALL as f64;
+    *output = widened;
+}

--- a/tests/compiletests/ui/dis/const-float-cast-optimized.stderr
+++ b/tests/compiletests/ui/dis/const-float-cast-optimized.stderr
@@ -1,0 +1,16 @@
+OpCapability Shader
+OpCapability Float64
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/const-float-cast-optimized.rs"
+OpName %2 "output"
+OpDecorate %2 Location 0
+%4 = OpTypeFloat 64
+%5 = OpTypePointer Output %4
+%6 = OpTypeVoid
+%7 = OpTypeFunction %6
+%2 = OpVariable  %5  Output
+%8 = OpConstant  %4  4626463454704697344

--- a/tests/compiletests/ui/dis/const-float-cast.rs
+++ b/tests/compiletests/ui/dis/const-float-cast.rs
@@ -1,0 +1,31 @@
+// Test whether float constant casts need optimization
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(output: &mut f32) {
+    // Test f64 to f32 (narrowing)
+    const BIG: f64 = 123.456;
+    let narrowed = BIG as f32;
+    *output = narrowed;
+
+    // Test f32 to f64 (widening) - this might create f32 type unnecessarily
+    const SMALL: f32 = 20.5;
+    let widened = SMALL as f64;
+    *output += widened as f32;
+
+    let kept: f32 = 1.0 + SMALL;
+    *output += kept;
+
+    // Test integer to float
+    const INT: u32 = 42;
+    let as_float = INT as f32;
+    *output += as_float;
+}

--- a/tests/compiletests/ui/dis/const-float-cast.stderr
+++ b/tests/compiletests/ui/dis/const-float-cast.stderr
@@ -1,0 +1,22 @@
+OpCapability Shader
+OpCapability Float64
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/const-float-cast.rs"
+OpName %2 "output"
+OpDecorate %2 Location 0
+%4 = OpTypeFloat 32
+%5 = OpTypePointer Output %4
+%6 = OpTypeVoid
+%7 = OpTypeFunction %6
+%8 = OpTypeFloat 64
+%9 = OpConstant  %8  4638387860618067575
+%2 = OpVariable  %5  Output
+%10 = OpConstant  %8  4626463454704697344
+%11 = OpConstant  %4  1065353216
+%12 = OpConstant  %4  1101266944
+%13 = OpTypeInt 32 0
+%14 = OpConstant  %13  42

--- a/tests/compiletests/ui/dis/const-from-cast.rs
+++ b/tests/compiletests/ui/dis/const-from-cast.rs
@@ -1,0 +1,22 @@
+// Test that constant integer from casts are optimized to avoid creating intermediate
+// types that would require additional capabilities (e.g., Int8 capability for u8).
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std::spirv;
+
+const K: u8 = 42;
+
+#[spirv(fragment)]
+pub fn main(output: &mut u32) {
+    let position = 2u32;
+    // This cast should be optimized to directly create a u32 constant with value 42,
+    // avoiding the creation of a u8 type that would require Int8 capability
+    let global_y_offset_bits = u32::from(K);
+    *output = global_y_offset_bits;
+}

--- a/tests/compiletests/ui/dis/const-from-cast.stderr
+++ b/tests/compiletests/ui/dis/const-from-cast.stderr
@@ -1,0 +1,15 @@
+OpCapability Shader
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/const-from-cast.rs"
+OpName %2 "output"
+OpDecorate %2 Location 0
+%4 = OpTypeInt 32 0
+%5 = OpTypePointer Output %4
+%6 = OpTypeVoid
+%7 = OpTypeFunction %6
+%2 = OpVariable  %5  Output
+%8 = OpConstant  %4  42

--- a/tests/compiletests/ui/dis/const-int-cast.rs
+++ b/tests/compiletests/ui/dis/const-int-cast.rs
@@ -1,0 +1,22 @@
+// Test that constant integer casts are optimized to avoid creating intermediate types
+// that would require additional capabilities (e.g., Int8 capability for u8).
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std::spirv;
+
+const K: u8 = 20;
+
+#[spirv(fragment)]
+pub fn main(output: &mut u32) {
+    let position = 2u32;
+    // This cast should be optimized to directly create a u32 constant with value 20,
+    // avoiding the creation of a u8 type that would require Int8 capability
+    let global_y_offset_bits = position * K as u32;
+    *output = global_y_offset_bits;
+}

--- a/tests/compiletests/ui/dis/const-int-cast.stderr
+++ b/tests/compiletests/ui/dis/const-int-cast.stderr
@@ -1,0 +1,15 @@
+OpCapability Shader
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/const-int-cast.rs"
+OpName %2 "output"
+OpDecorate %2 Location 0
+%4 = OpTypeInt 32 0
+%5 = OpTypePointer Output %4
+%6 = OpTypeVoid
+%7 = OpTypeFunction %6
+%2 = OpVariable  %5  Output
+%8 = OpConstant  %4  40

--- a/tests/compiletests/ui/dis/const-narrowing-cast.rs
+++ b/tests/compiletests/ui/dis/const-narrowing-cast.rs
@@ -1,0 +1,24 @@
+// Test that constant narrowing casts (e.g., u32 to u8) still work correctly
+// and produce the expected truncation behavior.
+
+// build-pass
+// compile-flags: -C llvm-args=--disassemble-globals
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(output: &mut u32) {
+    // This should create a u32 type and do proper truncation
+    const BIG: u32 = 300; // 0x12C
+    let truncated = BIG as u8; // Should be 0x2C = 44
+    *output = truncated as u32;
+
+    // This should optimize away the u8 type since it's widening
+    const SMALL: u8 = 20;
+    let widened = SMALL as u32;
+    *output += widened;
+}

--- a/tests/compiletests/ui/dis/const-narrowing-cast.stderr
+++ b/tests/compiletests/ui/dis/const-narrowing-cast.stderr
@@ -1,0 +1,18 @@
+OpCapability Shader
+OpCapability Int8
+OpCapability ShaderClockKHR
+OpExtension "SPV_KHR_shader_clock"
+OpMemoryModel Logical Simple
+OpEntryPoint Fragment %1 "main" %2
+OpExecutionMode %1 OriginUpperLeft
+%3 = OpString "$OPSTRING_FILENAME/const-narrowing-cast.rs"
+OpName %2 "output"
+OpDecorate %2 Location 0
+%4 = OpTypeInt 32 0
+%5 = OpTypePointer Output %4
+%6 = OpTypeVoid
+%7 = OpTypeFunction %6
+%8 = OpTypeInt 8 0
+%9 = OpConstant  %4  300
+%2 = OpVariable  %5  Output
+%10 = OpConstant  %4  20

--- a/tests/compiletests/ui/dis/custom_entry_point.stderr
+++ b/tests/compiletests/ui/dis/custom_entry_point.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple

--- a/tests/compiletests/ui/dis/generic-fn-op-name.stderr
+++ b/tests/compiletests/ui/dis/generic-fn-op-name.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple

--- a/tests/compiletests/ui/dis/issue-723-output.stderr
+++ b/tests/compiletests/ui/dis/issue-723-output.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple

--- a/tests/compiletests/ui/dis/non-writable-storage_buffer.stderr
+++ b/tests/compiletests/ui/dis/non-writable-storage_buffer.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple

--- a/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
+++ b/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_non_semantic_info"
 OpExtension "SPV_KHR_shader_clock"

--- a/tests/compiletests/ui/dis/panic_sequential_many.stderr
+++ b/tests/compiletests/ui/dis/panic_sequential_many.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_non_semantic_info"
 OpExtension "SPV_KHR_shader_clock"

--- a/tests/compiletests/ui/dis/spec_constant-attr.stderr
+++ b/tests/compiletests/ui/dis/spec_constant-attr.stderr
@@ -1,8 +1,4 @@
 OpCapability Shader
-OpCapability Float64
-OpCapability Int64
-OpCapability Int16
-OpCapability Int8
 OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple

--- a/tests/compiletests/ui/lang/consts/u32-from-u64-fail.rs
+++ b/tests/compiletests/ui/lang/consts/u32-from-u64-fail.rs
@@ -1,0 +1,16 @@
+// Test that u32::from(u64) fails to compile since From<u64> is not implemented for u32
+// This ensures our From trait optimization doesn't accidentally allow invalid conversions
+
+// build-fail
+
+use spirv_std::spirv;
+
+const K: u64 = 42;
+
+#[spirv(fragment)]
+pub fn main(output: &mut u32) {
+    // This should fail to compile because From<u64> is not implemented for u32
+    // (u64 to u32 is a narrowing conversion that could lose data)
+    let value = u32::from(K);
+    *output = value;
+}

--- a/tests/compiletests/ui/lang/consts/u32-from-u64-fail.stderr
+++ b/tests/compiletests/ui/lang/consts/u32-from-u64-fail.stderr
@@ -1,0 +1,17 @@
+error[E0277]: the trait bound `u32: From<u64>` is not satisfied
+  --> $DIR/u32-from-u64-fail.rs:14:17
+   |
+14 |     let value = u32::from(K);
+   |                 ^^^ the trait `From<u64>` is not implemented for `u32`
+   |
+   = help: the following other types implement trait `From<T>`:
+             `u32` implements `From<Char>`
+             `u32` implements `From<Ipv4Addr>`
+             `u32` implements `From<bool>`
+             `u32` implements `From<char>`
+             `u32` implements `From<u16>`
+             `u32` implements `From<u8>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/compiletests/ui/lang/consts/u8-const-cast-no-capability.rs
+++ b/tests/compiletests/ui/lang/consts/u8-const-cast-no-capability.rs
@@ -1,0 +1,14 @@
+// build-pass
+// Test that u8 constants cast to u32 don't require Int8 capability when optimized away
+
+#![no_std]
+use spirv_std::spirv;
+
+const K: u8 = 20;
+
+#[spirv(fragment)]
+pub fn main(output: &mut u32) {
+    // This should not require Int8 capability as K is only used as u32
+    // and the optimization should fold the constant cast
+    *output = K as u32;
+}

--- a/tests/compiletests/ui/lang/consts/u8-const-cast.rs
+++ b/tests/compiletests/ui/lang/consts/u8-const-cast.rs
@@ -1,0 +1,37 @@
+// build-pass
+// Test that u8 constants cast to u32 don't require Int8 capability
+
+use spirv_std::spirv;
+
+const K: u8 = 20;
+
+#[spirv(fragment)]
+pub fn main(output: &mut u32) {
+    let position = 2u32;
+    // This should not require Int8 capability as K is only used as u32
+    let global_y_offset_bits = position * K as u32;
+    *output = global_y_offset_bits;
+}
+
+#[spirv(fragment)]
+pub fn test_various_const_casts(output: &mut [u32; 5]) {
+    // Test u8 -> u32
+    const U8_VAL: u8 = 255;
+    output[0] = U8_VAL as u32;
+
+    // Test i8 -> i32
+    const I8_VAL: i8 = -128;
+    output[1] = I8_VAL as i32 as u32;
+
+    // Test u16 -> u32
+    const U16_VAL: u16 = 65535;
+    output[2] = U16_VAL as u32;
+
+    // Test bool -> u32
+    const BOOL_VAL: bool = true;
+    output[3] = BOOL_VAL as u32;
+
+    // Test u32 -> bool -> u32
+    const U32_VAL: u32 = 42;
+    output[4] = (U32_VAL != 0) as u32;
+}


### PR DESCRIPTION
Add constant folding for widening casts (u8->u32, f32->f64) to avoid creating intermediate types. Remove capability checks during type creation and add bidirectional validation in linker to remove unused type capabilities.

Fixes #300