### PR TITLE
Add HitTriangleVertexPositionsKHR built-in for ray tracing pipelines

### DIFF
--- a/crates/rustc_codegen_spirv/src/symbols.rs
+++ b/crates/rustc_codegen_spirv/src/symbols.rs
@@ -138,6 +138,10 @@ const BUILTINS: &[(&str, BuiltIn)] = {
         ("ray_tmax", BuiltIn::RayTmaxKHR),
         ("object_to_world", BuiltIn::ObjectToWorldKHR),
         ("world_to_object", BuiltIn::WorldToObjectKHR),
+        (
+            "hit_triangle_vertex_positions",
+            BuiltIn::HitTriangleVertexPositionsKHR,
+        ),
         ("hit_kind", BuiltIn::HitKindKHR),
         ("incoming_ray_flags", BuiltIn::IncomingRayFlagsKHR),
         ("warps_per_sm_nv", WarpsPerSMNV),


### PR DESCRIPTION
Vulkan extension: https://registry.khronos.org/vulkan/specs/latest/man/html/HitTriangleVertexPositionsKHR.html
SPIRV extension: https://github.khronos.org/SPIRV-Registry/extensions/KHR/SPV_KHR_ray_tracing_position_fetch.html

Note that this PR only adds the RayTracing[Pipeline] part, not the RayQuery part.