### PR TITLE
ci: fix two PRs with same branch name but different forks canceling each other

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ name: CI
 
 # Cancel PR actions on new commits
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Happened with https://github.com/Rust-GPU/rust-gpu/pull/339 and https://github.com/Rust-GPU/rust-gpu/pull/335 where the branch is named `main` but from two different forks. This should hopefully prevent it in the future, though I won't verify that this actually fixed it since we're already merging one of them.

https://docs.github.com/en/actions/reference/contexts-reference#github-context