### PR TITLE
blake3 difftest

### DIFF
--- a/tests/difftests/tests/Cargo.lock
+++ b/tests/difftests/tests/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +78,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake3-rust"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "blake3-rust-gpu",
+ "bytemuck",
+ "difftest",
+]
+
+[[package]]
+name = "blake3-rust-gpu"
+version = "0.0.0"
+dependencies = [
+ "blake3",
+ "difftest",
+ "spirv-std",
 ]
 
 [[package]]
@@ -139,6 +177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +207,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -930,12 +983,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple-compute-rust"
-version = "0.0.0"
-dependencies = [
- "difftest",
- "spirv-std",
-]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simple-compute-wgsl"

--- a/tests/difftests/tests/Cargo.toml
+++ b/tests/difftests/tests/Cargo.toml
@@ -1,7 +1,8 @@
 [workspace]
 resolver = "2"
 members = [
-    "simple-compute/simple-compute-rust",
+    "blake3/blake3-rust",
+    "blake3/blake3-rust-gpu",
     "simple-compute/simple-compute-wgsl",
 ]
 
@@ -21,6 +22,8 @@ spirv-std = { path = "../../../crates/spirv-std", version = "=0.9.0" }
 spirv-std-types = { path = "../../../crates/spirv-std/shared", version = "=0.9.0" }
 spirv-std-macros = { path = "../../../crates/spirv-std/macros", version = "=0.9.0" }
 difftest = { path = "../../../tests/difftests/lib" }
+anyhow = "1.0.98"
+bytemuck = "1.21.0"
 # External dependencies that need to be mentioned more than once.
 num-traits = { version = "0.2.15", default-features = false }
 glam = { version = ">=0.22, <=0.29", default-features = false }

--- a/tests/difftests/tests/blake3/blake3-rust-gpu/Cargo.toml
+++ b/tests/difftests/tests/blake3/blake3-rust-gpu/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "blake3-rust-gpu"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["rlib", "dylib"]
+
+# Common deps
+[dependencies]
+
+# GPU deps
+spirv-std.workspace = true
+blake3 = {version = "1.8.2", default-features = false}
+
+# CPU deps
+[target.'cfg(not(target_arch = "spirv"))'.dependencies]
+difftest.workspace = true

--- a/tests/difftests/tests/blake3/blake3-rust-gpu/src/lib.rs
+++ b/tests/difftests/tests/blake3/blake3-rust-gpu/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+use spirv_std::spirv;
+
+#[spirv(compute(threads(1)))]
+pub fn main_cs(#[spirv(storage_buffer, descriptor_set = 0, binding = 0)] output: &mut [u32]) {
+    let hash = blake3::Hasher::new().finalize();
+    let bytes = hash.as_bytes();
+
+    for i in 0..8 {
+        output[i] = u32::from_le_bytes([bytes[i], bytes[i + 1], bytes[i + 2], bytes[i + 3]]);
+    }
+}

--- a/tests/difftests/tests/blake3/blake3-rust-gpu/src/main.rs
+++ b/tests/difftests/tests/blake3/blake3-rust-gpu/src/main.rs
@@ -1,0 +1,13 @@
+use difftest::config::Config;
+use difftest::scaffold::compute::{RustComputeShader, WgpuComputeTest};
+
+fn main() {
+    // Load the config from the harness.
+    let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
+
+    // Define test parameters, loading the rust shader from the current crate.
+    let test = WgpuComputeTest::new(RustComputeShader::default(), [1, 1, 1], 1024);
+
+    // Run the test and write the output to a file.
+    test.run_test(&config).unwrap();
+}

--- a/tests/difftests/tests/blake3/blake3-rust/Cargo.toml
+++ b/tests/difftests/tests/blake3/blake3-rust/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "blake3-rust"
+edition.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+difftest.workspace = true
+anyhow.workspace = true
+bytemuck.workspace = true
+blake3-rust-gpu = {path = "../blake3-rust-gpu"}

--- a/tests/difftests/tests/blake3/blake3-rust/src/main.rs
+++ b/tests/difftests/tests/blake3/blake3-rust/src/main.rs
@@ -1,0 +1,16 @@
+use difftest::config::Config;
+use std::fs::File;
+use std::io::Write;
+
+fn main() {
+    let mut buf = [0u32; 256];
+    blake3_rust_gpu::main_cs(&mut buf);
+    write_cpu_test(bytemuck::bytes_of(&buf)).unwrap();
+}
+
+fn write_cpu_test(output: &[u8]) -> anyhow::Result<()> {
+    let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
+    let mut f = File::create(&config.output_path)?;
+    f.write_all(&output)?;
+    Ok(())
+}


### PR DESCRIPTION
blake3 is failing with a bunch of ICEs, see https://github.com/Rust-GPU/rust-gpu/issues/312. This is a repro of the failure within out difftest framework, so that a fix can be developed. 


black_box error:
```
error: internal compiler error: /Users/runner/work/rust-gpu/rust-gpu/tests/difftests/tests/target/release/build/rustc_codegen_spirv-46ee035126448e6d/out/pqp_cg_ssa/src/mir/block.rs:956:29: intrinsic black_box must be overridden by codegen backend, but isn't
test difftests::blake3 ... 2025-07-07T13:16:50.839901Z ERROR difftests::runner: Cargo execution failed for package 'blake3-rust-gpu'
   --> /Users/runner/.rustup/toolchains/nightly-2024-11-22-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/hint.rs:389:5
    |
389 |     crate::intrinsics::black_box(dummy)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

thread 'rustc' panicked at /Users/runner/work/rust-gpu/rust-gpu/tests/difftests/tests/target/release/build/rustc_codegen_spirv-46ee035126448e6d/out/pqp_cg_ssa/src/mir/block.rs:956:29:
Box<dyn Any>
stack backtrace:
   Compiling spirv-std-macros v0.9.0 (/Users/runner/work/rust-gpu/rust-gpu/crates/spirv-std/macros)
   0:        0x10eaf527c - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h447e736edf25ff33
   1:        0x10bd155e0 - core::fmt::write::hf4d022d9ef02167e
   2:        0x10eae9428 - std::io::Write::write_fmt::h11757e8bc697ea8e
   3:        0x10eaf513c - std::sys::backtrace::BacktraceLock::print::haf4ac7c7af3cf97a
   4:        0x10eaf7610 - std::panicking::default_hook::{{closure}}::h52aa610c7cde4596
   5:        0x10eaf7458 - std::panicking::default_hook::hdcfc7f1ad8d891f0
   6:        0x10c934bb0 - <alloc[e2e5e8515d00274d]::boxed::Box<rustc_driver_impl[c6ade677a6b0e20c]::install_ice_hook::{closure#0}> as core[924c651d484e1a25]::ops::function::Fn<(&dyn for<'a, 'b> core[924c651d484e1a25]::ops::function::Fn<(&'a std[fc297465fa958267]::panic::PanicHookInfo<'b>,), Output = ()> + core[924c651d484e1a25]::marker::Send + core[924c651d484e1a25]::marker::Sync, &std[fc297465fa958267]::panic::PanicHookInfo)>>::call
   7:        0x10c934bb0 - <alloc[e2e5e8515d00274d]::boxed::Box<rustc_driver_impl[c6ade677a6b0e20c]::install_ice_hook::{closure#0}> as core[924c651d484e1a25]::ops::function::Fn<(&dyn for<'a, 'b> core[924c651d484e1a25]::ops::function::Fn<(&'a std[fc297465fa958267]::panic::PanicHookInfo<'b>,), Output = ()> + core[924c651d484e1a25]::marker::Send + core[924c651d484e1a25]::marker::Sync, &std[fc297465fa958267]::panic::PanicHookInfo)>>::call
   8:        0x10eaf7edc - std::panicking::rust_panic_with_hook::heb73fc7746f92ba7
   9:        0x10c9d9718 - std[fc297465fa958267]::panicking::begin_panic::<rustc_errors[caf545eadef7fdd]::ExplicitBug>::{closure#0}
  10:        0x10c9d94d0 - std[fc297465fa958267]::sys::backtrace::__rust_end_short_backtrace::<std[fc297465fa958267]::panicking::begin_panic<rustc_errors[caf545eadef7fdd]::ExplicitBug>::{closure#0}, !>
  11:        0x11125c04c - std[fc297465fa958267]::panicking::begin_panic::<rustc_errors[caf545eadef7fdd]::ExplicitBug>
  12:        0x10c9dfad4 - <rustc_errors[caf545eadef7fdd]::diagnostic::BugAbort as rustc_errors[caf545eadef7fdd]::diagnostic::EmissionGuarantee>::emit_producing_guarantee
  13:        0x102cd621c - <unknown>
  14:        0x102b37588 - <unknown>
  15:        0x102b374b0 - <unknown>
  16:        0x102b3747c - <unknown>
  17:        0x1031b65c0 - <unknown>
  18:        0x102dc1b50 - <unknown>
  19:        0x102dd05f4 - <unknown>
  20:        0x102cca2b4 - <unknown>
  21:        0x102d6fa90 - <unknown>
  22:        0x102c3693c - <unknown>
  23:        0x102c364a0 - <unknown>
  24:        0x102ccb650 - <unknown>
  25:        0x102c35638 - <unknown>
  26:        0x10d1cbad8 - <rustc_session[3e2f7db2cc04b493]::session::Session>::time::<alloc[e2e5e8515d00274d]::boxed::Box<dyn core[924c651d484e1a25]::any::Any>, rustc_interface[fb6f1569d3f1850c]::passes::start_codegen::{closure#0}>
  27:        0x10d2fadd4 - rustc_interface[fb6f1569d3f1850c]::passes::start_codegen
  28:        0x10d2885f0 - <rustc_interface[fb6f1569d3f1850c]::queries::Linker>::codegen_and_build_linker
  29:        0x10c91dd20 - <rustc_middle[dc5a577fd6f5eb51]::ty::context::GlobalCtxt>::enter::<rustc_driver_impl[c6ade677a6b0e20c]::run_compiler::{closure#0}::{closure#1}::{closure#7}, core[924c651d484e1a25]::result::Result<core[924c651d484e1a25]::option::Option<rustc_interface[fb6f1569d3f1850c]::queries::Linker>, rustc_span[60df94d8028129a3]::ErrorGuaranteed>>
  30:        0x10c8e51b0 - <rustc_interface[fb6f1569d3f1850c]::interface::Compiler>::enter::<rustc_driver_impl[c6ade677a6b0e20c]::run_compiler::{closure#0}::{closure#1}, core[924c651d484e1a25]::result::Result<core[924c651d484e1a25]::option::Option<rustc_interface[fb6f1569d3f1850c]::queries::Linker>, rustc_span[60df94d8028129a3]::ErrorGuaranteed>>
  31:        0x10c927588 - rustc_span[60df94d8028129a3]::create_session_globals_then::<core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>, rustc_interface[fb6f1569d3f1850c]::util::run_in_thread_with_globals<rustc_interface[fb6f1569d3f1850c]::util::run_in_thread_pool_with_globals<rustc_interface[fb6f1569d3f1850c]::interface::run_compiler<core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>, rustc_driver_impl[c6ade677a6b0e20c]::run_compiler::{closure#0}>::{closure#1}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>::{closure#0}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>::{closure#0}::{closure#0}::{closure#0}>
  32:        0x10c90f588 - std[fc297465fa958267]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[fb6f1569d3f1850c]::util::run_in_thread_with_globals<rustc_interface[fb6f1569d3f1850c]::util::run_in_thread_pool_with_globals<rustc_interface[fb6f1569d3f1850c]::interface::run_compiler<core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>, rustc_driver_impl[c6ade677a6b0e20c]::run_compiler::{closure#0}>::{closure#1}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>::{closure#0}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>
  33:        0x10c912b54 - <<std[fc297465fa958267]::thread::Builder>::spawn_unchecked_<rustc_interface[fb6f1569d3f1850c]::util::run_in_thread_with_globals<rustc_interface[fb6f1569d3f1850c]::util::run_in_thread_pool_with_globals<rustc_interface[fb6f1569d3f1850c]::interface::run_compiler<core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>, rustc_driver_impl[c6ade677a6b0e20c]::run_compiler::{closure#0}>::{closure#1}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>::{closure#0}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[924c651d484e1a25]::result::Result<(), rustc_span[60df94d8028129a3]::ErrorGuaranteed>>::{closure#1} as core[924c651d484e1a25]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  34:        0x10eb01fe8 - std::sys::pal::unix::thread::Thread::new::thread_start::h5a3f92a0fdbf8eb0
  35:        0x18525ef94 - __pthread_joiner_wake
```

memset error, only locally observed:
```
error: memset on structs not implemented yet
   --> /home/firestar99/.cargo/registry/src/index.crates.io-6f17d22bba15001f/blake3-1.8.2/src/lib.rs:552:17
    |
552 |                 self.buf = [0; BLOCK_LEN];
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
```

```rust
pub const BLOCK_LEN: usize = 64;
let buf: [u8; BLOCK_LEN];
buf = [0; BLOCK_LEN]; // self removed
```