### PR TITLE
ci: enable clippy for more crates

### DIFF
--- a/.github/workflows/lint.sh
+++ b/.github/workflows/lint.sh
@@ -28,11 +28,11 @@ function clippy_no_features() {
 }
 
 # Core crates
-clippy crates/rustc_codegen_spirv-target-specs
-clippy crates/rustc_codegen_spirv-types
+clippy_no_features crates/rustc_codegen_spirv-target-specs
+clippy_no_features crates/rustc_codegen_spirv-types
 clippy crates/rustc_codegen_spirv
 clippy crates/spirv-builder
-clippy crates/spirv-std
+clippy_no_features crates/spirv-std
 
 # Examples
 clippy examples/multibuilder

--- a/.github/workflows/lint.sh
+++ b/.github/workflows/lint.sh
@@ -28,17 +28,29 @@ function clippy_no_features() {
 }
 
 # Core crates
+clippy crates/rustc_codegen_spirv-target-specs
+clippy crates/rustc_codegen_spirv-types
 clippy crates/rustc_codegen_spirv
 clippy crates/spirv-builder
+clippy crates/spirv-std
 
 # Examples
-
+clippy examples/multibuilder
 clippy examples/runners/ash
+clippy_no_features examples/runners/cpu
 clippy examples/runners/wgpu
 
-clippy_no_features examples/runners/cpu
+# shaders
 clippy_no_features examples/shaders/sky-shader
 clippy_no_features examples/shaders/simplest-shader
+clippy_no_features examples/shaders/compute-shader
+clippy_no_features examples/shaders/mouse-shader
+clippy_no_features examples/shaders/reduce
+
+# tests
+clippy tests/compiletests
+clippy tests/difftests/bin
+clippy tests/difftests/lib
 
 # Custom lints
 

--- a/tests/compiletests/src/main.rs
+++ b/tests/compiletests/src/main.rs
@@ -151,7 +151,7 @@ impl Runner {
                 format!("{}-{}", env, variation.name)
             };
 
-            println!("Testing env: {}\n", stage_id);
+            println!("Testing env: {stage_id}\n");
 
             let target = format!("{SPIRV_TARGET_PREFIX}{env}");
             let libs = build_deps(&self.deps_target_dir, &self.codegen_backend_path, &target);

--- a/tests/difftests/bin/src/main.rs
+++ b/tests/difftests/bin/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::exit)]
+
 use anyhow::Result;
 use std::{
     env,

--- a/tests/difftests/bin/src/main.rs
+++ b/tests/difftests/bin/src/main.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
             ..o
         },
         Some(Err(e)) => {
-            eprintln!("Error parsing test options: {}", e);
+            eprintln!("Error parsing test options: {e}");
             process::exit(1);
         }
         None => TestOpts {
@@ -120,8 +120,7 @@ fn main() -> Result<()> {
             .map(|filter| {
                 if filter.contains('/') {
                     // Convert path-like filter to test name format
-                    let path_filter = filter.replace('/', "::");
-                    format!("{}", path_filter)
+                    filter.replace('/', "::")
                 } else {
                     filter
                 }

--- a/tests/difftests/bin/src/runner.rs
+++ b/tests/difftests/bin/src/runner.rs
@@ -131,7 +131,7 @@ impl Runner {
             let config_json = serde_json::to_string(&config)
                 .map_err(|e| RunnerError::Config { msg: e.to_string() })?;
             let mut config_file = NamedTempFile::new()?;
-            write!(config_file, "{}", config_json).map_err(|e| RunnerError::Io { source: e })?;
+            write!(config_file, "{config_json}").map_err(|e| RunnerError::Io { source: e })?;
             trace!("Config file created at {}", config_file.path().display());
 
             let mut cmd = Command::new("cargo");
@@ -294,7 +294,7 @@ impl Runner {
                     .join("::")
             },
         );
-        format!("difftests::{}", name)
+        format!("difftests::{name}")
     }
 
     pub fn collect_test_dirs(root: &Path) -> RunnerResult<Vec<PathBuf>> {

--- a/tests/difftests/bin/src/runner.rs
+++ b/tests/difftests/bin/src/runner.rs
@@ -383,7 +383,7 @@ mod tests {
             version = "0.1.0"
             edition = "2021"
         "#;
-        write!(temp, "{}", cargo_toml).expect("failed to write to temp file");
+        write!(temp, "{cargo_toml}").expect("failed to write to temp file");
         let runner = Runner::new(PathBuf::from("dummy_base"));
         let pkg_name = runner
             .get_package_name(temp.path())

--- a/tests/difftests/lib/src/lib.rs
+++ b/tests/difftests/lib/src/lib.rs
@@ -11,7 +11,7 @@ mod tests {
     fn test_config_from_path() {
         let mut tmp = NamedTempFile::new().unwrap();
         let config_json = r#"{ "output_path": "/tmp/output.txt" }"#;
-        write!(tmp, "{}", config_json).unwrap();
+        write!(tmp, "{config_json}").unwrap();
         let config = Config::from_path(tmp.path()).unwrap();
         assert_eq!(config.output_path.to_str().unwrap(), "/tmp/output.txt");
     }


### PR DESCRIPTION
clippy doesn't run on eg. compiletest and difftest and there's some code it's complaining about