### PR TITLE
compiletest: avoid invoking `rustc` with absolute paths.

### DIFF
--- a/tests/compiletests/src/main.rs
+++ b/tests/compiletests/src/main.rs
@@ -65,6 +65,13 @@ fn main() {
     let deps_target_dir = original_target_dir.join("compiletest-deps");
     let compiletest_build_dir = original_target_dir.join("compiletest-results");
 
+    // HACK(eddyb) force `compiletest` to pass `ui/...` relative paths to `rustc`,
+    // which should always end up being the same regardless of the path that the
+    // Rust-GPU repo is checked out at (among other things, this avoids harcoded
+    // `compiletest` limits being hit by e.g. users with slightly longer paths).
+    std::env::set_current_dir(tests_dir).unwrap();
+    let tests_dir = PathBuf::from("");
+
     // Pull in rustc_codegen_spirv as a dynamic library in the same way
     // spirv-builder does.
     let codegen_backend_path = find_rustc_codegen_spirv();

--- a/tests/compiletests/ui/dis/asm_op_decorate.rs
+++ b/tests/compiletests/ui/dis/asm_op_decorate.rs
@@ -8,6 +8,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 // FIXME(eddyb) this should use revisions to track both the `vulkan1.2` output
 // and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
 // are not supported in `compiletest-rs`.

--- a/tests/compiletests/ui/dis/asm_op_decorate.stderr
+++ b/tests/compiletests/ui/dis/asm_op_decorate.stderr
@@ -4,7 +4,7 @@ OpExtension "SPV_EXT_descriptor_indexing"
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-%2 = OpString "$OPSTRING_FILENAME/asm_op_decorate.rs"
+%2 = OpString "$DIR/asm_op_decorate.rs"
 OpName %3 "asm_op_decorate::main"
 OpName %4 "asm_op_decorate::add_decorate"
 OpDecorate %5 Binding 0

--- a/tests/compiletests/ui/dis/const-float-cast-optimized.rs
+++ b/tests/compiletests/ui/dis/const-float-cast-optimized.rs
@@ -8,6 +8,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 #[spirv(fragment)]

--- a/tests/compiletests/ui/dis/const-float-cast-optimized.stderr
+++ b/tests/compiletests/ui/dis/const-float-cast-optimized.stderr
@@ -3,7 +3,7 @@ OpCapability Float64
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft
-%3 = OpString "$OPSTRING_FILENAME/const-float-cast-optimized.rs"
+%3 = OpString "$DIR/const-float-cast-optimized.rs"
 OpName %2 "output"
 OpDecorate %2 Location 0
 %4 = OpTypeFloat 64

--- a/tests/compiletests/ui/dis/const-float-cast.rs
+++ b/tests/compiletests/ui/dis/const-float-cast.rs
@@ -7,6 +7,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 #[spirv(fragment)]

--- a/tests/compiletests/ui/dis/const-float-cast.stderr
+++ b/tests/compiletests/ui/dis/const-float-cast.stderr
@@ -3,7 +3,7 @@ OpCapability Float64
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft
-%3 = OpString "$OPSTRING_FILENAME/const-float-cast.rs"
+%3 = OpString "$DIR/const-float-cast.rs"
 OpName %2 "output"
 OpDecorate %2 Location 0
 %4 = OpTypeFloat 32

--- a/tests/compiletests/ui/dis/const-from-cast.rs
+++ b/tests/compiletests/ui/dis/const-from-cast.rs
@@ -8,6 +8,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 const K: u8 = 42;

--- a/tests/compiletests/ui/dis/const-from-cast.stderr
+++ b/tests/compiletests/ui/dis/const-from-cast.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft
-%3 = OpString "$OPSTRING_FILENAME/const-from-cast.rs"
+%3 = OpString "$DIR/const-from-cast.rs"
 OpName %2 "output"
 OpDecorate %2 Location 0
 %4 = OpTypeInt 32 0

--- a/tests/compiletests/ui/dis/const-int-cast.rs
+++ b/tests/compiletests/ui/dis/const-int-cast.rs
@@ -8,6 +8,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 const K: u8 = 20;

--- a/tests/compiletests/ui/dis/const-int-cast.stderr
+++ b/tests/compiletests/ui/dis/const-int-cast.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft
-%3 = OpString "$OPSTRING_FILENAME/const-int-cast.rs"
+%3 = OpString "$DIR/const-int-cast.rs"
 OpName %2 "output"
 OpDecorate %2 Location 0
 %4 = OpTypeInt 32 0

--- a/tests/compiletests/ui/dis/const-narrowing-cast.rs
+++ b/tests/compiletests/ui/dis/const-narrowing-cast.rs
@@ -8,6 +8,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 #[spirv(fragment)]

--- a/tests/compiletests/ui/dis/const-narrowing-cast.stderr
+++ b/tests/compiletests/ui/dis/const-narrowing-cast.stderr
@@ -3,7 +3,7 @@ OpCapability Int8
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft
-%3 = OpString "$OPSTRING_FILENAME/const-narrowing-cast.rs"
+%3 = OpString "$DIR/const-narrowing-cast.rs"
 OpName %2 "output"
 OpDecorate %2 Location 0
 %4 = OpTypeInt 32 0

--- a/tests/compiletests/ui/dis/custom_entry_point.rs
+++ b/tests/compiletests/ui/dis/custom_entry_point.rs
@@ -7,6 +7,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 #[spirv(fragment(entry_point_name = "hello_world"))]

--- a/tests/compiletests/ui/dis/custom_entry_point.stderr
+++ b/tests/compiletests/ui/dis/custom_entry_point.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "hello_world"
 OpExecutionMode %1 OriginUpperLeft
-%2 = OpString "$OPSTRING_FILENAME/custom_entry_point.rs"
+%2 = OpString "$DIR/custom_entry_point.rs"
 OpName %3 "custom_entry_point::main"
 %4 = OpTypeVoid
 %5 = OpTypeFunction %4

--- a/tests/compiletests/ui/dis/generic-fn-op-name.rs
+++ b/tests/compiletests/ui/dis/generic-fn-op-name.rs
@@ -8,6 +8,12 @@
 // normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
+// HACK(eddyb) this comment prevents `rustfmt` from deleting the above empty line.
+//
 #![feature(adt_const_params)]
 #![allow(incomplete_features)]
 

--- a/tests/compiletests/ui/dis/generic-fn-op-name.stderr
+++ b/tests/compiletests/ui/dis/generic-fn-op-name.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-%2 = OpString "$OPSTRING_FILENAME/generic-fn-op-name.rs"
+%2 = OpString "$DIR/generic-fn-op-name.rs"
 OpName %3 "generic_fn_op_name::main"
 OpName %4 "generic_fn_op_name::generic::<f32, {generic_fn_op_name::Dimensionality::TwoD}>"
 %5 = OpTypeVoid

--- a/tests/compiletests/ui/dis/issue-723-output.rs
+++ b/tests/compiletests/ui/dis/issue-723-output.rs
@@ -19,6 +19,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 #[spirv(fragment)]

--- a/tests/compiletests/ui/dis/issue-723-output.stderr
+++ b/tests/compiletests/ui/dis/issue-723-output.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft
-%3 = OpString "$OPSTRING_FILENAME/issue-723-output.rs"
+%3 = OpString "$DIR/issue-723-output.rs"
 OpName %4 "issue_723_output::main"
 OpDecorate %2 Location 0
 %5 = OpTypeFloat 32

--- a/tests/compiletests/ui/dis/non-writable-storage_buffer.rs
+++ b/tests/compiletests/ui/dis/non-writable-storage_buffer.rs
@@ -9,6 +9,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 // FIXME(eddyb) this should use revisions to track both the `vulkan1.2` output
 // and the pre-`vulkan1.2` output, but per-revisions `{only,ignore}-*` directives
 // are not supported in `compiletest-rs`.

--- a/tests/compiletests/ui/dis/non-writable-storage_buffer.stderr
+++ b/tests/compiletests/ui/dis/non-writable-storage_buffer.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main"
 OpExecutionMode %1 OriginUpperLeft
-%2 = OpString "$OPSTRING_FILENAME/non-writable-storage_buffer.rs"
+%2 = OpString "$DIR/non-writable-storage_buffer.rs"
 OpName %3 "buf_imm"
 OpName %4 "buf_mut"
 OpName %5 "buf_interior_mut"

--- a/tests/compiletests/ui/dis/panic_builtin_bounds_check.rs
+++ b/tests/compiletests/ui/dis/panic_builtin_bounds_check.rs
@@ -15,9 +15,11 @@
 // normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
-// normalize-stderr-test "\S:\S*/panic_builtin_bounds_check.rs" -> "$$DIR/panic_builtin_bounds_check.rs"
 // FIXME(eddyb) handle this one in the test runner.
 // normalize-stderr-test "\S*/lib/rustlib/" -> "$$SYSROOT/lib/rustlib/"
+
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
 
 use spirv_std::spirv;
 

--- a/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
+++ b/tests/compiletests/ui/dis/panic_builtin_bounds_check.stderr
@@ -23,11 +23,11 @@ OpDecorate %6 ArrayStride 4
 %18 = OpTypePointer Function %9
 %2 = OpFunction  %7  None %8
 %19 = OpLabel
-OpLine %5 30 4
+OpLine %5 32 4
 %20 = OpVariable  %11  Function
-OpLine %5 30 23
+OpLine %5 32 23
 %21 = OpCompositeConstruct  %6  %12 %13 %14 %15
-OpLine %5 25 4
+OpLine %5 27 4
 OpStore %20 %21
 %22 = OpULessThan  %16  %17 %10
 OpNoLine
@@ -41,7 +41,7 @@ OpLine %4 280 4
 OpNoLine
 OpReturn
 %23 = OpLabel
-OpLine %5 25 4
+OpLine %5 27 4
 %27 = OpIAdd  %9  %12 %17
 %28 = OpInBoundsAccessChain  %18  %20 %27
 %29 = OpLoad  %9  %28

--- a/tests/compiletests/ui/dis/panic_sequential_many.rs
+++ b/tests/compiletests/ui/dis/panic_sequential_many.rs
@@ -16,9 +16,11 @@
 // normalize-stderr-test "OpSource .*\n" -> ""
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
-// normalize-stderr-test "\S:\S*/panic_sequential_many.rs" -> "$$DIR/panic_sequential_many.rs"
 // FIXME(eddyb) handle this one in the test runner.
 // normalize-stderr-test "\S*/lib/rustlib/" -> "$$SYSROOT/lib/rustlib/"
+
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
 
 use spirv_std::spirv;
 

--- a/tests/compiletests/ui/dis/panic_sequential_many.stderr
+++ b/tests/compiletests/ui/dis/panic_sequential_many.stderr
@@ -27,11 +27,11 @@ OpDecorate %5 Location 0
 %5 = OpVariable  %11  Output
 %2 = OpFunction  %12  None %13
 %16 = OpLabel
-OpLine %8 26 12
+OpLine %8 28 12
 %17 = OpLoad  %9  %3
-OpLine %8 26 35
+OpLine %8 28 35
 %18 = OpLoad  %9  %4
-OpLine %8 29 9
+OpLine %8 31 9
 %19 = OpIEqual  %14  %18 %15
 OpNoLine
 OpSelectionMerge %20 None
@@ -44,7 +44,7 @@ OpReturn
 %22 = OpLabel
 OpBranch %20
 %20 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %24 = OpUDiv  %9  %17 %18
 %25 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -58,7 +58,7 @@ OpReturn
 %28 = OpLabel
 OpBranch %26
 %26 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %30 = OpUDiv  %9  %24 %18
 %31 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -72,7 +72,7 @@ OpReturn
 %34 = OpLabel
 OpBranch %32
 %32 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %36 = OpUDiv  %9  %30 %18
 %37 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -86,7 +86,7 @@ OpReturn
 %40 = OpLabel
 OpBranch %38
 %38 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %42 = OpUDiv  %9  %36 %18
 %43 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -100,7 +100,7 @@ OpReturn
 %46 = OpLabel
 OpBranch %44
 %44 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %48 = OpUDiv  %9  %42 %18
 %49 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -114,7 +114,7 @@ OpReturn
 %52 = OpLabel
 OpBranch %50
 %50 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %54 = OpUDiv  %9  %48 %18
 %55 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -128,7 +128,7 @@ OpReturn
 %58 = OpLabel
 OpBranch %56
 %56 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %60 = OpUDiv  %9  %54 %18
 %61 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -142,7 +142,7 @@ OpReturn
 %64 = OpLabel
 OpBranch %62
 %62 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %66 = OpUDiv  %9  %60 %18
 %67 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -156,7 +156,7 @@ OpReturn
 %70 = OpLabel
 OpBranch %68
 %68 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %72 = OpUDiv  %9  %66 %18
 %73 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -170,7 +170,7 @@ OpReturn
 %76 = OpLabel
 OpBranch %74
 %74 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %78 = OpUDiv  %9  %72 %18
 %79 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -184,7 +184,7 @@ OpReturn
 %82 = OpLabel
 OpBranch %80
 %80 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %84 = OpUDiv  %9  %78 %18
 %85 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -198,7 +198,7 @@ OpReturn
 %88 = OpLabel
 OpBranch %86
 %86 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %90 = OpUDiv  %9  %84 %18
 %91 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -212,7 +212,7 @@ OpReturn
 %94 = OpLabel
 OpBranch %92
 %92 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %96 = OpUDiv  %9  %90 %18
 %97 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -226,7 +226,7 @@ OpReturn
 %100 = OpLabel
 OpBranch %98
 %98 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %102 = OpUDiv  %9  %96 %18
 %103 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -240,7 +240,7 @@ OpReturn
 %106 = OpLabel
 OpBranch %104
 %104 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %108 = OpUDiv  %9  %102 %18
 %109 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -254,7 +254,7 @@ OpReturn
 %112 = OpLabel
 OpBranch %110
 %110 = OpLabel
-OpLine %8 29 9
+OpLine %8 31 9
 %114 = OpUDiv  %9  %108 %18
 %115 = OpIEqual  %14  %18 %15
 OpNoLine
@@ -268,7 +268,7 @@ OpReturn
 %118 = OpLabel
 OpBranch %116
 %116 = OpLabel
-OpLine %8 29 4
+OpLine %8 31 4
 %120 = OpUDiv  %9  %114 %18
 OpStore %5 %120
 OpNoLine

--- a/tests/compiletests/ui/dis/spec_constant-attr.rs
+++ b/tests/compiletests/ui/dis/spec_constant-attr.rs
@@ -9,6 +9,9 @@
 // normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
 // normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
 
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
 use spirv_std::spirv;
 
 #[spirv(fragment)]

--- a/tests/compiletests/ui/dis/spec_constant-attr.stderr
+++ b/tests/compiletests/ui/dis/spec_constant-attr.stderr
@@ -2,7 +2,7 @@ OpCapability Shader
 OpMemoryModel Logical Simple
 OpEntryPoint Fragment %1 "main" %2
 OpExecutionMode %1 OriginUpperLeft
-%3 = OpString "$OPSTRING_FILENAME/spec_constant-attr.rs"
+%3 = OpString "$DIR/spec_constant-attr.rs"
 OpName %4 "no_default"
 OpName %5 "default_0"
 OpName %6 "default_123"


### PR DESCRIPTION
This PR makes the `compiletests` runner change its current working dir to `tests/compiletests/`, allowing the source paths, that the `compiletest` crate invokes `rustc` with, to always be relative e.g. `ui/foo/bar.rs`.

Among other things, this should help with @Firestar99 not being able to get the `ui/spirv-attr/invalid-target.rs` test to pass, because the JSON output is slightly too long and gets abbreviated with a big `<<<<<< SKIPPED 1026 BYTES >>>>>>` in the middle, due to *harcoded limits in the `compiletest` crate itself*.

---

This also cleans up the `$OPSTRING_FILENAME` hack used by disassembly tests, but I'm worried that will break on Windows again, so I'm opening this as a draft to see what that situation is like.
<sub>(I do think that the main reason for that hack was that the replacement of the test base path w/ `$DIR` wouldn't kick in on Windows, but that's a much bigger issue for absolute paths, than for relative ones, so it might be easier to work around it now)</sub>

**EDIT**: the situation is predictable enough that I added a `"ui/dis/" -> "$DIR"` normalization rule to the impacted tests (by that point, `compiletest` had already replaced all `\\` with `/`, so even if its own `$DIR` replacement failed, it should at least predictably result in paths like `ui/dis/` even on Windows).