### PR TITLE
Make `read_clock_khr` always available

### DIFF
--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -147,11 +147,6 @@ pub fn kill() -> ! {
 ///
 /// See:
 /// <https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_shader_clock.html>
-#[cfg(all(
-    target_feature = "Int64",
-    target_feature = "ShaderClockKHR",
-    target_feature = "ext:SPV_KHR_shader_clock"
-))]
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpReadClockKHR")]
 pub unsafe fn read_clock_khr<const SCOPE: u32>() -> u64 {
@@ -172,10 +167,6 @@ pub unsafe fn read_clock_khr<const SCOPE: u32>() -> u64 {
 /// capability. It returns a 'vector of two-components of 32-bit unsigned
 /// integer type with the first component containing the 32 least significant
 /// bits and the second component containing the 32 most significant bits.'
-#[cfg(all(
-    target_feature = "ShaderClockKHR",
-    target_feature = "ext:SPV_KHR_shader_clock"
-))]
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpReadClockKHR")]
 pub unsafe fn read_clock_uvec2_khr<V: Vector<u32, 2>, const SCOPE: u32>() -> V {

--- a/tests/compiletests/src/main.rs
+++ b/tests/compiletests/src/main.rs
@@ -151,6 +151,8 @@ impl Runner {
                 format!("{}-{}", env, variation.name)
             };
 
+            println!("Testing env: {}\n", stage_id);
+
             let target = format!("{SPIRV_TARGET_PREFIX}{env}");
             let libs = build_deps(&self.deps_target_dir, &self.codegen_backend_path, &target);
             let mut flags = test_rustc_flags(&self.codegen_backend_path, &libs, &[

--- a/tests/compiletests/src/main.rs
+++ b/tests/compiletests/src/main.rs
@@ -342,15 +342,7 @@ struct TestDeps {
 /// The RUSTFLAGS passed to all SPIR-V builds.
 // FIXME(eddyb) expose most of these from `spirv-builder`.
 fn rust_flags(codegen_backend_path: &Path) -> String {
-    let target_features = [
-        "Int8",
-        "Int16",
-        "Int64",
-        "Float64",
-        // Only needed for `ui/arch/read_clock_khr.rs`.
-        "ShaderClockKHR",
-        "ext:SPV_KHR_shader_clock",
-    ];
+    let target_features = ["Int8", "Int16", "Int64", "Float64"];
 
     [
         &*format!("-Zcodegen-backend={}", codegen_backend_path.display()),

--- a/tests/compiletests/ui/dis/asm_op_decorate.stderr
+++ b/tests/compiletests/ui/dis/asm_op_decorate.stderr
@@ -1,8 +1,6 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
 OpCapability RuntimeDescriptorArray
 OpExtension "SPV_EXT_descriptor_indexing"
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/const-float-cast-optimized.stderr
+++ b/tests/compiletests/ui/dis/const-float-cast-optimized.stderr
@@ -1,7 +1,5 @@
 OpCapability Shader
 OpCapability Float64
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/const-float-cast.stderr
+++ b/tests/compiletests/ui/dis/const-float-cast.stderr
@@ -1,7 +1,5 @@
 OpCapability Shader
 OpCapability Float64
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/const-from-cast.stderr
+++ b/tests/compiletests/ui/dis/const-from-cast.stderr
@@ -1,6 +1,4 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/const-int-cast.stderr
+++ b/tests/compiletests/ui/dis/const-int-cast.stderr
@@ -1,6 +1,4 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/const-narrowing-cast.stderr
+++ b/tests/compiletests/ui/dis/const-narrowing-cast.stderr
@@ -1,7 +1,5 @@
 OpCapability Shader
 OpCapability Int8
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/custom_entry_point.stderr
+++ b/tests/compiletests/ui/dis/custom_entry_point.stderr
@@ -1,6 +1,4 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "hello_world"
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/generic-fn-op-name.stderr
+++ b/tests/compiletests/ui/dis/generic-fn-op-name.stderr
@@ -1,6 +1,4 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/issue-723-output.stderr
+++ b/tests/compiletests/ui/dis/issue-723-output.stderr
@@ -1,6 +1,4 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/non-writable-storage_buffer.stderr
+++ b/tests/compiletests/ui/dis/non-writable-storage_buffer.stderr
@@ -1,6 +1,4 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft

--- a/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
+++ b/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
@@ -1,7 +1,5 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_non_semantic_info"
-OpExtension "SPV_KHR_shader_clock"
 %1 = OpExtInstImport "NonSemantic.DebugPrintf"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %2 "main"

--- a/tests/compiletests/ui/dis/panic_sequential_many.stderr
+++ b/tests/compiletests/ui/dis/panic_sequential_many.stderr
@@ -1,7 +1,5 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
 OpExtension "SPV_KHR_non_semantic_info"
-OpExtension "SPV_KHR_shader_clock"
 %1 = OpExtInstImport "NonSemantic.DebugPrintf"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %2 "main" %3 %4 %5

--- a/tests/compiletests/ui/dis/spec_constant-attr.rs
+++ b/tests/compiletests/ui/dis/spec_constant-attr.rs
@@ -9,11 +9,6 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
-// FIXME(eddyb) this should use revisions to track both the `vulkan1.2` output
-// and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
-// are not supported in `compiletest-rs`.
-// ignore-vulkan1.2
-
 use spirv_std::spirv;
 
 #[spirv(fragment)]

--- a/tests/compiletests/ui/dis/spec_constant-attr.stderr
+++ b/tests/compiletests/ui/dis/spec_constant-attr.stderr
@@ -1,6 +1,4 @@
 OpCapability Shader
-OpCapability ShaderClockKHR
-OpExtension "SPV_KHR_shader_clock"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft


### PR DESCRIPTION
split out from https://github.com/Rust-GPU/rust-gpu/pull/280 to get it merged sooner

Currently, the `arch::read_clock_khr` function is hidden behind it's `target_feature` gates `ShaderClockKHR` and `ext:SPV_KHR_shader_clock`, unlike every other intrinsic we have. Usually, the functions are always available and `spirv-val` just fails if you use a feature without enabling it. This PR removes the feature gate.

It also removes that extension and capability from the ones enabled by default in compiletest, as naga does not support it, to unblock https://github.com/Rust-GPU/rust-gpu/pull/280