### PR TITLE
ci: simplify clippy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,7 +242,9 @@ jobs:
         run: |
           RUSTDOCFLAGS=-Dwarnings cargo +stable doc --no-deps -p spirv-std
           RUSTDOCFLAGS=-Dwarnings cargo +stable doc --no-deps -p spirv-builder --no-default-features
-      - name: Clippy & custom lints
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: custom lints
         run: .github/workflows/lint.sh
 
   cargo-deny:

--- a/.github/workflows/lint.sh
+++ b/.github/workflows/lint.sh
@@ -1,57 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-if [[ -z "${CI}" ]]; then
-    FEAT="use-compiled-tools"
-else
-    FEAT="use-installed-tools"
-fi
-
-function clippy() {
-    echo ::group::"$1"
-    cargo clippy \
-        --manifest-path "$1/Cargo.toml" \
-        --no-default-features \
-        --features "$FEAT" \
-        --all-targets \
-        -- -D warnings
-    echo ::endgroup::
-}
-
-function clippy_no_features() {
-    echo ::group::"$1"
-    cargo clippy \
-        --manifest-path "$1/Cargo.toml" \
-        --all-targets \
-        -- -D warnings
-    echo ::endgroup::
-}
-
-# Core crates
-clippy_no_features crates/rustc_codegen_spirv-target-specs
-clippy_no_features crates/rustc_codegen_spirv-types
-clippy crates/rustc_codegen_spirv
-clippy crates/spirv-builder
-clippy_no_features crates/spirv-std
-
-# Examples
-clippy examples/multibuilder
-clippy examples/runners/ash
-clippy_no_features examples/runners/cpu
-clippy examples/runners/wgpu
-
-# shaders
-clippy_no_features examples/shaders/sky-shader
-clippy_no_features examples/shaders/simplest-shader
-clippy_no_features examples/shaders/compute-shader
-clippy_no_features examples/shaders/mouse-shader
-clippy_no_features examples/shaders/reduce
-
-# tests
-clippy tests/compiletests
-clippy tests/difftests/bin
-clippy tests/difftests/lib
-
 # Custom lints
 
 # 1. Disallow `std::env` (mis)use from `rustc_codegen_spirv`
@@ -111,6 +60,11 @@ version_test crates/spirv-std
 # HACK(eddyb) see `crates/rustc_codegen_spirv/build.rs` for more on `pqp_cg_ssa`
 # (a patched copy of `rustc_codegen_ssa`).
 echo ::group::rustc_codegen_spirv_disable_pqp_cg_ssa
+if [[ -z "${CI}" ]]; then
+    FEAT="use-compiled-tools"
+else
+    FEAT="use-installed-tools"
+fi
 cargo clippy \
     --manifest-path "crates/rustc_codegen_spirv/Cargo.toml" \
     --no-default-features \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,9 +2861,9 @@ version = "0.9.0"
 
 [[package]]
 name = "spirv-tools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa073f1f465ad80b16f0e2b0151389c9fcfeee83c5daa4361fe8c1d24f0e0b0c"
+checksum = "fc3664e43ea7c03e2ed668bc0544c2b73dddd7a868eb93ccfcc64ee1deb1431e"
 dependencies = [
  "memchr",
  "spirv-tools-sys",
@@ -2872,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools-sys"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c95b52623ba771b5172dea9f04799928ce53ebc2ffc360c69d0fea3c3248d8"
+checksum = "0ca70856dae44c3692c4b65e87f29a45861e4b6357f3b582016f767e1f7d1717"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ spirv-builder = { path = "./crates/spirv-builder", version = "=0.9.0", default-f
 spirv-std = { path = "./crates/spirv-std", version = "=0.9.0" }
 spirv-std-types = { path = "./crates/spirv-std/shared", version = "=0.9.0" }
 spirv-std-macros = { path = "./crates/spirv-std/macros", version = "=0.9.0" }
-spirv-tools = { version = "0.12", default-features = false }
+spirv-tools = { version = "0.12.1", default-features = false }
 rustc_codegen_spirv = { path = "./crates/rustc_codegen_spirv", version = "=0.9.0", default-features = false }
 rustc_codegen_spirv-types = { path = "./crates/rustc_codegen_spirv-types", version = "=0.9.0" }
 rustc_codegen_spirv-target-specs = { path = "crates/rustc_codegen_spirv-target-specs", version = "=0.9.0" }


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/spirv-tools-rs/pull/16 and publishing spirv-tools 0.12.1

> Hmpf, unfortunate that we can't pass the features somehow, to a single `cargo clippy --workspace` invocation.
> 
> Alternatively, it might be nice to not have SPIRV-Tools' C++ code be compiled by `spirv-tools-rs` when built for `cargo check`/`cargo clippy`, but I don't recall if that's even feasible to do.

https://github.com/Rust-GPU/rust-gpu/pull/329#pullrequestreview-3009595291

Well, now we can :D

This also speeds up our lint CI from 7m to 6m, likely from better multi-core utilization due to checking more crates in parallel
