### PR TITLE
Support more test names in difftest

### DIFF
--- a/tests/difftests/bin/src/main.rs
+++ b/tests/difftests/bin/src/main.rs
@@ -121,7 +121,7 @@ fn main() -> Result<()> {
                 if filter.contains('/') {
                     // Convert path-like filter to test name format
                     let path_filter = filter.replace('/', "::");
-                    format!("difftests::{}", path_filter)
+                    format!("{}", path_filter)
                 } else {
                     filter
                 }

--- a/tests/difftests/bin/src/main.rs
+++ b/tests/difftests/bin/src/main.rs
@@ -111,6 +111,27 @@ fn main() -> Result<()> {
         })
         .collect();
 
+    // If filters are provided that look like paths (contain '/'), convert them to test names
+    let opts = if opts.filters.iter().any(|f| f.contains('/')) {
+        let mut new_opts = opts;
+        new_opts.filters = new_opts
+            .filters
+            .into_iter()
+            .map(|filter| {
+                if filter.contains('/') {
+                    // Convert path-like filter to test name format
+                    let path_filter = filter.replace('/', "::");
+                    format!("difftests::{}", path_filter)
+                } else {
+                    filter
+                }
+            })
+            .collect();
+        new_opts
+    } else {
+        opts
+    };
+
     let passed = run_tests_console(&opts, tests).expect("Failed to run tests");
 
     process::exit(if passed { 0 } else { 1 });


### PR DESCRIPTION
These all now work. Previously, the path ones did not work:

  - cargo difftest -- difftests::arch::workgroup_memory (original format)
  - cargo difftest -- arch/workgroup_memory (path-like format)
  - cargo difftest -- arch (directory filter)