### PR TITLE
Update `ShaderPanicStrategy::DebugPrintfThenExit` documentation for Vulkan SDK changes.

### DIFF
--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -150,10 +150,7 @@ fn maybe_watch(
                 }
             } else {
                 spirv_builder::ShaderPanicStrategy::SilentExit
-            })
-            // HACK(eddyb) needed because of `debugPrintf` instrumentation limitations
-            // (see https://github.com/KhronosGroup/SPIRV-Tools/issues/4892).
-            .multimodule(has_debug_printf);
+            });
 
         fn handle_compile_result(compile_result: CompileResult) -> CompiledShaderModules {
             let load_spv_module = |path| {


### PR DESCRIPTION
I noticed a few changes in the Vulkan Validation Layer documentation and ended up with these items:
- `multimodule` recommendation is no longer necessary (since Vulkan SDK 1.3.275.0):
  - issue: https://github.com/KhronosGroup/SPIRV-Tools/issues/4892
  - PR: https://github.com/KhronosGroup/SPIRV-Tools/pull/5495
- `DEBUG_PRINTF_TO_STDOUT=1` is now `VK_LAYER_PRINTF_TO_STDOUT=1` (since Vulkan SDK 1.3.283.0)
  - old env var still works (just deprecated), but the new one fits in better
  - PR: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7781
- `VK_KHR_shader_non_semantic_info` isn't required anymore (since Vulkan SDK 1.4.313.0)
  - we should stop mentioning it, but it's recent and I left it in just in case
  - issue: https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9716
  - PR: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9718

I'm not sure how happy I am with the result, but it tries the offer both an easy set of env vars
(`VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation VK_LAYER_PRINTF_ONLY_PRESET=1 VK_LAYER_PRINTF_TO_STDOUT=1`)
and detailed explanations of all the moving parts, in case that doesn't suffice.

Honestly, we should probably have a separate document, and/or move this to `debug_printf!`
(and merely refer to it from this setting), since users trying that out would also need this info.

---

As a sneak peek, this is a screenshot of the new docs (click to open its full size):
<img height="300" src="https://github.com/user-attachments/assets/aa746536-b87d-4268-a7e8-63bd0c7f039a" />
