### PR TITLE
 better const folding for int and bool 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,18 @@ spirv-tools = { version = "0.12", default-features = false }
 rustc_codegen_spirv = { path = "./crates/rustc_codegen_spirv", version = "=0.9.0", default-features = false }
 rustc_codegen_spirv-types = { path = "./crates/rustc_codegen_spirv-types", version = "=0.9.0" }
 rustc_codegen_spirv-target-specs = { path = "crates/rustc_codegen_spirv-target-specs", version = "=0.9.0" }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.3", features = ["env-filter", "json"] }
+
+# difftest libraries mirrored from difftest workspace
+difftest = { path = "tests/difftests/lib" }
 
 # External dependencies that need to be mentioned more than once.
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.3", features = ["env-filter", "json"] }
 num-traits = { version = "0.2.15", default-features = false }
 glam = { version = ">=0.22, <=0.30", default-features = false }
 # libm 0.2.12 is a breaking change with new intrinsics
 libm = { version = ">=0.2.5, <=0.2.11", default-features = false }
+bytemuck = { version = "1.23", features = ["derive"] }
 
 # Enable incremental by default in release mode.
 [profile.release]

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -2910,6 +2910,12 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     ) -> Self::Value {
         assert_ty_eq!(self, then_val.ty, else_val.ty);
         let result_type = then_val.ty;
+
+        if let Some(ConstValue::Bool(b)) = self.try_get_const_value(cond) {
+            // as we directly return the values, it'll preserve their constness as well
+            return if b { then_val } else { else_val };
+        }
+
         self.emit()
             .select(
                 result_type,

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -105,16 +105,18 @@ macro_rules! simple_op {
                 if let Some(const_lhs) = self.try_get_const_value(lhs)
                     && let Some(const_rhs) = self.try_get_const_value(rhs)
                 {
-                    #[allow(unreachable_patterns)]
-                    match (const_lhs, const_rhs) {
+                    let result = (|| Some(match (const_lhs, const_rhs) {
                         $(
-                            (ConstValue::Unsigned($int_lhs), ConstValue::Unsigned($int_rhs)) => return self.const_uint_big(result_type, $fold_int),
-                            (ConstValue::Signed($int_lhs), ConstValue::Signed($int_rhs)) => return self.const_uint_big(result_type, $fold_int as u128),
+                            (ConstValue::Unsigned($int_lhs), ConstValue::Unsigned($int_rhs)) => $fold_int,
+                            (ConstValue::Signed($int_lhs), ConstValue::Signed($int_rhs)) => $fold_int as u128,
                         )?
-                        $((ConstValue::Unsigned($uint_lhs), ConstValue::Unsigned($uint_rhs)) => return self.const_uint_big(result_type, $fold_uint), )?
-                        $((ConstValue::Signed($sint_lhs), ConstValue::Signed($sint_rhs)) => return self.const_uint_big(result_type, $fold_sint as u128), )?
-                        $((ConstValue::Bool($bool_lhs), ConstValue::Bool($bool_rhs)) => return self.const_uint_big(result_type, ($fold_bool).into()), )?
-                        _ => (),
+                        $((ConstValue::Unsigned($uint_lhs), ConstValue::Unsigned($uint_rhs)) => $fold_uint,)?
+                        $((ConstValue::Signed($sint_lhs), ConstValue::Signed($sint_rhs)) => $fold_sint as u128, )?
+                        $((ConstValue::Bool($bool_lhs), ConstValue::Bool($bool_rhs)) => ($fold_bool).into(), )?
+                        _ => return None,
+                    }))();
+                    if let Some(result) = result {
+                        return self.const_uint_big(result_type, result);
                     }
                 }
             )?
@@ -172,23 +174,25 @@ macro_rules! simple_shift_op {
                 if let Some(const_lhs) = self.try_get_const_value(lhs)
                     && let Some(const_rhs) = self.try_get_const_value(rhs)
                 {
-                    #[allow(unreachable_patterns)]
-                    match (const_lhs, const_rhs) {
+                    let result = (|| Some(match (const_lhs, const_rhs) {
                         $(
-                            (ConstValue::Unsigned($int_lhs), ConstValue::Unsigned($int_rhs)) => return self.const_uint_big(result_type, $fold_int),
-							(ConstValue::Unsigned($int_lhs), ConstValue::Signed($int_rhs)) => return self.const_uint_big(result_type, $fold_int),
-							(ConstValue::Signed($int_lhs), ConstValue::Unsigned($int_rhs)) => return self.const_uint_big(result_type, $fold_int as u128),
-							(ConstValue::Signed($int_lhs), ConstValue::Signed($int_rhs)) => return self.const_uint_big(result_type, $fold_int as u128),
+                            (ConstValue::Unsigned($int_lhs), ConstValue::Unsigned($int_rhs)) => $fold_int,
+							(ConstValue::Unsigned($int_lhs), ConstValue::Signed($int_rhs)) => $fold_int,
+							(ConstValue::Signed($int_lhs), ConstValue::Unsigned($int_rhs)) => $fold_int as u128,
+							(ConstValue::Signed($int_lhs), ConstValue::Signed($int_rhs)) => $fold_int as u128,
 						)?
 						$(
-							(ConstValue::Unsigned($uint_lhs), ConstValue::Unsigned($uint_rhs)) => return self.const_uint_big(result_type, $fold_uint),
-                            (ConstValue::Unsigned($uint_lhs), ConstValue::Signed($uint_rhs)) => return self.const_uint_big(result_type, $fold_uint),
+							(ConstValue::Unsigned($uint_lhs), ConstValue::Unsigned($uint_rhs)) => $fold_uint,
+                            (ConstValue::Unsigned($uint_lhs), ConstValue::Signed($uint_rhs)) => $fold_uint,
                         )?
                         $(
-                            (ConstValue::Signed($sint_lhs), ConstValue::Unsigned($sint_rhs)) => return self.const_uint_big(result_type, $fold_sint as u128),
-                            (ConstValue::Signed($sint_lhs), ConstValue::Signed($sint_rhs)) => return self.const_uint_big(result_type, $fold_sint as u128),
+                            (ConstValue::Signed($sint_lhs), ConstValue::Unsigned($sint_rhs)) => $fold_sint as u128,
+                            (ConstValue::Signed($sint_lhs), ConstValue::Signed($sint_rhs)) => $fold_sint as u128,
                         )?
-                        _ => (),
+                        _ => return None,
+                    }))();
+                    if let Some(result) = result {
+                        return self.const_uint_big(result_type, result);
                     }
                 }
             )?
@@ -238,15 +242,18 @@ macro_rules! simple_uni_op {
             $(
                 #[allow(unreachable_patterns, clippy::collapsible_match)]
                 if let Some(const_val) = self.try_get_const_value(val) {
-                    match const_val {
+                    let result = (|| Some(match (const_val) {
                         $(
-                            ConstValue::Unsigned($int_val) => return self.const_uint_big(result_type, $fold_int),
-                            ConstValue::Signed($int_val) => return self.const_uint_big(result_type, $fold_int as u128),
+                            ConstValue::Unsigned($int_val) => $fold_int,
+                            ConstValue::Signed($int_val) => $fold_int as u128,
                         )?
-                        $(ConstValue::Unsigned($uint_val) => return self.const_uint_big(result_type, $fold_uint), )?
-                        $(ConstValue::Signed($sint_val) => return self.const_uint_big(result_type, $fold_sint as u128), )?
-                        $(ConstValue::Bool($bool_val) => return self.const_uint_big(result_type, ($fold_bool).into()), )?
-                        _ => (),
+                        $(ConstValue::Unsigned($uint_val) => $fold_uint, )?
+                        $(ConstValue::Signed($sint_val) => $fold_sint as u128, )?
+                        $(ConstValue::Bool($bool_val) => ($fold_bool).into(), )?
+                        _ => return None,
+                    }))();
+                    if let Some(result) = result {
+                        return self.const_uint_big(result_type, result);
                     }
                 }
             )?
@@ -1538,7 +1545,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         add,
         int: i_add,
         fold_const {
-            int(a, b) => a.wrapping_add(b);
+            int(a, b) => a.checked_add(b)?;
         }
     }
     // FIXME(eddyb) try to annotate the SPIR-V for `fast` and `algebraic`.
@@ -1549,7 +1556,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         sub,
         int: i_sub,
         fold_const {
-            int(a, b) => a.wrapping_sub(b);
+            int(a, b) => a.checked_sub(b)?;
         }
     }
     simple_op! {fsub, float: f_sub}
@@ -1559,7 +1566,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         mul,
         int: i_mul,
         fold_const {
-            int(a, b) => a.wrapping_mul(b);
+            int(a, b) => a.checked_mul(b)?;
         }
     }
     simple_op! {fmul, float: f_mul}
@@ -1569,7 +1576,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         udiv,
         uint: u_div,
         fold_const {
-            uint(a, b) => a.wrapping_div(b);
+            uint(a, b) => a.checked_div(b)?;
         }
     }
     // Note: exactudiv is UB when there's a remainder, so it's valid to implement as a normal div.
@@ -1578,14 +1585,14 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         exactudiv,
         uint: u_div,
         fold_const {
-            uint(a, b) => a.wrapping_div(b);
+            uint(a, b) => a.checked_div(b)?;
         }
     }
     simple_op! {
         sdiv,
         sint: s_div,
         fold_const {
-            sint(a, b) => a.wrapping_div(b);
+            sint(a, b) => a.checked_div(b)?;
         }
     }
     // Same note and TODO as exactudiv
@@ -1593,7 +1600,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         exactsdiv,
         sint: s_div,
         fold_const {
-            sint(a, b) => a.wrapping_div(b);
+            sint(a, b) => a.checked_div(b)?;
         }
     }
     simple_op! {fdiv, float: f_div}
@@ -1603,14 +1610,14 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         urem,
         uint: u_mod,
         fold_const {
-            uint(a, b) => a.wrapping_rem(b);
+            uint(a, b) => a.checked_rem(b)?;
         }
     }
     simple_op! {
         srem,
         sint: s_rem,
         fold_const {
-            sint(a, b) => a.wrapping_rem(b);
+            sint(a, b) => a.checked_rem(b)?;
         }
     }
     simple_op! {frem, float: f_rem}
@@ -1620,28 +1627,28 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         shl,
         int: shift_left_logical,
         fold_const {
-            int(a, b) => a.wrapping_shl(b as u32);
+            int(a, b) => a.checked_shl(b as u32)?;
         }
     }
     simple_shift_op! {
         lshr,
         uint: shift_right_logical,
         fold_const {
-            uint(a, b) => a.wrapping_shr(b as u32);
+            uint(a, b) => a.checked_shr(b as u32)?;
         }
     }
     simple_shift_op! {
         ashr,
         sint: shift_right_arithmetic,
         fold_const {
-            sint(a, b) => a.wrapping_shr(b as u32);
+            sint(a, b) => a.checked_shr(b as u32)?;
         }
     }
     simple_uni_op! {
         neg,
         sint: s_negate,
         fold_const {
-            sint(a) => a.wrapping_neg();
+            sint(a) => a.checked_neg()?;
         }
     }
     simple_uni_op! {fneg, float: f_negate}

--- a/crates/rustc_codegen_spirv/src/builder/libm_intrinsics.rs
+++ b/crates/rustc_codegen_spirv/src/builder/libm_intrinsics.rs
@@ -246,20 +246,20 @@ impl Builder<'_, '_> {
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Log1p) => {
                 assert_eq!(args.len(), 1);
                 let one = self.constant_float(args[0].ty, 1.0);
-                let add = self.add(args[0], one);
+                let add = self.fadd(args[0], one);
                 self.gl_op(GLOp::Log, result_type, [add])
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Exp10) => {
                 assert_eq!(args.len(), 1);
                 // exp10(x) == exp(x * log(10));
                 let log10 = self.constant_float(args[0].ty, 10.0f64.ln());
-                let mul = self.mul(args[0], log10);
+                let mul = self.fmul(args[0], log10);
                 self.gl_op(GLOp::Exp, result_type, [mul])
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Expm1) => {
                 let exp = self.gl_op(GLOp::Exp, args[0].ty, [args[0]]);
                 let one = self.constant_float(exp.ty, 1.0);
-                self.sub(exp, one)
+                self.fsub(exp, one)
             }
             LibmIntrinsic::Custom(LibmCustomIntrinsic::Erf) => {
                 self.undef_zombie(result_type, "Erf not supported yet")

--- a/tests/compiletests/ui/dis/entry-pass-mode-cast-array.stderr
+++ b/tests/compiletests/ui/dis/entry-pass-mode-cast-array.stderr
@@ -3,21 +3,11 @@
 OpLine %5 13 12
 %6 = OpLoad  %7  %8
 OpLine %5 14 4
-%9 = OpULessThan  %10  %11 %12
-OpNoLine
-OpSelectionMerge %13 None
-OpBranchConditional %9 %14 %15
-%14 = OpLabel
-OpBranch %13
-%15 = OpLabel
-OpReturn
-%13 = OpLabel
-OpLine %5 14 4
-%16 = OpCompositeExtract  %17  %6 0
-%18 = OpFAdd  %17  %16 %19
-%20 = OpCompositeInsert  %7  %18 %6 0
+%9 = OpCompositeExtract  %10  %6 0
+%11 = OpFAdd  %10  %9 %12
+%13 = OpCompositeInsert  %7  %11 %6 0
 OpLine %5 15 4
-OpStore %21 %20
+OpStore %14 %13
 OpNoLine
 OpReturn
 OpFunctionEnd

--- a/tests/compiletests/ui/dis/issue-731.stderr
+++ b/tests/compiletests/ui/dis/issue-731.stderr
@@ -3,21 +3,11 @@
 OpLine %5 11 12
 %6 = OpLoad  %7  %8
 OpLine %5 12 4
-%9 = OpULessThan  %10  %11 %12
-OpNoLine
-OpSelectionMerge %13 None
-OpBranchConditional %9 %14 %15
-%14 = OpLabel
-OpBranch %13
-%15 = OpLabel
-OpReturn
-%13 = OpLabel
-OpLine %5 12 4
-%16 = OpCompositeExtract  %17  %6 0
-%18 = OpFAdd  %17  %16 %19
-%20 = OpCompositeInsert  %7  %18 %6 0
+%9 = OpCompositeExtract  %10  %6 0
+%11 = OpFAdd  %10  %9 %12
+%13 = OpCompositeInsert  %7  %11 %6 0
 OpLine %5 13 4
-OpStore %21 %20
+OpStore %14 %13
 OpNoLine
 OpReturn
 OpFunctionEnd

--- a/tests/compiletests/ui/lang/u32/const_fold_div.rs
+++ b/tests/compiletests/ui/lang/u32/const_fold_div.rs
@@ -1,0 +1,10 @@
+// build-pass
+
+#![allow(unconditional_panic)]
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn const_fold_div(out: &mut u32) {
+    *out = 7u32 / 0;
+}

--- a/tests/difftests/tests/Cargo.lock
+++ b/tests/difftests/tests/Cargo.lock
@@ -211,6 +211,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fold_int-const-fold-cpu"
+version = "0.0.0"
+dependencies = [
+ "bytemuck",
+ "difftest",
+ "num_enum",
+ "spirv-std",
+]
+
+[[package]]
+name = "const_fold_int-const-fold-shader"
+version = "0.0.0"
+dependencies = [
+ "bytemuck",
+ "const_fold_int-const-fold-cpu",
+ "difftest",
+]
+
+[[package]]
+name = "const_fold_int-dynamic-values-cpu"
+version = "0.0.0"
+dependencies = [
+ "bytemuck",
+ "const_fold_int-const-fold-cpu",
+ "difftest",
+]
+
+[[package]]
+name = "const_fold_int-dynamic-values-shader"
+version = "0.0.0"
+dependencies = [
+ "bytemuck",
+ "const_fold_int-const-fold-cpu",
+ "difftest",
+]
+
+[[package]]
 name = "control_flow-rust"
 version = "0.0.0"
 dependencies = [
@@ -816,6 +853,27 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/tests/difftests/tests/Cargo.lock
+++ b/tests/difftests/tests/Cargo.lock
@@ -211,6 +211,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fold_int-const-expr-cpu"
+version = "0.0.0"
+dependencies = [
+ "bytemuck",
+ "const_fold_int-const-fold-cpu",
+ "difftest",
+]
+
+[[package]]
+name = "const_fold_int-const-expr-shader"
+version = "0.0.0"
+dependencies = [
+ "bytemuck",
+ "const_fold_int-const-fold-cpu",
+ "difftest",
+]
+
+[[package]]
 name = "const_fold_int-const-fold-cpu"
 version = "0.0.0"
 dependencies = [

--- a/tests/difftests/tests/Cargo.toml
+++ b/tests/difftests/tests/Cargo.toml
@@ -27,6 +27,8 @@ members = [
     "lang/core/ops/matrix_ops/matrix_ops-rust",
     "lang/core/ops/matrix_ops/matrix_ops-wgsl",
     "lang/core/ops/bitwise_ops/bitwise_ops-rust",
+    "lang/core/ops/const_fold_int/const-expr-cpu",
+    "lang/core/ops/const_fold_int/const-expr-shader",
     "lang/core/ops/const_fold_int/const-fold-cpu",
     "lang/core/ops/const_fold_int/const-fold-shader",
     "lang/core/ops/const_fold_int/dynamic-values-cpu",

--- a/tests/difftests/tests/Cargo.toml
+++ b/tests/difftests/tests/Cargo.toml
@@ -27,6 +27,10 @@ members = [
     "lang/core/ops/matrix_ops/matrix_ops-rust",
     "lang/core/ops/matrix_ops/matrix_ops-wgsl",
     "lang/core/ops/bitwise_ops/bitwise_ops-rust",
+    "lang/core/ops/const_fold_int/const-fold-cpu",
+    "lang/core/ops/const_fold_int/const-fold-shader",
+    "lang/core/ops/const_fold_int/dynamic-values-cpu",
+    "lang/core/ops/const_fold_int/dynamic-values-shader",
     "lang/core/ops/bitwise_ops/bitwise_ops-wgsl",
     "lang/core/ops/trig_ops/trig_ops-rust",
     "lang/core/ops/trig_ops/trig_ops-wgsl",
@@ -46,8 +50,6 @@ unexpected_cfgs = { level = "allow", check-cfg = [
 
 [workspace.dependencies]
 spirv-std = { path = "../../../crates/spirv-std", version = "=0.9.0" }
-spirv-std-types = { path = "../../../crates/spirv-std/shared", version = "=0.9.0" }
-spirv-std-macros = { path = "../../../crates/spirv-std/macros", version = "=0.9.0" }
 difftest = { path = "../../../tests/difftests/lib" }
 # External dependencies that need to be mentioned more than once.
 num-traits = { version = "0.2.15", default-features = false }

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-cpu/Cargo.toml
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-cpu/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "const_fold_int-const-expr-cpu"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+# GPU deps
+[dependencies]
+const_fold_int-const-fold-cpu = { path = "../const-fold-cpu" }
+
+# CPU deps (for the test harness)
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true
+bytemuck.workspace = true

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-cpu/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-cpu/src/main.rs
@@ -1,0 +1,5 @@
+use const_fold_int_const_fold_cpu::Variants;
+
+fn main() {
+    const_fold_int_const_fold_cpu::cpu_driver::run(Variants::ConstExpr);
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-shader/Cargo.toml
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-shader/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "const_fold_int-const-expr-shader"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["dylib"]
+
+# GPU deps
+[dependencies]
+const_fold_int-const-fold-cpu = { path = "../const-fold-cpu" }
+
+# CPU deps (for the test harness)
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true
+bytemuck.workspace = true

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-shader/src/lib.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-shader/src/lib.rs
@@ -1,0 +1,4 @@
+#![cfg_attr(target_arch = "spirv", no_std)]
+#![allow(arithmetic_overflow)]
+
+pub use const_fold_int_const_fold_cpu::shader::main_cs;

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-shader/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-expr-shader/src/main.rs
@@ -1,0 +1,5 @@
+use const_fold_int_const_fold_cpu::Variants;
+
+fn main() {
+    const_fold_int_const_fold_cpu::shader_driver::run(Variants::ConstExpr);
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/Cargo.toml
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "const_fold_int-const-fold-cpu"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+# GPU deps
+[dependencies]
+spirv-std.workspace = true
+num_enum = { version = "0.7.4", default-features = false }
+
+# CPU deps (for the test harness)
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true
+bytemuck.workspace = true

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/cpu_driver.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/cpu_driver.rs
@@ -1,0 +1,13 @@
+use crate::{INTERESTING_PATTERNS, Variants};
+use difftest::config::Config;
+
+pub fn run(variant: Variants) {
+    let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
+    let result = variant
+        .eval(&INTERESTING_PATTERNS)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .collect::<Vec<_>>();
+    config.write_result(&result).unwrap()
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/lib.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/lib.rs
@@ -14,20 +14,12 @@ macro_rules! op_u {
         [
             ($value << 0) as u32,
             ($value << 1) as u32,
-            ($value << 2) as u32,
             ($value << 30) as u32,
             ($value << 31) as u32,
-            ($value << 32) as u32,
-            ($value << 33) as u32,
-            ($value << 34) as u32,
             ($value >> 0) as u32,
             ($value >> 1) as u32,
-            ($value >> 2) as u32,
             ($value >> 30) as u32,
             ($value >> 31) as u32,
-            ($value >> 32) as u32,
-            ($value >> 33) as u32,
-            ($value >> 34) as u32,
         ]
     };
 }
@@ -66,21 +58,21 @@ pub const INTERESTING_PATTERNS: [u32; 8] = interesting_patterns!(identity);
 pub enum Variants {
     /// const folding in rust-gpu
     ConstFold,
-    // /// `const {}` expr for const eval within rustc
-    // ConstExpr,
+    /// `const {}` expr for const eval within rustc
+    ConstExpr,
     /// dynamic values from `input_patterns`
     DynamicValues,
 }
 
-pub type EvalResult = [[[u32; 16]; 8]; 2];
+pub type EvalResult = [[[u32; 8]; 8]; 2];
 
 impl Variants {
     pub fn eval(&self, input_patterns: &[u32; 8]) -> EvalResult {
         match self {
             Variants::ConstFold => [interesting_patterns!(op_u), interesting_patterns!(op_i)],
-            // Variants::ConstExpr => {
-            //     const { [interesting_patterns!(op_u), interesting_patterns!(op_i)] }
-            // }
+            Variants::ConstExpr => {
+                const { [interesting_patterns!(op_u), interesting_patterns!(op_i)] }
+            }
             Variants::DynamicValues => [
                 [
                     op_u!(input_patterns[0]),

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/lib.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/lib.rs
@@ -1,0 +1,108 @@
+#![cfg_attr(target_arch = "spirv", no_std)]
+#![allow(arithmetic_overflow)]
+
+#[cfg(not(target_arch = "spirv"))]
+pub mod cpu_driver;
+pub mod shader;
+#[cfg(not(target_arch = "spirv"))]
+pub mod shader_driver;
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+
+macro_rules! op_u {
+    ($value:expr) => {
+        [
+            ($value << 0) as u32,
+            ($value << 1) as u32,
+            ($value << 2) as u32,
+            ($value << 30) as u32,
+            ($value << 31) as u32,
+            ($value << 32) as u32,
+            ($value << 33) as u32,
+            ($value << 34) as u32,
+            ($value >> 0) as u32,
+            ($value >> 1) as u32,
+            ($value >> 2) as u32,
+            ($value >> 30) as u32,
+            ($value >> 31) as u32,
+            ($value >> 32) as u32,
+            ($value >> 33) as u32,
+            ($value >> 34) as u32,
+        ]
+    };
+}
+
+macro_rules! op_i {
+    ($value:expr) => {
+        op_u!($value as i32)
+    };
+}
+
+macro_rules! interesting_patterns {
+    ($op_name:ident) => {
+        [
+            $op_name!(0u32),
+            $op_name!(1u32),
+            $op_name!(0xFFFFFFFFu32),
+            $op_name!(0xDEADBEEFu32),
+            $op_name!(0b10011001100110011001100110011001u32),
+            $op_name!(0b10000000000000000000000000000001u32),
+            $op_name!(0x12345678u32),
+            $op_name!(0x87654321u32),
+        ]
+    };
+}
+
+macro_rules! identity {
+    ($expr:expr) => {
+        $expr
+    };
+}
+
+pub const INTERESTING_PATTERNS: [u32; 8] = interesting_patterns!(identity);
+
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+pub enum Variants {
+    /// const folding in rust-gpu
+    ConstFold,
+    // /// `const {}` expr for const eval within rustc
+    // ConstExpr,
+    /// dynamic values from `input_patterns`
+    DynamicValues,
+}
+
+pub type EvalResult = [[[u32; 16]; 8]; 2];
+
+impl Variants {
+    pub fn eval(&self, input_patterns: &[u32; 8]) -> EvalResult {
+        match self {
+            Variants::ConstFold => [interesting_patterns!(op_u), interesting_patterns!(op_i)],
+            // Variants::ConstExpr => {
+            //     const { [interesting_patterns!(op_u), interesting_patterns!(op_i)] }
+            // }
+            Variants::DynamicValues => [
+                [
+                    op_u!(input_patterns[0]),
+                    op_u!(input_patterns[1]),
+                    op_u!(input_patterns[2]),
+                    op_u!(input_patterns[3]),
+                    op_u!(input_patterns[4]),
+                    op_u!(input_patterns[5]),
+                    op_u!(input_patterns[6]),
+                    op_u!(input_patterns[7]),
+                ],
+                [
+                    op_i!(input_patterns[0]),
+                    op_i!(input_patterns[1]),
+                    op_i!(input_patterns[2]),
+                    op_i!(input_patterns[3]),
+                    op_i!(input_patterns[4]),
+                    op_i!(input_patterns[5]),
+                    op_i!(input_patterns[6]),
+                    op_i!(input_patterns[7]),
+                ],
+            ],
+        }
+    }
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/main.rs
@@ -1,0 +1,5 @@
+use const_fold_int_const_fold_cpu::Variants;
+
+fn main() {
+    const_fold_int_const_fold_cpu::cpu_driver::run(Variants::ConstFold);
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/shader.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/shader.rs
@@ -1,0 +1,13 @@
+use crate::{EvalResult, Variants};
+use spirv_std::spirv;
+
+#[spirv(compute(threads(1)))]
+pub fn main_cs(
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] variant: &u32,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] input_patterns: &[u32; 8],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 2)] output: &mut EvalResult,
+) {
+    if let Ok(variant) = Variants::try_from(*variant) {
+        *output = variant.eval(input_patterns);
+    }
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/shader_driver.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-cpu/src/shader_driver.rs
@@ -1,0 +1,19 @@
+use crate::{EvalResult, INTERESTING_PATTERNS, Variants};
+use difftest::config::Config;
+use difftest::scaffold::compute::{BufferConfig, RustComputeShader, WgpuComputeTestMultiBuffer};
+
+pub fn run(variant: Variants) {
+    let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
+
+    let test = WgpuComputeTestMultiBuffer::new(
+        RustComputeShader::default(),
+        [64, 1, 1],
+        Vec::from(&[
+            BufferConfig::read_only(&[u32::from(variant)]),
+            BufferConfig::read_only(&INTERESTING_PATTERNS),
+            BufferConfig::writeback(size_of::<EvalResult>()),
+        ]),
+    );
+
+    test.run_test(&config).unwrap();
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-shader/Cargo.toml
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-shader/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "const_fold_int-const-fold-shader"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["dylib"]
+
+# GPU deps
+[dependencies]
+const_fold_int-const-fold-cpu = { path = "../const-fold-cpu" }
+
+# CPU deps (for the test harness)
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true
+bytemuck.workspace = true

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-shader/src/lib.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-shader/src/lib.rs
@@ -1,0 +1,4 @@
+#![cfg_attr(target_arch = "spirv", no_std)]
+#![allow(arithmetic_overflow)]
+
+pub use const_fold_int_const_fold_cpu::shader::main_cs;

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-shader/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/const-fold-shader/src/main.rs
@@ -1,0 +1,5 @@
+use const_fold_int_const_fold_cpu::Variants;
+
+fn main() {
+    const_fold_int_const_fold_cpu::shader_driver::run(Variants::ConstFold);
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-cpu/Cargo.toml
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-cpu/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "const_fold_int-dynamic-values-cpu"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+# GPU deps
+[dependencies]
+const_fold_int-const-fold-cpu = { path = "../const-fold-cpu" }
+
+# CPU deps (for the test harness)
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true
+bytemuck.workspace = true

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-cpu/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-cpu/src/main.rs
@@ -1,0 +1,5 @@
+use const_fold_int_const_fold_cpu::Variants;
+
+fn main() {
+    const_fold_int_const_fold_cpu::cpu_driver::run(Variants::DynamicValues);
+}

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-shader/Cargo.toml
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-shader/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "const_fold_int-dynamic-values-shader"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["rlib", "dylib"]
+
+# GPU deps
+[dependencies]
+const_fold_int-const-fold-cpu = { path = "../const-fold-cpu" }
+
+# CPU deps (for the test harness)
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true
+bytemuck.workspace = true

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-shader/src/lib.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-shader/src/lib.rs
@@ -1,0 +1,4 @@
+#![cfg_attr(target_arch = "spirv", no_std)]
+#![allow(arithmetic_overflow)]
+
+pub use const_fold_int_const_fold_cpu::shader::main_cs;

--- a/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-shader/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/const_fold_int/dynamic-values-shader/src/main.rs
@@ -1,0 +1,5 @@
+use const_fold_int_const_fold_cpu::Variants;
+
+fn main() {
+    const_fold_int_const_fold_cpu::shader_driver::run(Variants::DynamicValues);
+}


### PR DESCRIPTION
see https://github.com/Rust-GPU/rust-gpu/issues/300

const folding used to only support:
* basic int: add, mul
* casting from https://github.com/Rust-GPU/rust-gpu/pull/302

This PR adds const folding for:
* basic int: sub, div, rem, shr, lshl, ashl, neg, not (+ unchecked variants)
* basic bool: and, or, xor, not
* comparison for int and bool (`icmp`)
* select with const condition

Should probably add some diff tests