### PR TITLE
Customize `Function` and `BasicBlock` to carry both a SPIR-V ID and an index, for O(1) access.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/ext_inst.rs
+++ b/crates/rustc_codegen_spirv/src/builder/ext_inst.rs
@@ -41,7 +41,7 @@ impl ExtInst {
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     pub fn custom_inst(
-        &self,
+        &mut self,
         result_type: Word,
         inst: custom_insts::CustomInst<Operand>,
     ) -> SpirvValue {
@@ -58,7 +58,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             .with_type(result_type)
     }
 
-    pub fn gl_op(&self, op: GLOp, result_type: Word, args: impl AsRef<[SpirvValue]>) -> SpirvValue {
+    pub fn gl_op(
+        &mut self,
+        op: GLOp,
+        result_type: Word,
+        args: impl AsRef<[SpirvValue]>,
+    ) -> SpirvValue {
         let args = args.as_ref();
         let glsl = self.ext_inst.borrow_mut().import_glsl(self);
         self.emit()

--- a/crates/rustc_codegen_spirv/src/builder/mod.rs
+++ b/crates/rustc_codegen_spirv/src/builder/mod.rs
@@ -47,8 +47,12 @@ pub struct Builder<'a, 'tcx> {
 
 impl<'a, 'tcx> Builder<'a, 'tcx> {
     /// See comment on `BuilderCursor`
-    pub fn emit(&self) -> std::cell::RefMut<'_, rspirv::dr::Builder> {
-        self.emit_with_cursor(self.cursor)
+    //
+    // FIXME(eddyb) take advantage of `&mut self` to avoid `RefCell` entirely
+    // (sadly it requires making `&CodegeCx`'s types/consts more like SPIR-T,
+    // and completely disjoint from mutably building functions).
+    pub fn emit(&mut self) -> std::cell::RefMut<'a, rspirv::dr::Builder> {
+        self.cx.emit_with_cursor(self.cursor)
     }
 
     pub fn zombie(&self, word: Word, reason: &str) {

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -538,7 +538,7 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
         };
         let inst_class = inst_name
             .strip_prefix("Op")
-            .and_then(|n| self.instruction_table.table.get(n));
+            .and_then(|n| self.cx.instruction_table.table.get(n));
         let inst_class = if let Some(inst) = inst_class {
             inst
         } else {

--- a/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
+++ b/crates/rustc_codegen_spirv/src/builder/spirv_asm.rs
@@ -3,7 +3,7 @@ use crate::maybe_pqp_cg_ssa as rustc_codegen_ssa;
 
 use super::Builder;
 use crate::abi::ConvSpirvType;
-use crate::builder_spirv::{BuilderCursor, SpirvValue};
+use crate::builder_spirv::SpirvValue;
 use crate::codegen_cx::CodegenCx;
 use crate::spirv_type::SpirvType;
 use rspirv::dr;
@@ -418,12 +418,11 @@ impl<'cx, 'tcx> Builder<'cx, 'tcx> {
                 // OpVariable with Function storage class should be emitted inside the function,
                 // however, all other OpVariables should appear in the global scope instead.
                 if inst.operands[0].unwrap_storage_class() == StorageClass::Function {
-                    self.emit_with_cursor(BuilderCursor {
-                        block: Some(0),
-                        ..self.cursor
-                    })
-                    .insert_into_block(dr::InsertPoint::Begin, inst)
-                    .unwrap();
+                    let mut builder = self.emit();
+                    builder.select_block(Some(0)).unwrap();
+                    builder
+                        .insert_into_block(dr::InsertPoint::Begin, inst)
+                        .unwrap();
                 } else {
                     self.emit_global()
                         .insert_types_global_values(dr::InsertPoint::End, inst);


### PR DESCRIPTION
As may be obvious from the first commit, I was hoping to remove the `RefCell` around the `rspirv::dr::Builder`.
<sub>(it's still possible, but it would require keeping global and function builders separate, and using different ID ranges, and I almost jerry-rigged some contraption using `spirt::{Context,Type,Const}` but it'd be too much work to port everything over, not to mention new exciting failure modes)</sub>

---

Instead, I ended up fixing a long-standing issue with how we expose SPIR-V functions and blocks to `rustc_codegen_ssa` - which is mostly straight-forward, as it already has associated types for `Function` and `BasicBlock`, we were just using raw SPIR-V IDs (or `SpirvValue`, in the case of `Function`) for no good reason.

After this PR, we're always tracking the `rspirv::dr::Builder` function/block indices, not just IDs (while still using IDs to validate that the index didn't go out of sync due to ad-hoc mutation etc.), so there shouldn't be any reason to iterate through functions (or through a function's blocks) searching for a specific ID.

There were already some fast paths before, so this might not have much impact on perf, but I still like the result (if nothing else, it should be harder to misuse, and I even got to remove a silly `call` special-case).