### PR TITLE
rustup: update to `nightly-2025-06-23` (~1.89).

### DIFF
--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -18,9 +18,9 @@ use std::{env, fs, mem};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain.toml");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2025-05-09"
+channel = "nightly-2025-06-23"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = 50aa04180709189a03dde5fd1c05751b2625ed37"#;
+# commit_hash = be19eda0dc4c22c5cf5f1b48fd163acf9bd4b0a6"#;
 
 fn rustc_output(arg: &str) -> Result<String, Box<dyn Error>> {
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());
@@ -209,6 +209,13 @@ pub(crate) fn create_object_file(_: &Session) -> Option<write::Object<'static>> 
 #[cfg(any())]
 pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static>> {",
                 );
+                src = src.replace(
+                    "
+pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {",
+                    "
+#[cfg(any())]
+pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {",
+                );
             }
 
             // HACK(eddyb) "typed alloca" patches.
@@ -319,9 +326,6 @@ mod maybe_pqp_cg_ssa;
 
     // HACK(eddyb) `if cfg!(llvm_enzyme)` added upstream for autodiff support.
     println!("cargo::rustc-check-cfg=cfg(llvm_enzyme)");
-
-    // HACK(eddyb) `cfg_attr(bootstrap, ...` used upstream temporarily.
-    println!("cargo::rustc-check-cfg=cfg(bootstrap)");
 
     Ok(())
 }

--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -262,17 +262,17 @@ pub(super) fn elf_e_flags(architecture: Architecture, sess: &Session) -> u32 {",
         }
         if line.starts_with('[') {
             toml_directive = Some(line);
-        } else if toml_directive == Some("[dependencies]") {
-            if let Some((name, _)) = line.split_once(" = ") {
-                // HACK(eddyb) ignore a weird edge case.
-                if name == "thorin-dwp" {
-                    continue;
-                }
-                let extern_crate = format!("extern crate {};", name.replace('-', "_"));
-                if !all_extern_crates.contains(&extern_crate) {
-                    writeln(&mut all_extern_crates, "#[allow(unused_extern_crates)]");
-                    writeln(&mut all_extern_crates, &extern_crate);
-                }
+        } else if toml_directive == Some("[dependencies]")
+            && let Some((name, _)) = line.split_once(" = ")
+        {
+            // HACK(eddyb) ignore a weird edge case.
+            if name == "thorin-dwp" {
+                continue;
+            }
+            let extern_crate = format!("extern crate {};", name.replace('-', "_"));
+            if !all_extern_crates.contains(&extern_crate) {
+                writeln(&mut all_extern_crates, "#[allow(unused_extern_crates)]");
+                writeln(&mut all_extern_crates, &extern_crate);
             }
         }
     }

--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -542,12 +542,11 @@ impl<'tcx> ConvSpirvType<'tcx> for TyAndLayout<'tcx> {
 
             let attrs = AggregatedSpirvAttributes::parse(cx, cx.tcx.get_attrs_unchecked(adt.did()));
 
-            if let Some(intrinsic_type_attr) = attrs.intrinsic_type.map(|attr| attr.value) {
-                if let Ok(spirv_type) =
+            if let Some(intrinsic_type_attr) = attrs.intrinsic_type.map(|attr| attr.value)
+                && let Ok(spirv_type) =
                     trans_intrinsic_type(cx, span, *self, args, intrinsic_type_attr)
-                {
-                    return spirv_type;
-                }
+            {
+                return spirv_type;
             }
         }
 
@@ -613,12 +612,12 @@ impl<'tcx> ConvSpirvType<'tcx> for TyAndLayout<'tcx> {
                 };
                 // FIXME(eddyb) use `ArrayVec` here.
                 let mut field_names = Vec::new();
-                if let TyKind::Adt(adt, _) = self.ty.kind() {
-                    if let Variants::Single { index } = self.variants {
-                        for i in self.fields.index_by_increasing_offset() {
-                            let field = &adt.variants()[index].fields[FieldIdx::new(i)];
-                            field_names.push(field.name);
-                        }
+                if let TyKind::Adt(adt, _) = self.ty.kind()
+                    && let Variants::Single { index } = self.variants
+                {
+                    for i in self.fields.index_by_increasing_offset() {
+                        let field = &adt.variants()[index].fields[FieldIdx::new(i)];
+                        field_names.push(field.name);
                     }
                 }
                 SpirvType::Adt {
@@ -918,10 +917,10 @@ fn trans_struct_or_union<'tcx>(
     let mut field_offsets = Vec::new();
     let mut field_names = Vec::new();
     for i in ty.fields.index_by_increasing_offset() {
-        if let Some(expected_field_idx) = union_case {
-            if i != expected_field_idx.as_usize() {
-                continue;
-            }
+        if let Some(expected_field_idx) = union_case
+            && i != expected_field_idx.as_usize()
+        {
+            continue;
         }
 
         let field_ty = ty.field(cx, i);
@@ -995,10 +994,11 @@ impl<'tcx> From<TyAndLayout<'tcx>> for TyLayoutNameKey<'tcx> {
 impl fmt::Display for TyLayoutNameKey<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.ty)?;
-        if let (TyKind::Adt(def, _), Some(index)) = (self.ty.kind(), self.variant) {
-            if def.is_enum() && !def.variants().is_empty() {
-                write!(f, "::{}", def.variants()[index].name)?;
-            }
+        if let (TyKind::Adt(def, _), Some(index)) = (self.ty.kind(), self.variant)
+            && def.is_enum()
+            && !def.variants().is_empty()
+        {
+            write!(f, "::{}", def.variants()[index].name)?;
         }
         if let (TyKind::Coroutine(_, _), Some(index)) = (self.ty.kind(), self.variant) {
             write!(f, "::{}", CoroutineArgs::variant_name(index))?;

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -12,7 +12,6 @@ pub use spirv_asm::InstructionTable;
 // HACK(eddyb) avoids rewriting all of the imports (see `lib.rs` and `build.rs`).
 use crate::maybe_pqp_cg_ssa as rustc_codegen_ssa;
 
-use crate::abi::ConvSpirvType;
 use crate::builder_spirv::{BuilderCursor, SpirvValue, SpirvValueExt};
 use crate::codegen_cx::CodegenCx;
 use crate::spirv_type::SpirvType;
@@ -193,10 +192,6 @@ impl<'a, 'tcx> DebugInfoBuilderMethods for Builder<'a, 'tcx> {
         todo!()
     }
 
-    fn get_dbg_loc(&self) -> Option<Self::DILocation> {
-        None
-    }
-
     fn insert_reference_to_gdb_debug_scripts_section_global(&mut self) {
         todo!()
     }
@@ -253,10 +248,6 @@ impl<'a, 'tcx> ArgAbiBuilderMethods<'tcx> for Builder<'a, 'tcx> {
                 arg_abi
             ),
         }
-    }
-
-    fn arg_memory_ty(&self, arg_abi: &ArgAbi<'tcx, Ty<'tcx>>) -> Self::Type {
-        arg_abi.layout.spirv_type(self.span(), self)
     }
 }
 

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -126,15 +126,13 @@ impl<'a, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'tcx> {
                 | InlineAsmOperandRef::Label { .. } => (None, None),
             };
 
-            if let Some(in_value) = in_value {
-                if let (BackendRepr::Scalar(scalar), OperandValue::Immediate(in_value_spv)) =
+            if let Some(in_value) = in_value
+                && let (BackendRepr::Scalar(scalar), OperandValue::Immediate(in_value_spv)) =
                     (in_value.layout.backend_repr, &mut in_value.val)
-                {
-                    if let Primitive::Pointer(_) = scalar.primitive() {
-                        let in_value_precise_type = in_value.layout.spirv_type(self.span(), self);
-                        *in_value_spv = self.pointercast(*in_value_spv, in_value_precise_type);
-                    }
-                }
+                && let Primitive::Pointer(_) = scalar.primitive()
+            {
+                let in_value_precise_type = in_value.layout.spirv_type(self.span(), self);
+                *in_value_spv = self.pointercast(*in_value_spv, in_value_precise_type);
             }
             if let Some(out_place) = out_place {
                 let out_place_precise_type = out_place.layout.spirv_type(self.span(), self);

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -168,25 +168,25 @@ impl<'tcx> CodegenCx<'tcx> {
         }
 
         // Check if this is a From trait implementation
-        if let Some(impl_def_id) = self.tcx.impl_of_method(def_id) {
-            if let Some(trait_ref) = self.tcx.impl_trait_ref(impl_def_id) {
-                let trait_def_id = trait_ref.skip_binder().def_id;
+        if let Some(impl_def_id) = self.tcx.impl_of_method(def_id)
+            && let Some(trait_ref) = self.tcx.impl_trait_ref(impl_def_id)
+        {
+            let trait_def_id = trait_ref.skip_binder().def_id;
 
-                // Check if this is the From trait.
-                let trait_path = self.tcx.def_path_str(trait_def_id);
-                if matches!(
-                    trait_path.as_str(),
-                    "core::convert::From" | "std::convert::From"
-                ) {
-                    // Extract the source and target types from the trait substitutions
-                    let trait_args = trait_ref.skip_binder().args;
-                    if let (Some(target_ty), Some(source_ty)) =
-                        (trait_args.types().nth(0), trait_args.types().nth(1))
-                    {
-                        self.from_trait_impls
-                            .borrow_mut()
-                            .insert(def_id, (source_ty, target_ty));
-                    }
+            // Check if this is the From trait.
+            let trait_path = self.tcx.def_path_str(trait_def_id);
+            if matches!(
+                trait_path.as_str(),
+                "core::convert::From" | "std::convert::From"
+            ) {
+                // Extract the source and target types from the trait substitutions
+                let trait_args = trait_ref.skip_binder().args;
+                if let (Some(target_ty), Some(source_ty)) =
+                    (trait_args.types().nth(0), trait_args.types().nth(1))
+                {
+                    self.from_trait_impls
+                        .borrow_mut()
+                        .insert(def_id, (source_ty, target_ty));
                 }
             }
         }
@@ -251,12 +251,12 @@ impl<'tcx> CodegenCx<'tcx> {
                     _ => return None,
                 })
             });
-            if let Some(spec) = spec {
-                if let Some((ty,)) = instance.args.types().collect_tuple() {
-                    self.fmt_rt_arg_new_fn_ids_to_ty_and_spec
-                        .borrow_mut()
-                        .insert(fn_id, (ty, spec));
-                }
+            if let Some(spec) = spec
+                && let Some((ty,)) = instance.args.types().collect_tuple()
+            {
+                self.fmt_rt_arg_new_fn_ids_to_ty_and_spec
+                    .borrow_mut()
+                    .insert(fn_id, (ty, spec));
             }
         }
 

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -894,10 +894,6 @@ impl<'tcx> MiscCodegenMethods<'tcx> for CodegenCx<'tcx> {
         self.tcx.sess
     }
 
-    fn codegen_unit(&self) -> &'tcx CodegenUnit<'tcx> {
-        self.codegen_unit
-    }
-
     fn set_frame_pointer_type(&self, _llfn: Self::Function) {
         todo!()
     }

--- a/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/mod.rs
@@ -774,16 +774,16 @@ impl CodegenArgs {
                 // with just the filename component of the path.
                 if inst.class.opcode == Op::String {
                     let path = Path::new(inst.operands[0].unwrap_literal_string());
-                    if path.is_absolute() {
-                        if let Some(file_name) = path.file_name() {
-                            let mut inst = inst.clone();
-                            inst.operands[0] = Operand::LiteralString(format!(
-                                "$OPSTRING_FILENAME/{}",
-                                file_name.to_string_lossy(),
-                            ));
-                            eprintln!("{}", inst.disassemble());
-                            continue;
-                        }
+                    if path.is_absolute()
+                        && let Some(file_name) = path.file_name()
+                    {
+                        let mut inst = inst.clone();
+                        inst.operands[0] = Operand::LiteralString(format!(
+                            "$OPSTRING_FILENAME/{}",
+                            file_name.to_string_lossy(),
+                        ));
+                        eprintln!("{}", inst.disassemble());
+                        continue;
                     }
                 }
                 eprintln!("{}", inst.disassemble());

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -178,12 +178,12 @@ fn dump_mir(tcx: TyCtxt<'_>, mono_items: &[(MonoItem<'_>, MonoItemData)], path: 
     create_dir_all(path.parent().unwrap()).unwrap();
     let mut file = File::create(path).unwrap();
     for &(mono_item, _) in mono_items {
-        if let MonoItem::Fn(instance) = mono_item {
-            if matches!(instance.def, InstanceKind::Item(_)) {
-                let mut mir = Cursor::new(Vec::new());
-                if write_mir_pretty(tcx, Some(instance.def_id()), &mut mir).is_ok() {
-                    writeln!(file, "{}", String::from_utf8(mir.into_inner()).unwrap()).unwrap();
-                }
+        if let MonoItem::Fn(instance) = mono_item
+            && matches!(instance.def, InstanceKind::Item(_))
+        {
+            let mut mir = Cursor::new(Vec::new());
+            if write_mir_pretty(tcx, Some(instance.def_id()), &mut mir).is_ok() {
+                writeln!(file, "{}", String::from_utf8(mir.into_inner()).unwrap()).unwrap();
             }
         }
     }

--- a/crates/rustc_codegen_spirv/src/linker/dce.rs
+++ b/crates/rustc_codegen_spirv/src/linker/dce.rs
@@ -57,10 +57,10 @@ fn all_inst_iter(func: &Function) -> impl DoubleEndedIterator<Item = &Instructio
 fn spread_roots(module: &Module, rooted: &mut FxIndexSet<Word>) -> bool {
     let mut any = false;
     for inst in module.global_inst_iter() {
-        if let Some(id) = inst.result_id {
-            if rooted.contains(&id) {
-                any |= root(inst, rooted);
-            }
+        if let Some(id) = inst.result_id
+            && rooted.contains(&id)
+        {
+            any |= root(inst, rooted);
         }
     }
     for func in &module.functions {
@@ -72,10 +72,10 @@ fn spread_roots(module: &Module, rooted: &mut FxIndexSet<Word>) -> bool {
             for inst in all_inst_iter(func).rev() {
                 if !instruction_is_pure(inst) {
                     any |= root(inst, rooted);
-                } else if let Some(id) = inst.result_id {
-                    if rooted.contains(&id) {
-                        any |= root(inst, rooted);
-                    }
+                } else if let Some(id) = inst.result_id
+                    && rooted.contains(&id)
+                {
+                    any |= root(inst, rooted);
                 }
             }
         }

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -56,10 +56,10 @@ pub fn remove_duplicate_ext_inst_imports(module: &mut Module) {
 
     // Then rewrite all OpExtInst referencing the rewritten IDs
     for inst in module.all_inst_iter_mut() {
-        if inst.class.opcode == Op::ExtInst {
-            if let Operand::IdRef(ref mut id) = inst.operands[0] {
-                *id = rewrite_rules.get(id).copied().unwrap_or(*id);
-            }
+        if inst.class.opcode == Op::ExtInst
+            && let Operand::IdRef(ref mut id) = inst.operands[0]
+        {
+            *id = rewrite_rules.get(id).copied().unwrap_or(*id);
         }
     }
 }
@@ -201,11 +201,11 @@ pub fn remove_duplicate_types(module: &mut Module) {
     let names = gather_names(&module.debug_names);
 
     for inst in &mut module.types_global_values {
-        if inst.class.opcode == Op::TypeForwardPointer {
-            if let Operand::IdRef(id) = inst.operands[0] {
-                unresolved_forward_pointers.insert(id);
-                continue;
-            }
+        if inst.class.opcode == Op::TypeForwardPointer
+            && let Operand::IdRef(id) = inst.operands[0]
+        {
+            unresolved_forward_pointers.insert(id);
+            continue;
         }
         if inst.class.opcode == Op::TypePointer
             && unresolved_forward_pointers.contains(&inst.result_id.unwrap())

--- a/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
+++ b/crates/rustc_codegen_spirv/src/linker/import_export_link.rs
@@ -34,16 +34,16 @@ fn find_import_export_pairs_and_killed_params(
         .map(|(z, _)| z)
         .collect();
     for inst in module.global_inst_iter() {
-        if let Some(result_id) = inst.result_id {
-            if !zombie_infected.contains(&result_id) {
-                let mut id_operands = inst.operands.iter().filter_map(|o| o.id_ref_any());
-                // NOTE(eddyb) this takes advantage of the fact that the module
-                // is ordered def-before-use (with the minor exception of forward
-                // references for recursive data, which are not fully supported),
-                // to be able to propagate "zombie infection" in one pass.
-                if id_operands.any(|id| zombie_infected.contains(&id)) {
-                    zombie_infected.insert(result_id);
-                }
+        if let Some(result_id) = inst.result_id
+            && !zombie_infected.contains(&result_id)
+        {
+            let mut id_operands = inst.operands.iter().filter_map(|o| o.id_ref_any());
+            // NOTE(eddyb) this takes advantage of the fact that the module
+            // is ordered def-before-use (with the minor exception of forward
+            // references for recursive data, which are not fully supported),
+            // to be able to propagate "zombie infection" in one pass.
+            if id_operands.any(|id| zombie_infected.contains(&id)) {
+                zombie_infected.insert(result_id);
             }
         }
     }
@@ -202,17 +202,17 @@ fn check_tys_equal(
 
 fn replace_all_uses_with(module: &mut Module, rules: &FxHashMap<u32, u32>) {
     module.all_inst_iter_mut().for_each(|inst| {
-        if let Some(result_type) = &mut inst.result_type {
-            if let Some(&rewrite) = rules.get(result_type) {
-                *result_type = rewrite;
-            }
+        if let Some(result_type) = &mut inst.result_type
+            && let Some(&rewrite) = rules.get(result_type)
+        {
+            *result_type = rewrite;
         }
 
         inst.operands.iter_mut().for_each(|op| {
-            if let Some(w) = op.id_ref_any_mut() {
-                if let Some(&rewrite) = rules.get(w) {
-                    *w = rewrite;
-                }
+            if let Some(w) = op.id_ref_any_mut()
+                && let Some(&rewrite) = rules.get(w)
+            {
+                *w = rewrite;
             }
         });
     });

--- a/crates/rustc_codegen_spirv/src/linker/inline.rs
+++ b/crates/rustc_codegen_spirv/src/linker/inline.rs
@@ -510,13 +510,13 @@ impl Inliner<'_, '_> {
         // AFAIK there is no case where keeping decorations on inline wouldn't be valid.
         for annotation_idx in 0..self.annotations.len() {
             let inst = &self.annotations[annotation_idx];
-            if let [Operand::IdRef(target), ..] = inst.operands[..] {
-                if let Some(&rewritten_target) = rewrite_rules.get(&target) {
-                    // Copy decoration instruction and push it.
-                    let mut cloned_inst = inst.clone();
-                    cloned_inst.operands[0] = Operand::IdRef(rewritten_target);
-                    self.annotations.push(cloned_inst);
-                }
+            if let [Operand::IdRef(target), ..] = inst.operands[..]
+                && let Some(&rewritten_target) = rewrite_rules.get(&target)
+            {
+                // Copy decoration instruction and push it.
+                let mut cloned_inst = inst.clone();
+                cloned_inst.operands[0] = Operand::IdRef(rewritten_target);
+                self.annotations.push(cloned_inst);
             }
         }
     }
@@ -664,10 +664,10 @@ impl Inliner<'_, '_> {
             // HACK(eddyb) new IDs should be generated earlier, to avoid pushing
             // callee IDs to `call_result_phi.operands` only to rewrite them here.
             for op in &mut call_result_phi.operands {
-                if let Some(id) = op.id_ref_any_mut() {
-                    if let Some(&rewrite) = rewrite_rules.get(id) {
-                        *id = rewrite;
-                    }
+                if let Some(id) = op.id_ref_any_mut()
+                    && let Some(&rewrite) = rewrite_rules.get(id)
+                {
+                    *id = rewrite;
                 }
             }
 
@@ -699,10 +699,10 @@ impl Inliner<'_, '_> {
                 };
                 for reaching_inst in reaching_insts {
                     for op in &mut reaching_inst.operands {
-                        if let Some(id) = op.id_ref_any_mut() {
-                            if *id == call_result_id {
-                                *id = returned_value_id;
-                            }
+                        if let Some(id) = op.id_ref_any_mut()
+                            && *id == call_result_id
+                        {
+                            *id = returned_value_id;
                         }
                     }
                 }

--- a/crates/rustc_codegen_spirv/src/linker/param_weakening.rs
+++ b/crates/rustc_codegen_spirv/src/linker/param_weakening.rs
@@ -48,16 +48,16 @@ pub fn remove_unused_params(module: Module) -> Module {
             };
 
             for (i, operand) in operands.iter().enumerate() {
-                if let Some(ignore_operands) = ignore_operands {
-                    if ignore_operands.contains(i) {
-                        continue;
-                    }
+                if let Some(ignore_operands) = ignore_operands
+                    && ignore_operands.contains(i)
+                {
+                    continue;
                 }
 
-                if let Operand::IdRef(id) = operand {
-                    if let Some(&param_idx) = params_id_to_idx.get(id) {
-                        unused_params.remove(param_idx);
-                    }
+                if let Operand::IdRef(id) = operand
+                    && let Some(&param_idx) = params_id_to_idx.get(id)
+                {
+                    unused_params.remove(param_idx);
                 }
             }
         }
@@ -82,17 +82,16 @@ pub fn remove_unused_params(module: Module) -> Module {
         }
 
         for inst in func.all_inst_iter_mut() {
-            if inst.class.opcode == Op::FunctionCall {
-                if let Some(unused_callee_params) =
+            if inst.class.opcode == Op::FunctionCall
+                && let Some(unused_callee_params) =
                     unused_params_per_func_id.get(&inst.operands[0].unwrap_id_ref())
-                {
-                    inst.operands = mem::take(&mut inst.operands)
-                        .into_iter()
-                        .enumerate()
-                        .filter(|&(i, _)| i == 0 || !unused_callee_params.contains(i - 1))
-                        .map(|(_, o)| o)
-                        .collect();
-                }
+            {
+                inst.operands = mem::take(&mut inst.operands)
+                    .into_iter()
+                    .enumerate()
+                    .filter(|&(i, _)| i == 0 || !unused_callee_params.contains(i - 1))
+                    .map(|(_, o)| o)
+                    .collect();
             }
         }
 

--- a/crates/rustc_codegen_spirv/src/linker/peephole_opts.rs
+++ b/crates/rustc_codegen_spirv/src/linker/peephole_opts.rs
@@ -344,20 +344,20 @@ fn process_instruction(
 
     // Fun little optimization: SPIR-V has a fancy OpVectorTimesScalar instruction. If we have a
     // vector times a collection of scalars, and the scalars are all the same, reduce it!
-    if operation_opcode == Op::FMul && composite_arguments.len() == 2 {
-        if let (&IdentifiedOperand::Vector(composite), IdentifiedOperand::Scalars(scalars))
+    if operation_opcode == Op::FMul
+        && composite_arguments.len() == 2
+        && let (&IdentifiedOperand::Vector(composite), IdentifiedOperand::Scalars(scalars))
         | (IdentifiedOperand::Scalars(scalars), &IdentifiedOperand::Vector(composite)) =
             (&composite_arguments[0], &composite_arguments[1])
-        {
-            let scalar = scalars[0];
-            if scalars.iter().skip(1).all(|&s| s == scalar) {
-                return Some(Instruction::new(
-                    Op::VectorTimesScalar,
-                    inst.result_type,
-                    inst.result_id,
-                    vec![Operand::IdRef(composite), Operand::IdRef(scalar)],
-                ));
-            }
+    {
+        let scalar = scalars[0];
+        if scalars.iter().skip(1).all(|&s| s == scalar) {
+            return Some(Instruction::new(
+                Op::VectorTimesScalar,
+                inst.result_type,
+                inst.result_id,
+                vec![Operand::IdRef(composite), Operand::IdRef(scalar)],
+            ));
         }
     }
 

--- a/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
+++ b/crates/rustc_codegen_spirv/src/linker/simple_passes.rs
@@ -69,12 +69,11 @@ pub fn block_ordering_pass(func: &mut Function) {
         let mut edges = outgoing_edges(current_block).collect::<Vec<_>>();
         // HACK(eddyb) treat `OpSelectionMerge` as an edge, in case it points
         // to an otherwise-unreachable block.
-        if let Some(before_last_idx) = current_block.instructions.len().checked_sub(2) {
-            if let Some(before_last) = current_block.instructions.get(before_last_idx) {
-                if before_last.class.opcode == Op::SelectionMerge {
-                    edges.push(before_last.operands[0].unwrap_id_ref());
-                }
-            }
+        if let Some(before_last_idx) = current_block.instructions.len().checked_sub(2)
+            && let Some(before_last) = current_block.instructions.get(before_last_idx)
+            && before_last.class.opcode == Op::SelectionMerge
+        {
+            edges.push(before_last.operands[0].unwrap_id_ref());
         }
         // Reverse the order, so reverse-postorder keeps things tidy
         for &outgoing in edges.iter().rev() {
@@ -308,23 +307,23 @@ pub fn check_type_capabilities(sess: &Session, module: &Module) -> Result<()> {
                 let signedness = inst.operands[1].unwrap_literal_bit32() != 0;
                 let type_name = if signedness { "i" } else { "u" };
 
-                if let Some(required_cap) = capability_for_int_width(width) {
-                    if !declared_capabilities.contains(&required_cap) {
-                        errors.push(format!(
-                            "`{type_name}{width}` type used without `OpCapability {required_cap:?}`"
-                        ));
-                    }
+                if let Some(required_cap) = capability_for_int_width(width)
+                    && !declared_capabilities.contains(&required_cap)
+                {
+                    errors.push(format!(
+                        "`{type_name}{width}` type used without `OpCapability {required_cap:?}`"
+                    ));
                 }
             }
             Op::TypeFloat => {
                 let width = inst.operands[0].unwrap_literal_bit32();
 
-                if let Some(required_cap) = capability_for_float_width(width) {
-                    if !declared_capabilities.contains(&required_cap) {
-                        errors.push(format!(
-                            "`f{width}` type used without `OpCapability {required_cap:?}`"
-                        ));
-                    }
+                if let Some(required_cap) = capability_for_float_width(width)
+                    && !declared_capabilities.contains(&required_cap)
+                {
+                    errors.push(format!(
+                        "`f{width}` type used without `OpCapability {required_cap:?}`"
+                    ));
                 }
             }
             _ => {}

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/controlflow.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/controlflow.rs
@@ -113,20 +113,17 @@ pub fn convert_custom_aborts_to_unstructured_returns_in_entry_points(
                 .filter_map(|func_at_inst| {
                     let data_inst_def = func_at_inst.def();
                     let data_inst_form_def = &cx[data_inst_def.form];
-                    if let DataInstKind::SpvInst(spv_inst) = &data_inst_form_def.kind {
-                        if spv_inst.opcode == wk.OpLoad {
-                            if let Value::Const(ct) = data_inst_def.inputs[0] {
-                                if let ConstKind::PtrToGlobalVar(gv) = cx[ct].kind {
-                                    if interface_global_vars.contains(&gv) {
-                                        return Some((
-                                            gv,
-                                            data_inst_form_def.output_type.unwrap(),
-                                            Value::DataInstOutput(func_at_inst.position),
-                                        ));
-                                    }
-                                }
-                            }
-                        }
+                    if let DataInstKind::SpvInst(spv_inst) = &data_inst_form_def.kind
+                        && spv_inst.opcode == wk.OpLoad
+                        && let Value::Const(ct) = data_inst_def.inputs[0]
+                        && let ConstKind::PtrToGlobalVar(gv) = cx[ct].kind
+                        && interface_global_vars.contains(&gv)
+                    {
+                        return Some((
+                            gv,
+                            data_inst_form_def.output_type.unwrap(),
+                            Value::DataInstOutput(func_at_inst.position),
+                        ));
                     }
                     None
                 });

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/diagnostics.rs
@@ -404,28 +404,28 @@ impl DiagnosticReporter<'_> {
             });
 
         let attrs_def = &self.cx[attrs];
-        if !self.linker_options.early_report_zombies {
-            if let Some(zombie) = try_decode_custom_decoration::<ZombieDecoration<'_>>(attrs_def) {
-                let ZombieDecoration { reason } = zombie.decode();
-                let def_span = current_def
-                    .and_then(|def| def.to_rustc_span(self.cx, &mut self.span_regen))
-                    .or_else(|| {
-                        // If there's no clear source for the span, try to get
-                        // it from the same attrs as the zombie, which could
-                        // be missing from `use_stack` in some edge cases
-                        // (such as zombied function parameters).
-                        self.span_regen.spirt_attrs_to_rustc_span(self.cx, attrs)
-                    })
-                    .unwrap_or(DUMMY_SP);
-                let mut err = self
-                    .sess
-                    .dcx()
-                    .struct_span_err(def_span, reason.to_string());
-                for use_origin in use_stack_for_def.iter().rev() {
-                    use_origin.note(self.cx, &mut self.span_regen, &mut err);
-                }
-                self.overall_result = Err(err.emit());
+        if !self.linker_options.early_report_zombies
+            && let Some(zombie) = try_decode_custom_decoration::<ZombieDecoration<'_>>(attrs_def)
+        {
+            let ZombieDecoration { reason } = zombie.decode();
+            let def_span = current_def
+                .and_then(|def| def.to_rustc_span(self.cx, &mut self.span_regen))
+                .or_else(|| {
+                    // If there's no clear source for the span, try to get
+                    // it from the same attrs as the zombie, which could
+                    // be missing from `use_stack` in some edge cases
+                    // (such as zombied function parameters).
+                    self.span_regen.spirt_attrs_to_rustc_span(self.cx, attrs)
+                })
+                .unwrap_or(DUMMY_SP);
+            let mut err = self
+                .sess
+                .dcx()
+                .struct_span_err(def_span, reason.to_string());
+            for use_origin in use_stack_for_def.iter().rev() {
+                use_origin.note(self.cx, &mut self.span_regen, &mut err);
             }
+            self.overall_result = Err(err.emit());
         }
 
         let diags = attrs_def.attrs.iter().flat_map(|attr| match attr {
@@ -623,69 +623,68 @@ impl<'a> Visitor<'a> for DiagnosticReporter<'a> {
                     ext_set,
                     inst: ext_inst,
                 } = self.cx[data_inst_def.form].kind
+                    && ext_set == self.custom_ext_inst_set
                 {
-                    if ext_set == self.custom_ext_inst_set {
-                        match CustomOp::decode(ext_inst) {
-                            CustomOp::SetDebugSrcLoc => {
-                                *last_debug_src_loc_inst = Some(data_inst_def);
-                            }
-                            CustomOp::ClearDebugSrcLoc => {
-                                *last_debug_src_loc_inst = None;
-                            }
-                            op => match op.with_operands(&data_inst_def.inputs) {
-                                CustomInst::SetDebugSrcLoc { .. }
-                                | CustomInst::ClearDebugSrcLoc => unreachable!(),
-                                CustomInst::PushInlinedCallFrame { callee_name } => {
-                                    // Treat this like a call, in the caller.
-                                    replace_origin(self, IntraFuncUseOrigin::CallCallee);
-
-                                    let const_kind = |v: Value| match v {
-                                        Value::Const(ct) => &self.cx[ct].kind,
-                                        _ => unreachable!(),
-                                    };
-                                    let const_str = |v: Value| match const_kind(v) {
-                                        &ConstKind::SpvStringLiteralForExtInst(s) => s,
-                                        _ => unreachable!(),
-                                    };
-                                    self.use_stack.push(UseOrigin::IntraFunc {
-                                        func_attrs: AttrSet::default(),
-                                        special_func: Some(SpecialFunc::Inlined {
-                                            callee_name: const_str(callee_name),
-                                        }),
-                                        last_debug_src_loc_inst: None,
-                                        inst_attrs: AttrSet::default(),
-                                        origin: IntraFuncUseOrigin::Other,
-                                    });
-                                }
-                                CustomInst::PopInlinedCallFrame => {
-                                    match self.use_stack.last() {
-                                        Some(UseOrigin::IntraFunc { special_func, .. }) => {
-                                            if let Some(SpecialFunc::Inlined { .. }) = special_func
-                                            {
-                                                self.use_stack.pop().unwrap();
-                                                // Undo what `PushInlinedCallFrame` did to the
-                                                // original `UseOrigin::IntraFunc`.
-                                                replace_origin(self, IntraFuncUseOrigin::Other);
-                                            } else {
-                                                // HACK(eddyb) synthesize a diagnostic to report right away.
-                                                self.report_from_attrs(
-                                                    AttrSet::default().append_diag(
-                                                        self.cx,
-                                                        Diag::bug([
-                                                            "`PopInlinedCallFrame` without an \
-                                                             inlined call frame in `use_stack`"
-                                                                .into(),
-                                                        ]),
-                                                    ),
-                                                );
-                                            }
-                                        }
-                                        _ => unreachable!(),
-                                    }
-                                }
-                                CustomInst::Abort { .. } => {}
-                            },
+                    match CustomOp::decode(ext_inst) {
+                        CustomOp::SetDebugSrcLoc => {
+                            *last_debug_src_loc_inst = Some(data_inst_def);
                         }
+                        CustomOp::ClearDebugSrcLoc => {
+                            *last_debug_src_loc_inst = None;
+                        }
+                        op => match op.with_operands(&data_inst_def.inputs) {
+                            CustomInst::SetDebugSrcLoc { .. } | CustomInst::ClearDebugSrcLoc => {
+                                unreachable!()
+                            }
+                            CustomInst::PushInlinedCallFrame { callee_name } => {
+                                // Treat this like a call, in the caller.
+                                replace_origin(self, IntraFuncUseOrigin::CallCallee);
+
+                                let const_kind = |v: Value| match v {
+                                    Value::Const(ct) => &self.cx[ct].kind,
+                                    _ => unreachable!(),
+                                };
+                                let const_str = |v: Value| match const_kind(v) {
+                                    &ConstKind::SpvStringLiteralForExtInst(s) => s,
+                                    _ => unreachable!(),
+                                };
+                                self.use_stack.push(UseOrigin::IntraFunc {
+                                    func_attrs: AttrSet::default(),
+                                    special_func: Some(SpecialFunc::Inlined {
+                                        callee_name: const_str(callee_name),
+                                    }),
+                                    last_debug_src_loc_inst: None,
+                                    inst_attrs: AttrSet::default(),
+                                    origin: IntraFuncUseOrigin::Other,
+                                });
+                            }
+                            CustomInst::PopInlinedCallFrame => {
+                                match self.use_stack.last() {
+                                    Some(UseOrigin::IntraFunc { special_func, .. }) => {
+                                        if let Some(SpecialFunc::Inlined { .. }) = special_func {
+                                            self.use_stack.pop().unwrap();
+                                            // Undo what `PushInlinedCallFrame` did to the
+                                            // original `UseOrigin::IntraFunc`.
+                                            replace_origin(self, IntraFuncUseOrigin::Other);
+                                        } else {
+                                            // HACK(eddyb) synthesize a diagnostic to report right away.
+                                            self.report_from_attrs(
+                                                AttrSet::default().append_diag(
+                                                    self.cx,
+                                                    Diag::bug([
+                                                        "`PopInlinedCallFrame` without an \
+                                                             inlined call frame in `use_stack`"
+                                                            .into(),
+                                                    ]),
+                                                ),
+                                            );
+                                        }
+                                    }
+                                    _ => unreachable!(),
+                                }
+                            }
+                            CustomInst::Abort { .. } => {}
+                        },
                     }
                 }
             }

--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
@@ -313,10 +313,9 @@ fn remove_unused_values_in_func(cx: &Context, func_def_body: &mut FuncDefBody) {
                 region,
                 input_idx: _,
             } = v
+                && region == self.func_body_region
             {
-                if region == self.func_body_region {
-                    return;
-                }
+                return;
             }
             if self.used.insert(v) {
                 self.queue.push_back(v);
@@ -461,10 +460,9 @@ fn remove_unused_values_in_func(cx: &Context, func_def_body: &mut FuncDefBody) {
                 while let Some(mut func_at_inst) = func_at_inst_iter.next() {
                     if let DataInstKind::SpvInst(spv_inst) =
                         &cx[func_at_inst.reborrow().def().form].kind
+                        && spv_inst.opcode == wk.OpNop
                     {
-                        if spv_inst.opcode == wk.OpNop {
-                            continue;
-                        }
+                        continue;
                     }
                     if !used_values.contains(&Value::DataInstOutput(func_at_inst.position)) {
                         // Replace the removed `DataInstDef` itself with `OpNop`,

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -848,6 +848,13 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
         // GVN currently can lead to the memcpy-out-of-const-alloc-global-var
         // pattern, even for `ScalarPair` (e.g. `return None::<u32>;`).
         "-Zmir-enable-passes=-GVN".to_string(),
+        // HACK(eddyb) avoid ever reusing instantiations from `compiler_builtins`
+        // which is special-cased to turn calls to functions that never return,
+        // into aborts, and this applies to the panics of UB-checking helpers
+        // (https://github.com/rust-lang/rust/pull/122580#issuecomment-3033026194)
+        // but while upstream that only loses the panic message, for us it's even
+        // worse, as we lose the chance to remove otherwise-dead `fmt::Arguments`.
+        "-Zshare-generics=off".to_string(),
     ];
 
     // Wrapper for `env::var` that appropriately informs Cargo of the dependency.

--- a/crates/spirv-std/macros/src/image.rs
+++ b/crates/spirv-std/macros/src/image.rs
@@ -238,7 +238,9 @@ impl Parse for ImageType {
             )
         })?;
 
-        if format.is_some() && format != Some(ImageFormat::Unknown) {
+        if let Some(format) = &format
+            && *format != ImageFormat::Unknown
+        {
             if sampled_type.is_some() {
                 return Err(syn::Error::new(
                     starting_span,
@@ -254,7 +256,6 @@ impl Parse for ImageType {
                 ));
             }
 
-            let format = format.as_ref().unwrap();
             sampled_type = Some(match format {
                 ImageFormat::Rgba32f
                 | ImageFormat::Rgba16f

--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -529,14 +529,12 @@ impl SampleImplRewriter {
 
         // use the type to insert it into the generic argument of the trait we're implementing
         // e.g., `ImageWithMethods<Dummy>` becomes `ImageWithMethods<SampleParams<SomeTy<B>, NoneTy, NoneTy>>`
-        if let Some(t) = &mut new_impl.trait_ {
-            if let syn::PathArguments::AngleBracketed(a) =
+        if let Some(t) = &mut new_impl.trait_
+            && let syn::PathArguments::AngleBracketed(a) =
                 &mut t.1.segments.last_mut().unwrap().arguments
-            {
-                if let Some(syn::GenericArgument::Type(t)) = a.args.last_mut() {
-                    *t = ty.clone();
-                }
-            }
+            && let Some(syn::GenericArgument::Type(t)) = a.args.last_mut()
+        {
+            *t = ty.clone();
         }
 
         // rewrite the implemented functions

--- a/crates/spirv-std/src/arch/demote_to_helper_invocation_ext.rs
+++ b/crates/spirv-std/src/arch/demote_to_helper_invocation_ext.rs
@@ -5,7 +5,7 @@ use core::arch::asm;
 /// `discard()` in HLSL. Any stores to memory after this instruction are
 /// suppressed and the fragment does not write outputs to the framebuffer.
 ///
-/// Unlike [super::kill], this does not necessarily terminate the invocation. It
+/// Unlike [`super::kill`], this does not necessarily terminate the invocation. It
 /// is not considered a flow control instruction (flow control does not become
 /// non-uniform) and does not terminate the block.
 ///

--- a/crates/spirv-std/src/arch/mesh_shading.rs
+++ b/crates/spirv-std/src/arch/mesh_shading.rs
@@ -16,7 +16,7 @@ use core::arch::asm;
 /// There must not be any control flow path to an output write that is not preceded
 /// by this instruction.
 ///
-/// This instruction is only valid in the *MeshEXT* Execution Model.
+/// This instruction is only valid in the *`MeshEXT`* Execution Model.
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpSetMeshOutputsEXT")]
 #[inline]
@@ -38,7 +38,7 @@ pub unsafe fn set_mesh_outputs_ext(vertex_count: u32, primitive_count: u32) {
 /// for the launch of child mesh tasks. See Vulkan API specification for more detail.
 ///
 /// 'Payload' is an optional pointer to the payload structure to pass to the generated mesh shader invocations.
-/// 'Payload' must be the result of an *OpVariable* with a storage class of *TaskPayloadWorkgroupEXT*.
+/// 'Payload' must be the result of an *`OpVariable`* with a storage class of *`TaskPayloadWorkgroupEXT`*.
 ///
 /// The arguments are taken from the first invocation in each workgroup.
 /// Any invocation must execute this instruction exactly once and under uniform
@@ -46,14 +46,14 @@ pub unsafe fn set_mesh_outputs_ext(vertex_count: u32, primitive_count: u32) {
 /// This instruction also serves as an *OpControlBarrier* instruction, and also
 /// performs and adheres to the description and semantics of an *OpControlBarrier*
 /// instruction with the 'Execution' and 'Memory' operands set to *Workgroup* and
-/// the 'Semantics' operand set to a combination of *WorkgroupMemory* and
-/// *AcquireRelease*.
+/// the 'Semantics' operand set to a combination of *`WorkgroupMemory`* and
+/// *`AcquireRelease`*.
 /// Ceases all further processing: Only instructions executed before
-/// *OpEmitMeshTasksEXT* have observable side effects.
+/// *`OpEmitMeshTasksEXT`* have observable side effects.
 ///
 /// This instruction must be the last instruction in a block.
 ///
-/// This instruction is only valid in the *TaskEXT* Execution Model.
+/// This instruction is only valid in the *`TaskEXT`* Execution Model.
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpEmitMeshTasksEXT")]
 #[inline]
@@ -77,7 +77,7 @@ pub unsafe fn emit_mesh_tasks_ext(group_count_x: u32, group_count_y: u32, group_
 /// for the launch of child mesh tasks. See Vulkan API specification for more detail.
 ///
 /// 'Payload' is an optional pointer to the payload structure to pass to the generated mesh shader invocations.
-/// 'Payload' must be the result of an *OpVariable* with a storage class of *TaskPayloadWorkgroupEXT*.
+/// 'Payload' must be the result of an *`OpVariable`* with a storage class of *`TaskPayloadWorkgroupEXT`*.
 ///
 /// The arguments are taken from the first invocation in each workgroup.
 /// Any invocation must execute this instruction exactly once and under uniform
@@ -85,14 +85,14 @@ pub unsafe fn emit_mesh_tasks_ext(group_count_x: u32, group_count_y: u32, group_
 /// This instruction also serves as an *OpControlBarrier* instruction, and also
 /// performs and adheres to the description and semantics of an *OpControlBarrier*
 /// instruction with the 'Execution' and 'Memory' operands set to *Workgroup* and
-/// the 'Semantics' operand set to a combination of *WorkgroupMemory* and
-/// *AcquireRelease*.
+/// the 'Semantics' operand set to a combination of *`WorkgroupMemory`* and
+/// *`AcquireRelease`*.
 /// Ceases all further processing: Only instructions executed before
-/// *OpEmitMeshTasksEXT* have observable side effects.
+/// *`OpEmitMeshTasksEXT`* have observable side effects.
 ///
 /// This instruction must be the last instruction in a block.
 ///
-/// This instruction is only valid in the *TaskEXT* Execution Model.
+/// This instruction is only valid in the *`TaskEXT`* Execution Model.
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpEmitMeshTasksEXT")]
 #[inline]

--- a/crates/spirv-std/src/arch/ray_tracing.rs
+++ b/crates/spirv-std/src/arch/ray_tracing.rs
@@ -14,7 +14,7 @@ use core::arch::asm;
 /// - `hit_kind` is the integer hit kind reported back to other shaders and
 ///   accessible by the `hit kind` builtin.
 ///
-/// This instruction is allowed only in IntersectionKHR execution model.
+/// This instruction is allowed only in `IntersectionKHR` execution model.
 ///
 /// This instruction is a shader call instruction which may invoke shaders with
 /// the `any_hit` execution model.

--- a/crates/spirv-std/src/arch/subgroup.rs
+++ b/crates/spirv-std/src/arch/subgroup.rs
@@ -844,7 +844,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -875,7 +875,7 @@ Result Type must be a scalar or vector of floating-point type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type. The method used to perform the group operation on the contributed Value(s) from active invocations is implementation defined.
 
@@ -908,7 +908,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 1. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 1. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -939,7 +939,7 @@ Result Type must be a scalar or vector of floating-point type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 1. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 1. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type. The method used to perform the group operation on the contributed Value(s) from active invocations is implementation defined.
 
@@ -959,7 +959,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is INT_MAX.
+The identity I for Operation is `INT_MAX`.
 
 The type of `value` must be the same as Result Type.
 
@@ -972,7 +972,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is INT_MAX. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is `INT_MAX`. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -990,7 +990,7 @@ Result Type must be a scalar or vector of integer type, whose Signedness operand
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is UINT_MAX.
+The identity I for Operation is `UINT_MAX`.
 
 The type of `value` must be the same as Result Type.
 
@@ -1003,7 +1003,7 @@ Result Type must be a scalar or vector of integer type, whose Signedness operand
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is UINT_MAX. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is `UINT_MAX`. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1034,7 +1034,7 @@ Result Type must be a scalar or vector of floating-point type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is +INF. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is +INF. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type. The method used to perform the group operation on the contributed Value(s) from active invocations is implementation defined. From the set of Value(s) provided by active invocations within a subgroup, if for any two Values one of them is a NaN, the other is chosen. If all Value(s) that are used by the current invocation are NaN, then the result is an undefined value.
 
@@ -1054,7 +1054,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is INT_MIN.
+The identity I for Operation is `INT_MIN`.
 
 The type of `value` must be the same as Result Type.
 
@@ -1067,7 +1067,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is INT_MIN. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is `INT_MIN`. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1098,7 +1098,7 @@ Result Type must be a scalar or vector of integer type, whose Signedness operand
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1160,7 +1160,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is ~0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is ~0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1193,7 +1193,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1226,7 +1226,7 @@ Result Type must be a scalar or vector of integer type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1259,7 +1259,7 @@ Result Type must be a scalar or vector of Boolean type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is ~0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is ~0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1292,7 +1292,7 @@ Result Type must be a scalar or vector of Boolean type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 
@@ -1325,7 +1325,7 @@ Result Type must be a scalar or vector of Boolean type.
 
 Execution is a Scope that identifies the group of invocations affected by this command. It must be Subgroup.
 
-The identity I for Operation is 0. If Operation is ClusteredReduce, `ClusterSize` must be present.
+The identity I for Operation is 0. If Operation is `ClusteredReduce`, `ClusterSize` must be present.
 
 The type of `value` must be the same as Result Type.
 

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -95,7 +95,7 @@ pub type Cubemap = crate::Image!(cube, type=f32, sampled, __crate_root=crate);
 /// You likely want to write this type using the [`crate::Image!`] macro helper, as the generic
 /// arguments here can get extremely verbose.
 ///
-/// See SPIR-V OpTypeImage specification for the meaning of integer parameters.
+/// See SPIR-V `OpTypeImage` specification for the meaning of integer parameters.
 #[spirv(generic_image_type)]
 #[derive(Copy, Clone)]
 // HACK(eddyb) avoids "transparent newtype of `_anti_zst_padding`" misinterpretation.

--- a/examples/runners/wgpu/src/compute.rs
+++ b/examples/runners/wgpu/src/compute.rs
@@ -177,16 +177,12 @@ async fn start_internal(options: &Options, compiled_shader_modules: CompiledShad
         let mut cpass = encoder.begin_compute_pass(&Default::default());
         cpass.set_bind_group(0, &bind_group, &[]);
         cpass.set_pipeline(&compute_pipeline);
-        if timestamping {
-            if let Some(queries) = queries.as_ref() {
-                cpass.write_timestamp(queries, 0);
-            }
+        if timestamping && let Some(queries) = queries.as_ref() {
+            cpass.write_timestamp(queries, 0);
         }
         cpass.dispatch_workgroups(src_range.len() as u32 / 64, 1, 1);
-        if timestamping {
-            if let Some(queries) = queries.as_ref() {
-                cpass.write_timestamp(queries, 1);
-            }
+        if timestamping && let Some(queries) = queries.as_ref() {
+            cpass.write_timestamp(queries, 1);
         }
     }
 
@@ -198,56 +194,53 @@ async fn start_internal(options: &Options, compiled_shader_modules: CompiledShad
         src.len() as wgpu::BufferAddress,
     );
 
-    if timestamping {
-        if let (Some(queries), Some(timestamp_buffer), Some(timestamp_readback_buffer)) = (
+    if timestamping
+        && let (Some(queries), Some(timestamp_buffer), Some(timestamp_readback_buffer)) = (
             queries.as_ref(),
             timestamp_buffer.as_ref(),
             timestamp_readback_buffer.as_ref(),
-        ) {
-            encoder.resolve_query_set(queries, 0..2, timestamp_buffer, 0);
-            encoder.copy_buffer_to_buffer(
-                timestamp_buffer,
-                0,
-                timestamp_readback_buffer,
-                0,
-                timestamp_buffer.size(),
-            );
-        }
+        )
+    {
+        encoder.resolve_query_set(queries, 0..2, timestamp_buffer, 0);
+        encoder.copy_buffer_to_buffer(
+            timestamp_buffer,
+            0,
+            timestamp_readback_buffer,
+            0,
+            timestamp_buffer.size(),
+        );
     }
 
     queue.submit(Some(encoder.finish()));
     let buffer_slice = readback_buffer.slice(..);
-    if timestamping {
-        if let Some(timestamp_readback_buffer) = timestamp_readback_buffer.as_ref() {
-            let timestamp_slice = timestamp_readback_buffer.slice(..);
-            timestamp_slice.map_async(wgpu::MapMode::Read, |r| r.unwrap());
-        }
+    if timestamping && let Some(timestamp_readback_buffer) = timestamp_readback_buffer.as_ref() {
+        let timestamp_slice = timestamp_readback_buffer.slice(..);
+        timestamp_slice.map_async(wgpu::MapMode::Read, |r| r.unwrap());
     }
     buffer_slice.map_async(wgpu::MapMode::Read, |r| r.unwrap());
     // NOTE(eddyb) `poll` should return only after the above callbacks fire
     // (see also https://github.com/gfx-rs/wgpu/pull/2698 for more details).
     device.poll(wgpu::PollType::Wait).unwrap();
 
-    if timestamping {
-        if let (Some(timestamp_readback_buffer), Some(timestamp_period)) =
+    if timestamping
+        && let (Some(timestamp_readback_buffer), Some(timestamp_period)) =
             (timestamp_readback_buffer.as_ref(), timestamp_period)
+    {
         {
-            {
-                let timing_data = timestamp_readback_buffer.slice(..).get_mapped_range();
-                let timings = timing_data
-                    .chunks_exact(8)
-                    .map(|b| u64::from_ne_bytes(b.try_into().unwrap()))
-                    .collect::<Vec<_>>();
+            let timing_data = timestamp_readback_buffer.slice(..).get_mapped_range();
+            let timings = timing_data
+                .chunks_exact(8)
+                .map(|b| u64::from_ne_bytes(b.try_into().unwrap()))
+                .collect::<Vec<_>>();
 
-                println!(
-                    "Took: {:?}",
-                    Duration::from_nanos(
-                        ((timings[1] - timings[0]) as f64 * f64::from(timestamp_period)) as u64
-                    )
-                );
-                drop(timing_data);
-                timestamp_readback_buffer.unmap();
-            }
+            println!(
+                "Took: {:?}",
+                Duration::from_nanos(
+                    ((timings[1] - timings[0]) as f64 * f64::from(timestamp_period)) as u64
+                )
+            );
+            drop(timing_data);
+            timestamp_readback_buffer.unmap();
         }
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2025-05-09"
+channel = "nightly-2025-06-23"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = 50aa04180709189a03dde5fd1c05751b2625ed37
+# commit_hash = be19eda0dc4c22c5cf5f1b48fd163acf9bd4b0a6
 
 # Whenever changing the nightly channel, update the commit hash above, and make
 # sure to change `REQUIRED_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` also.

--- a/tests/compiletests/src/main.rs
+++ b/tests/compiletests/src/main.rs
@@ -371,6 +371,13 @@ fn rust_flags(codegen_backend_path: &Path) -> String {
         // GVN currently can lead to the memcpy-out-of-const-alloc-global-var
         // pattern, even for `ScalarPair` (e.g. `return None::<u32>;`).
         "-Zmir-enable-passes=-GVN",
+        // HACK(eddyb) avoid ever reusing instantiations from `compiler_builtins`
+        // which is special-cased to turn calls to functions that never return,
+        // into aborts, and this applies to the panics of UB-checking helpers
+        // (https://github.com/rust-lang/rust/pull/122580#issuecomment-3033026194)
+        // but while upstream that only loses the panic message, for us it's even
+        // worse, as we lose the chance to remove otherwise-dead `fmt::Arguments`.
+        "-Zshare-generics=off",
         // NOTE(eddyb) flags copied from `spirv-builder` are all above this line.
         "-Cdebuginfo=2",
         "-Cembed-bitcode=no",

--- a/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_0_fail.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_0_fail.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation of `spirv_std::arch::subgroup_clustered_i_add::<0, u32, u32>::{constant#0}` failed
+error[E0080]: evaluation panicked: `ClusterSize` must be at least 1
    --> $SPIRV_STD_SRC/arch/subgroup.rs:840:1
     |
 840 | / macro_subgroup_op_clustered!(impl Integer, "OpGroupNonUniformIAdd", subgroup_clustered_i_add; r"
@@ -8,7 +8,7 @@ error[E0080]: evaluation of `spirv_std::arch::subgroup_clustered_i_add::<0, u32,
 ...   |
 856 | | * `ClusterSize` must not be greater than the size of the group
 857 | | ");
-    | |__^ evaluation panicked: `ClusterSize` must be at least 1
+    | |__^ evaluation of `spirv_std::arch::subgroup_clustered_i_add::<0, u32, u32>::{constant#0}` failed here
     |
     = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `macro_subgroup_op_clustered` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_non_power_of_two_fail.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_non_power_of_two_fail.stderr
@@ -1,4 +1,4 @@
-error[E0080]: evaluation of `spirv_std::arch::subgroup_clustered_i_add::<5, u32, u32>::{constant#0}` failed
+error[E0080]: evaluation panicked: `ClusterSize` must be a power of 2
    --> $SPIRV_STD_SRC/arch/subgroup.rs:840:1
     |
 840 | / macro_subgroup_op_clustered!(impl Integer, "OpGroupNonUniformIAdd", subgroup_clustered_i_add; r"
@@ -8,7 +8,7 @@ error[E0080]: evaluation of `spirv_std::arch::subgroup_clustered_i_add::<5, u32,
 ...   |
 856 | | * `ClusterSize` must not be greater than the size of the group
 857 | | ");
-    | |__^ evaluation panicked: `ClusterSize` must be a power of 2
+    | |__^ evaluation of `spirv_std::arch::subgroup_clustered_i_add::<5, u32, u32>::{constant#0}` failed here
     |
     = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `macro_subgroup_op_clustered` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/compiletests/ui/dis/issue-1062.stderr
+++ b/tests/compiletests/ui/dis/issue-1062.stderr
@@ -4,7 +4,7 @@ OpLine %5 11 12
 %6 = OpLoad  %7  %8
 OpLine %5 11 35
 %9 = OpLoad  %7  %10
-OpLine %11 1108 4
+OpLine %11 1128 4
 %12 = OpBitwiseAnd  %7  %9 %13
 %14 = OpISub  %7  %15 %12
 %16 = OpShiftLeftLogical  %7  %6 %12

--- a/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
+++ b/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
@@ -4,47 +4,47 @@ OpExtension "SPV_KHR_non_semantic_info"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %2 "main"
 OpExecutionMode %2 OriginUpperLeft
-%3 = OpString "/n[Rust panicked at $DIR/panic_builtin_bounds_check.rs:25:5]/n index out of bounds: the len is %u but the index is %u/n      in main()/n"
-%4 = OpString "$DIR/panic_builtin_bounds_check.rs"
-OpDecorate %5 ArrayStride 4
-%6 = OpTypeVoid
-%7 = OpTypeFunction %6
-%8 = OpTypeInt 32 0
-%9 = OpConstant  %8  4
-%5 = OpTypeArray %8 %9
-%10 = OpTypePointer Function %5
-%11 = OpConstant  %8  0
-%12 = OpConstant  %8  1
-%13 = OpConstant  %8  2
-%14 = OpConstant  %8  3
-%15 = OpTypeBool
-%16 = OpConstant  %8  5
-%17 = OpUndef  %8
-%18 = OpTypePointer Function %8
-%2 = OpFunction  %6  None %7
+%3 = OpString "/n[Rust panicked at $SYSROOT/lib/rustlib/src/rust/library/core/src/panicking.rs:280:5]/n index out of bounds: the len is %u but the index is %u/n      in main()/n"
+%4 = OpString $SYSROOT/lib/rustlib/src/rust/library/core/src/panicking.rs"
+%5 = OpString "$DIR/panic_builtin_bounds_check.rs"
+OpDecorate %6 ArrayStride 4
+%7 = OpTypeVoid
+%8 = OpTypeFunction %7
+%9 = OpTypeInt 32 0
+%10 = OpConstant  %9  4
+%6 = OpTypeArray %9 %10
+%11 = OpTypePointer Function %6
+%12 = OpConstant  %9  0
+%13 = OpConstant  %9  1
+%14 = OpConstant  %9  2
+%15 = OpConstant  %9  3
+%16 = OpTypeBool
+%17 = OpConstant  %9  5
+%18 = OpTypePointer Function %9
+%2 = OpFunction  %7  None %8
 %19 = OpLabel
-OpLine %4 30 4
-%20 = OpVariable  %10  Function
-OpLine %4 30 23
-%21 = OpCompositeConstruct  %5  %11 %12 %13 %14
-OpLine %4 25 4
+OpLine %5 30 4
+%20 = OpVariable  %11  Function
+OpLine %5 30 23
+%21 = OpCompositeConstruct  %6  %12 %13 %14 %15
+OpLine %5 25 4
 OpStore %20 %21
-%22 = OpULessThan  %15  %16 %9
+%22 = OpULessThan  %16  %17 %10
 OpNoLine
 OpSelectionMerge %23 None
 OpBranchConditional %22 %24 %25
 %24 = OpLabel
 OpBranch %23
 %25 = OpLabel
-OpLine %4 25 4
-%26 = OpExtInst  %6  %1 1 %3 %17 %16
+OpLine %4 280 4
+%26 = OpExtInst  %7  %1 1 %3 %10 %17
 OpNoLine
 OpReturn
 %23 = OpLabel
-OpLine %4 25 4
-%27 = OpIAdd  %8  %11 %16
+OpLine %5 25 4
+%27 = OpIAdd  %9  %12 %17
 %28 = OpInBoundsAccessChain  %18  %20 %27
-%29 = OpLoad  %8  %28
+%29 = OpLoad  %9  %28
 OpNoLine
 OpReturn
 OpFunctionEnd

--- a/tests/compiletests/ui/dis/panic_sequential_many.stderr
+++ b/tests/compiletests/ui/dis/panic_sequential_many.stderr
@@ -4,8 +4,9 @@ OpExtension "SPV_KHR_non_semantic_info"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %2 "main" %3 %4 %5
 OpExecutionMode %2 OriginUpperLeft
-%6 = OpString "/n[Rust panicked at $DIR/panic_sequential_many.rs:29:10]/n attempt to divide by zero/n      in main()/n"
-%7 = OpString "$DIR/panic_sequential_many.rs"
+%6 = OpString "/n[Rust panicked at $SYSROOT/lib/rustlib/src/rust/library/core/src/panicking.rs:187:5]/n attempt to divide by zero/n      in main()/n"
+%7 = OpString $SYSROOT/lib/rustlib/src/rust/library/core/src/panicking.rs"
+%8 = OpString "$DIR/panic_sequential_many.rs"
 OpName %3 "x"
 OpName %4 "y"
 OpName %5 "o"
@@ -14,262 +15,262 @@ OpDecorate %3 Location 0
 OpDecorate %4 Flat
 OpDecorate %4 Location 1
 OpDecorate %5 Location 0
-%8 = OpTypeInt 32 0
-%9 = OpTypePointer Input %8
-%10 = OpTypePointer Output %8
-%11 = OpTypeVoid
-%12 = OpTypeFunction %11
-%3 = OpVariable  %9  Input
-%4 = OpVariable  %9  Input
-%13 = OpTypeBool
-%14 = OpConstant  %8  0
-%5 = OpVariable  %10  Output
-%2 = OpFunction  %11  None %12
-%15 = OpLabel
-OpLine %7 26 12
-%16 = OpLoad  %8  %3
-OpLine %7 26 35
-%17 = OpLoad  %8  %4
-OpLine %7 29 9
-%18 = OpIEqual  %13  %17 %14
+%9 = OpTypeInt 32 0
+%10 = OpTypePointer Input %9
+%11 = OpTypePointer Output %9
+%12 = OpTypeVoid
+%13 = OpTypeFunction %12
+%3 = OpVariable  %10  Input
+%4 = OpVariable  %10  Input
+%14 = OpTypeBool
+%15 = OpConstant  %9  0
+%5 = OpVariable  %11  Output
+%2 = OpFunction  %12  None %13
+%16 = OpLabel
+OpLine %8 26 12
+%17 = OpLoad  %9  %3
+OpLine %8 26 35
+%18 = OpLoad  %9  %4
+OpLine %8 29 9
+%19 = OpIEqual  %14  %18 %15
 OpNoLine
-OpSelectionMerge %19 None
-OpBranchConditional %18 %20 %21
-%20 = OpLabel
-OpLine %7 29 9
-%22 = OpExtInst  %11  %1 1 %6
-OpNoLine
-OpReturn
+OpSelectionMerge %20 None
+OpBranchConditional %19 %21 %22
 %21 = OpLabel
-OpBranch %19
-%19 = OpLabel
-OpLine %7 29 9
-%23 = OpUDiv  %8  %16 %17
-%24 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %25 None
-OpBranchConditional %24 %26 %27
-%26 = OpLabel
-OpLine %7 29 9
-%28 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%23 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%22 = OpLabel
+OpBranch %20
+%20 = OpLabel
+OpLine %8 29 9
+%24 = OpUDiv  %9  %17 %18
+%25 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %26 None
+OpBranchConditional %25 %27 %28
 %27 = OpLabel
-OpBranch %25
-%25 = OpLabel
-OpLine %7 29 9
-%29 = OpUDiv  %8  %23 %17
-%30 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %31 None
-OpBranchConditional %30 %32 %33
-%32 = OpLabel
-OpLine %7 29 9
-%34 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%29 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%28 = OpLabel
+OpBranch %26
+%26 = OpLabel
+OpLine %8 29 9
+%30 = OpUDiv  %9  %24 %18
+%31 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %32 None
+OpBranchConditional %31 %33 %34
 %33 = OpLabel
-OpBranch %31
-%31 = OpLabel
-OpLine %7 29 9
-%35 = OpUDiv  %8  %29 %17
-%36 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %37 None
-OpBranchConditional %36 %38 %39
-%38 = OpLabel
-OpLine %7 29 9
-%40 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%35 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%34 = OpLabel
+OpBranch %32
+%32 = OpLabel
+OpLine %8 29 9
+%36 = OpUDiv  %9  %30 %18
+%37 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %38 None
+OpBranchConditional %37 %39 %40
 %39 = OpLabel
-OpBranch %37
-%37 = OpLabel
-OpLine %7 29 9
-%41 = OpUDiv  %8  %35 %17
-%42 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %43 None
-OpBranchConditional %42 %44 %45
-%44 = OpLabel
-OpLine %7 29 9
-%46 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%41 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%40 = OpLabel
+OpBranch %38
+%38 = OpLabel
+OpLine %8 29 9
+%42 = OpUDiv  %9  %36 %18
+%43 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %44 None
+OpBranchConditional %43 %45 %46
 %45 = OpLabel
-OpBranch %43
-%43 = OpLabel
-OpLine %7 29 9
-%47 = OpUDiv  %8  %41 %17
-%48 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %49 None
-OpBranchConditional %48 %50 %51
-%50 = OpLabel
-OpLine %7 29 9
-%52 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%47 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%46 = OpLabel
+OpBranch %44
+%44 = OpLabel
+OpLine %8 29 9
+%48 = OpUDiv  %9  %42 %18
+%49 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %50 None
+OpBranchConditional %49 %51 %52
 %51 = OpLabel
-OpBranch %49
-%49 = OpLabel
-OpLine %7 29 9
-%53 = OpUDiv  %8  %47 %17
-%54 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %55 None
-OpBranchConditional %54 %56 %57
-%56 = OpLabel
-OpLine %7 29 9
-%58 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%53 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%52 = OpLabel
+OpBranch %50
+%50 = OpLabel
+OpLine %8 29 9
+%54 = OpUDiv  %9  %48 %18
+%55 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %56 None
+OpBranchConditional %55 %57 %58
 %57 = OpLabel
-OpBranch %55
-%55 = OpLabel
-OpLine %7 29 9
-%59 = OpUDiv  %8  %53 %17
-%60 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %61 None
-OpBranchConditional %60 %62 %63
-%62 = OpLabel
-OpLine %7 29 9
-%64 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%59 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%58 = OpLabel
+OpBranch %56
+%56 = OpLabel
+OpLine %8 29 9
+%60 = OpUDiv  %9  %54 %18
+%61 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %62 None
+OpBranchConditional %61 %63 %64
 %63 = OpLabel
-OpBranch %61
-%61 = OpLabel
-OpLine %7 29 9
-%65 = OpUDiv  %8  %59 %17
-%66 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %67 None
-OpBranchConditional %66 %68 %69
-%68 = OpLabel
-OpLine %7 29 9
-%70 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%65 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%64 = OpLabel
+OpBranch %62
+%62 = OpLabel
+OpLine %8 29 9
+%66 = OpUDiv  %9  %60 %18
+%67 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %68 None
+OpBranchConditional %67 %69 %70
 %69 = OpLabel
-OpBranch %67
-%67 = OpLabel
-OpLine %7 29 9
-%71 = OpUDiv  %8  %65 %17
-%72 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %73 None
-OpBranchConditional %72 %74 %75
-%74 = OpLabel
-OpLine %7 29 9
-%76 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%71 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%70 = OpLabel
+OpBranch %68
+%68 = OpLabel
+OpLine %8 29 9
+%72 = OpUDiv  %9  %66 %18
+%73 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %74 None
+OpBranchConditional %73 %75 %76
 %75 = OpLabel
-OpBranch %73
-%73 = OpLabel
-OpLine %7 29 9
-%77 = OpUDiv  %8  %71 %17
-%78 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %79 None
-OpBranchConditional %78 %80 %81
-%80 = OpLabel
-OpLine %7 29 9
-%82 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%77 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%76 = OpLabel
+OpBranch %74
+%74 = OpLabel
+OpLine %8 29 9
+%78 = OpUDiv  %9  %72 %18
+%79 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %80 None
+OpBranchConditional %79 %81 %82
 %81 = OpLabel
-OpBranch %79
-%79 = OpLabel
-OpLine %7 29 9
-%83 = OpUDiv  %8  %77 %17
-%84 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %85 None
-OpBranchConditional %84 %86 %87
-%86 = OpLabel
-OpLine %7 29 9
-%88 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%83 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%82 = OpLabel
+OpBranch %80
+%80 = OpLabel
+OpLine %8 29 9
+%84 = OpUDiv  %9  %78 %18
+%85 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %86 None
+OpBranchConditional %85 %87 %88
 %87 = OpLabel
-OpBranch %85
-%85 = OpLabel
-OpLine %7 29 9
-%89 = OpUDiv  %8  %83 %17
-%90 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %91 None
-OpBranchConditional %90 %92 %93
-%92 = OpLabel
-OpLine %7 29 9
-%94 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%89 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%88 = OpLabel
+OpBranch %86
+%86 = OpLabel
+OpLine %8 29 9
+%90 = OpUDiv  %9  %84 %18
+%91 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %92 None
+OpBranchConditional %91 %93 %94
 %93 = OpLabel
-OpBranch %91
-%91 = OpLabel
-OpLine %7 29 9
-%95 = OpUDiv  %8  %89 %17
-%96 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %97 None
-OpBranchConditional %96 %98 %99
-%98 = OpLabel
-OpLine %7 29 9
-%100 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%95 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%94 = OpLabel
+OpBranch %92
+%92 = OpLabel
+OpLine %8 29 9
+%96 = OpUDiv  %9  %90 %18
+%97 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %98 None
+OpBranchConditional %97 %99 %100
 %99 = OpLabel
-OpBranch %97
-%97 = OpLabel
-OpLine %7 29 9
-%101 = OpUDiv  %8  %95 %17
-%102 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %103 None
-OpBranchConditional %102 %104 %105
-%104 = OpLabel
-OpLine %7 29 9
-%106 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%101 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%100 = OpLabel
+OpBranch %98
+%98 = OpLabel
+OpLine %8 29 9
+%102 = OpUDiv  %9  %96 %18
+%103 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %104 None
+OpBranchConditional %103 %105 %106
 %105 = OpLabel
-OpBranch %103
-%103 = OpLabel
-OpLine %7 29 9
-%107 = OpUDiv  %8  %101 %17
-%108 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %109 None
-OpBranchConditional %108 %110 %111
-%110 = OpLabel
-OpLine %7 29 9
-%112 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%107 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%106 = OpLabel
+OpBranch %104
+%104 = OpLabel
+OpLine %8 29 9
+%108 = OpUDiv  %9  %102 %18
+%109 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %110 None
+OpBranchConditional %109 %111 %112
 %111 = OpLabel
-OpBranch %109
-%109 = OpLabel
-OpLine %7 29 9
-%113 = OpUDiv  %8  %107 %17
-%114 = OpIEqual  %13  %17 %14
-OpNoLine
-OpSelectionMerge %115 None
-OpBranchConditional %114 %116 %117
-%116 = OpLabel
-OpLine %7 29 9
-%118 = OpExtInst  %11  %1 1 %6
+OpLine %7 187 4
+%113 = OpExtInst  %12  %1 1 %6
 OpNoLine
 OpReturn
+%112 = OpLabel
+OpBranch %110
+%110 = OpLabel
+OpLine %8 29 9
+%114 = OpUDiv  %9  %108 %18
+%115 = OpIEqual  %14  %18 %15
+OpNoLine
+OpSelectionMerge %116 None
+OpBranchConditional %115 %117 %118
 %117 = OpLabel
-OpBranch %115
-%115 = OpLabel
-OpLine %7 29 4
-%119 = OpUDiv  %8  %113 %17
-OpStore %5 %119
+OpLine %7 187 4
+%119 = OpExtInst  %12  %1 1 %6
+OpNoLine
+OpReturn
+%118 = OpLabel
+OpBranch %116
+%116 = OpLabel
+OpLine %8 29 4
+%120 = OpUDiv  %9  %114 %18
+OpStore %5 %120
 OpNoLine
 OpReturn
 OpFunctionEnd

--- a/tests/compiletests/ui/dis/ptr_copy.normal.stderr
+++ b/tests/compiletests/ui/dis/ptr_copy.normal.stderr
@@ -1,68 +1,68 @@
 error: cannot memcpy dynamically sized data
-    --> $CORE_SRC/intrinsics/mod.rs:3850:9
-     |
-3850 |         copy(src, dst, count)
-     |         ^^^^^^^^^^^^^^^^^^^^^
-     |
-note: used from within `core::intrinsics::copy::<f32>`
-    --> $CORE_SRC/intrinsics/mod.rs:3830:21
-     |
-3830 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
-     |                     ^^^^
+   --> $CORE_SRC/ptr/mod.rs:633:9
+    |
+633 |         crate::intrinsics::copy(src, dst, count)
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+note: used from within `core::ptr::copy::<f32>`
+   --> $CORE_SRC/ptr/mod.rs:618:21
+    |
+618 | pub const unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize) {
+    |                     ^^^^
 note: called by `ptr_copy::copy_via_raw_ptr`
-    --> $DIR/ptr_copy.rs:28:18
-     |
-28   |         unsafe { core::ptr::copy(src, dst, 1) }
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   --> $DIR/ptr_copy.rs:28:18
+    |
+28  |         unsafe { core::ptr::copy(src, dst, 1) }
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: called by `ptr_copy::main`
-    --> $DIR/ptr_copy.rs:33:5
-     |
-33   |     copy_via_raw_ptr(&i, o);
-     |     ^^^^^^^^^^^^^^^^^^^^^^^
+   --> $DIR/ptr_copy.rs:33:5
+    |
+33  |     copy_via_raw_ptr(&i, o);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^
 note: called by `main`
-    --> $DIR/ptr_copy.rs:32:8
-     |
-32   | pub fn main(i: f32, o: &mut f32) {
-     |        ^^^^
+   --> $DIR/ptr_copy.rs:32:8
+    |
+32  | pub fn main(i: f32, o: &mut f32) {
+    |        ^^^^
 
 error: cannot cast between pointer types
        from `*f32`
          to `*struct () {  }`
-    --> $CORE_SRC/intrinsics/mod.rs:3838:9
-     |
-3838 | /         ub_checks::assert_unsafe_precondition!(
-3839 | |             check_language_ub,
-3840 | |             "ptr::copy requires that both pointer arguments are aligned and non-null",
-...    |
-3848 | |                 && ub_checks::maybe_is_aligned_and_not_null(dst, align, zero_size)
-3849 | |         );
-     | |_________^
-     |
-note: used from within `core::intrinsics::copy::<f32>`
-    --> $CORE_SRC/intrinsics/mod.rs:3838:9
-     |
-3838 | /         ub_checks::assert_unsafe_precondition!(
-3839 | |             check_language_ub,
-3840 | |             "ptr::copy requires that both pointer arguments are aligned and non-null",
-...    |
-3848 | |                 && ub_checks::maybe_is_aligned_and_not_null(dst, align, zero_size)
-3849 | |         );
-     | |_________^
+   --> $CORE_SRC/ptr/mod.rs:621:9
+    |
+621 | /         ub_checks::assert_unsafe_precondition!(
+622 | |             check_language_ub,
+623 | |             "ptr::copy requires that both pointer arguments are aligned and non-null",
+...   |
+631 | |                 && ub_checks::maybe_is_aligned_and_not_null(dst, align, zero_size)
+632 | |         );
+    | |_________^
+    |
+note: used from within `core::ptr::copy::<f32>`
+   --> $CORE_SRC/ptr/mod.rs:621:9
+    |
+621 | /         ub_checks::assert_unsafe_precondition!(
+622 | |             check_language_ub,
+623 | |             "ptr::copy requires that both pointer arguments are aligned and non-null",
+...   |
+631 | |                 && ub_checks::maybe_is_aligned_and_not_null(dst, align, zero_size)
+632 | |         );
+    | |_________^
 note: called by `ptr_copy::copy_via_raw_ptr`
-    --> $DIR/ptr_copy.rs:28:18
-     |
-28   |         unsafe { core::ptr::copy(src, dst, 1) }
-     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   --> $DIR/ptr_copy.rs:28:18
+    |
+28  |         unsafe { core::ptr::copy(src, dst, 1) }
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: called by `ptr_copy::main`
-    --> $DIR/ptr_copy.rs:33:5
-     |
-33   |     copy_via_raw_ptr(&i, o);
-     |     ^^^^^^^^^^^^^^^^^^^^^^^
+   --> $DIR/ptr_copy.rs:33:5
+    |
+33  |     copy_via_raw_ptr(&i, o);
+    |     ^^^^^^^^^^^^^^^^^^^^^^^
 note: called by `main`
-    --> $DIR/ptr_copy.rs:32:8
-     |
-32   | pub fn main(i: f32, o: &mut f32) {
-     |        ^^^^
+   --> $DIR/ptr_copy.rs:32:8
+    |
+32  | pub fn main(i: f32, o: &mut f32) {
+    |        ^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/compiletests/ui/dis/ptr_read.stderr
+++ b/tests/compiletests/ui/dis/ptr_read.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1455 8
+OpLine %8 1732 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/compiletests/ui/dis/ptr_read_method.stderr
+++ b/tests/compiletests/ui/dis/ptr_read_method.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %5
 %6 = OpFunctionParameter  %5
 %7 = OpLabel
-OpLine %8 1455 8
+OpLine %8 1732 8
 %9 = OpLoad  %10  %4
 OpLine %11 7 13
 OpStore %6 %9

--- a/tests/compiletests/ui/dis/ptr_write.stderr
+++ b/tests/compiletests/ui/dis/ptr_write.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 35
 %9 = OpLoad  %10  %4
-OpLine %11 1655 8
+OpLine %11 1932 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/dis/ptr_write_method.stderr
+++ b/tests/compiletests/ui/dis/ptr_write_method.stderr
@@ -4,7 +4,7 @@
 %7 = OpLabel
 OpLine %8 7 37
 %9 = OpLoad  %10  %4
-OpLine %11 1655 8
+OpLine %11 1932 8
 OpStore %6 %9
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/lang/core/unwrap_or.stderr
+++ b/tests/compiletests/ui/lang/core/unwrap_or.stderr
@@ -3,9 +3,9 @@
 OpLine %5 13 11
 %6 = OpCompositeInsert  %7  %8 %9 0
 %10 = OpCompositeExtract  %11  %6 1
-OpLine %12 1024 14
+OpLine %12 1026 14
 %13 = OpBitcast  %14  %8
-OpLine %12 1024 8
+OpLine %12 1026 8
 %15 = OpINotEqual  %16  %13 %17
 OpNoLine
 OpSelectionMerge %18 None


### PR DESCRIPTION
Not much to see this time, other than:
- some more `format_args!` complications (less efficient codegen for some reason)
- `-Zshare-generics=off` now being needed (because of weird special-casing done to `compiler-builtins` otherwise leaking to shader crates, via e.g. `<Range<usize> as Iterator>>:next`)
- a couple bulk Clippy-driven changes (esp. `clippy::collapsible_if`, it's surprisingly applicable)