### PR TITLE
`format_args!` "decompiler": forced warnings and `fmt::Arguments::new_v1_formatted` "support".

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -3664,7 +3664,16 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
 
                 Err(FormatArgsNotRecognized(step)) => {
                     if let Some(current_span) = self.current_span {
-                        let mut warn = self.tcx.dcx().struct_span_warn(
+                        // HACK(eddyb) Cargo silences warnings in dependencies.
+                        let force_warn = |span, msg| -> rustc_errors::Diag<'_, ()> {
+                            rustc_errors::Diag::new(
+                                self.tcx.dcx(),
+                                rustc_errors::Level::ForceWarning(None),
+                                msg,
+                            )
+                            .with_span(span)
+                        };
+                        let mut warn = force_warn(
                             current_span,
                             "failed to find and remove `format_args!` construction for this `panic!`",
                         );

--- a/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/declare.rs
@@ -229,6 +229,12 @@ impl<'tcx> CodegenCx<'tcx> {
                 (pieces_len.parse().unwrap(), rt_args_len.parse().unwrap()),
             );
         }
+        if demangled_symbol_name == "<core::fmt::Arguments>::new_v1_formatted" {
+            // HACK(eddyb) `!0` used as a placeholder value to indicate "dynamic".
+            self.fmt_args_new_fn_ids
+                .borrow_mut()
+                .insert(fn_id, (!0, !0));
+        }
 
         // HACK(eddyb) there is no good way to identify these definitions
         // (e.g. no `#[lang = "..."]` attribute), but this works well enough.


### PR DESCRIPTION
*(Each commit should be reviewed separately)*

---

The main "externally" visible change is the "force warnings" one - thought it's still mostly just for us.

Due to Cargo using `--cap-lints`, you normally can't see warnings in non-local dependencies - and that includes the standard library when using `-Zbuild-std` (like we do).
So every time the "`format_args!` decompiler" would fail (e.g. while working on a `rustup`, before updating it) for a `panic!` in e.g. `core`, it would silently cause issues downstream (while making it harder to diagnose)

After this PR, it will always warn in the crate responsible (though hopefully never, for Rust-GPU users).

---

I've had this "force warnings" change around for a while, but never submitted it because there were always a few warnings from `core` - turns out they were caused by `fmt::Arguments::new_v1_formatted`, which is used for `format_args!` with any non-default options (e.g. padding) or non-trivial argument numbering, etc.

I decided to "support" those cases - however, actually extracting the necessary information would be too much effort (and require relying on unstable implementation details of `core::fmt::rt`), so the `debugPrintf` form includes all the arguments but in a very general "these N args go into M placeholders *somehow*".

Also, there's some really hacky skipping of `core::fmt::rt::Placeholder::new` calls, due to `main` predating:
- https://github.com/rust-lang/rust/pull/139131

Thankfully, that PR landed between 1.87 and 1.88, so #249 (the ~1.88 rustup) should be able to remove the hacks (as the entire `&[core::fmt::rt::Placeholder]` slice should be a constant then, just like the `&[&str]` one is).

(In theory, due to the level of simplification done upstream, it may be plausible to start decoding the `Placeholder` values, but I would not want to put effort into it until an usecase is revealed)

---

There are also some changes that in theory aren't needed before #320 (the ~1.89 rustup), but which I've found invaluable while debugging any changes to the `format_args!` "decompiler" logic (and which I wish I had done much sooner).