### PR TITLE
Add `RayQuery::get_intersection_triangle_vertex_positions()` extension

### DIFF
--- a/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
+++ b/crates/rustc_codegen_spirv/src/spirv_type_constraints.rs
@@ -1104,9 +1104,7 @@ pub fn instruction_signatures(op: Op) -> Option<&'static [InstSig<'static>]> {
             reserved!(SPV_NV_displacement_micromap)
         }
         // SPV_KHR_ray_tracing_position_fetch
-        Op::RayQueryGetIntersectionTriangleVertexPositionsKHR => {
-            reserved!(SPV_KHR_ray_tracing_position_fetch)
-        }
+        Op::RayQueryGetIntersectionTriangleVertexPositionsKHR => {}
         // SPV_INTEL_bfloat16_conversion
         Op::ConvertFToBF16INTEL | Op::ConvertBF16ToFINTEL => {
             reserved!(SPV_INTEL_bfloat16_conversion)

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -1061,4 +1061,27 @@ impl RayQuery {
             result
         }
     }
+
+    /// Gets the vertex positions for the triangle at the current intersection.
+    ///
+    /// Requires Capability `RayQueryPositionFetchKHR` and extension `SPV_KHR_ray_tracing_position_fetch`
+    #[spirv_std_macros::gpu_only]
+    #[doc(alias = "OpRayQueryGetIntersectionTriangleVertexPositionsKHR")]
+    #[inline]
+    pub unsafe fn get_intersection_triangle_vertex_positions<V: Vector<f32, 3>>(&self) -> [V; 3] {
+        unsafe {
+            let mut result = Default::default();
+
+            asm! {
+                "%u32 = OpTypeInt 32 0",
+                "%intersection = OpConstant %u32 0",
+                "%result = OpRayQueryGetIntersectionTriangleVertexPositionsKHR typeof*{result} {ray_query} %intersection",
+                "OpStore {result} %result",
+                ray_query = in(reg) self,
+                result = in(reg) &mut result,
+            }
+
+            result
+        }
+    }
 }

--- a/tests/compiletests/ui/arch/ray_query_get_intersection_triangle_vertex_positions.rs
+++ b/tests/compiletests/ui/arch/ray_query_get_intersection_triangle_vertex_positions.rs
@@ -1,0 +1,24 @@
+// build-pass
+// compile-flags: -Ctarget-feature=+RayQueryKHR,+ext:SPV_KHR_ray_query
+// compile-flags: -Ctarget-feature=+RayQueryPositionFetchKHR,+ext:SPV_KHR_ray_tracing_position_fetch
+
+use glam::{Vec3, Vec4};
+use spirv_std::ray_tracing::{AccelerationStructure, RayFlags, RayQuery};
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main(
+    #[spirv(descriptor_set = 0, binding = 0)] accel: &AccelerationStructure,
+    out0: &mut Vec4,
+    out1: &mut Vec4,
+    out2: &mut Vec4,
+) {
+    unsafe {
+        spirv_std::ray_query!(let mut handle);
+        handle.initialize(accel, RayFlags::NONE, 0, Vec3::ZERO, 0.0, Vec3::ZERO, 0.0);
+        let vertex_positions: [Vec3; 3] = handle.get_intersection_triangle_vertex_positions();
+        *out0 = Vec4::from((vertex_positions[0], 1.));
+        *out1 = Vec4::from((vertex_positions[1], 1.));
+        *out2 = Vec4::from((vertex_positions[2], 1.));
+    }
+}


### PR DESCRIPTION
followup from https://github.com/Rust-GPU/rust-gpu/pull/339 adding it for ray_tracing pipelines

Vulkan extension: https://registry.khronos.org/vulkan/specs/latest/man/html/HitTriangleVertexPositionsKHR.html
SPIRV extension: https://github.khronos.org/SPIRV-Registry/extensions/KHR/SPV_KHR_ray_tracing_position_fetch.html