### PR TITLE
Add Image::fetch_with_lod

### DIFF
--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -174,22 +174,7 @@ impl<
     where
         I: Integer,
     {
-        let mut result = SampledType::Vec4::default();
-        unsafe {
-            asm! {
-                "OpDecorate %image NonUniform",
-                "OpDecorate %result NonUniform",
-                "%image = OpLoad _ {this}",
-                "%coordinate = OpLoad _ {coordinate}",
-                "%result = OpImageFetch typeof*{result} %image %coordinate Lod {lod}",
-                "OpStore {result} %result",
-                result = in(reg) &mut result,
-                this = in(reg) self,
-                coordinate = in(reg) &coordinate,
-                lod = in(reg) lod,
-            }
-        }
-        result.truncate_into()
+        self.fetch_with(coordinate, sample_with::lod(lod))
     }
 }
 

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -163,13 +163,13 @@ impl<
         result.truncate_into()
     }
 
-    /// Fetch a single texel at a mipmap `level` with a sampler set at compile time
+    /// Fetch a single texel at a mipmap `lod` with a sampler set at compile time
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageFetch")]
-    pub fn fetch_with_level<I>(
+    pub fn fetch_with_lod<I>(
         &self,
         coordinate: impl ImageCoordinate<I, DIM, ARRAYED>,
-        level: u32,
+        lod: u32,
     ) -> SampledType::SampleResult
     where
         I: Integer,
@@ -181,12 +181,12 @@ impl<
                 "OpDecorate %result NonUniform",
                 "%image = OpLoad _ {this}",
                 "%coordinate = OpLoad _ {coordinate}",
-                "%result = OpImageFetch typeof*{result} %image %coordinate Lod {level}",
+                "%result = OpImageFetch typeof*{result} %image %coordinate Lod {lod}",
                 "OpStore {result} %result",
                 result = in(reg) &mut result,
                 this = in(reg) self,
                 coordinate = in(reg) &coordinate,
-                level = in(reg) level,
+                lod = in(reg) lod,
             }
         }
         result.truncate_into()

--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -164,6 +164,8 @@ impl<
     }
 
     /// Fetch a single texel at a mipmap `lod` with a sampler set at compile time
+    ///
+    /// `lod` is also known as `level` in WGSL's `textureLoad`
     #[crate::macros::gpu_only]
     #[doc(alias = "OpImageFetch")]
     pub fn fetch_with_lod<I>(

--- a/tests/compiletests/ui/image/fetch_with_level.rs
+++ b/tests/compiletests/ui/image/fetch_with_level.rs
@@ -1,0 +1,13 @@
+// build-pass
+
+use spirv_std::spirv;
+use spirv_std::{Image, arch};
+
+#[spirv(fragment)]
+pub fn main(
+    #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled),
+    output: &mut glam::Vec4,
+) {
+    let texel = image.fetch_with_level(glam::IVec2::new(0, 1), 0);
+    *output = texel;
+}

--- a/tests/compiletests/ui/image/fetch_with_lod.rs
+++ b/tests/compiletests/ui/image/fetch_with_lod.rs
@@ -8,6 +8,6 @@ pub fn main(
     #[spirv(descriptor_set = 0, binding = 0)] image: &Image!(2D, type=f32, sampled),
     output: &mut glam::Vec4,
 ) {
-    let texel = image.fetch_with_level(glam::IVec2::new(0, 1), 0);
+    let texel = image.fetch_with_lod(glam::IVec2::new(0, 1), 0);
     *output = texel;
 }

--- a/tests/compiletests/ui/image/gather_err.stderr
+++ b/tests/compiletests/ui/image/gather_err.stderr
@@ -9,12 +9,12 @@ error[E0277]: the trait bound `Image<f32, 0, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:199:15
+   --> $SPIRV_STD_SRC/image.rs:215:15
     |
-192 |     pub fn gather<F>(
+208 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-199 |         Self: HasGather,
+215 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is not satisfied
@@ -28,12 +28,12 @@ error[E0277]: the trait bound `Image<f32, 2, 2, 0, 0, 1, 0, 4>: HasGather` is no
               Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-   --> $SPIRV_STD_SRC/image.rs:199:15
+   --> $SPIRV_STD_SRC/image.rs:215:15
     |
-192 |     pub fn gather<F>(
+208 |     pub fn gather<F>(
     |            ------ required by a bound in this associated function
 ...
-199 |         Self: HasGather,
+215 |         Self: HasGather,
     |               ^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
 
 error: aborting due to 2 previous errors

--- a/tests/compiletests/ui/image/query/query_levels_err.stderr
+++ b/tests/compiletests/ui/image/query/query_levels_err.stderr
@@ -10,12 +10,12 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
-   --> $SPIRV_STD_SRC/image.rs:951:15
+   --> $SPIRV_STD_SRC/image.rs:967:15
     |
-949 |     pub fn query_levels(&self) -> u32
+965 |     pub fn query_levels(&self) -> u32
     |            ------------ required by a bound in this associated function
-950 |     where
-951 |         Self: HasQueryLevels,
+966 |     where
+967 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
 
 error: aborting due to 1 previous error

--- a/tests/compiletests/ui/image/query/query_lod_err.stderr
+++ b/tests/compiletests/ui/image/query/query_lod_err.stderr
@@ -10,12 +10,12 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQueryLevels` 
               Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
               Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
-   --> $SPIRV_STD_SRC/image.rs:980:15
+   --> $SPIRV_STD_SRC/image.rs:996:15
     |
-974 |     pub fn query_lod(
+990 |     pub fn query_lod(
     |            --------- required by a bound in this associated function
 ...
-980 |         Self: HasQueryLevels,
+996 |         Self: HasQueryLevels,
     |               ^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
 
 error: aborting due to 1 previous error

--- a/tests/compiletests/ui/image/query/query_size_err.stderr
+++ b/tests/compiletests/ui/image/query/query_size_err.stderr
@@ -15,12 +15,12 @@ error[E0277]: the trait bound `Image<f32, 1, 2, 0, 0, 1, 0, 4>: HasQuerySize` is
                Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
              and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
-    --> $SPIRV_STD_SRC/image.rs:1015:15
+    --> $SPIRV_STD_SRC/image.rs:1031:15
      |
-1013 |     pub fn query_size<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(&self) -> Size
+1029 |     pub fn query_size<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(&self) -> Size
      |            ---------- required by a bound in this associated function
-1014 |     where
-1015 |         Self: HasQuerySize,
+1030 |     where
+1031 |         Self: HasQuerySize,
      |               ^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
 
 error: aborting due to 1 previous error

--- a/tests/compiletests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/compiletests/ui/image/query/query_size_lod_err.stderr
@@ -10,12 +10,12 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod`
                Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
                Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
-    --> $SPIRV_STD_SRC/image.rs:1061:15
+    --> $SPIRV_STD_SRC/image.rs:1077:15
      |
-1056 |     pub fn query_size_lod<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(
+1072 |     pub fn query_size_lod<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(
      |            -------------- required by a bound in this associated function
 ...
-1061 |         Self: HasQuerySizeLod,
+1077 |         Self: HasQuerySizeLod,
      |               ^^^^^^^^^^^^^^^ required by this bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
 
 error: aborting due to 1 previous error

--- a/tests/compiletests/ui/image/query/sampled_image_rect_query_size_lod_err.stderr
+++ b/tests/compiletests/ui/image/query/sampled_image_rect_query_size_lod_err.stderr
@@ -10,12 +10,12 @@ error[E0277]: the trait bound `Image<f32, 4, 2, 0, 0, 1, 0, 4>: HasQuerySizeLod`
                Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
                Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `SampledImage::<Image<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#9}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>>::query_size_lod`
-    --> /image.rs:1226:12
+    --> /image.rs:1242:12
      |
-1212 |     pub fn query_size_lod<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(
+1228 |     pub fn query_size_lod<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(
      |            -------------- required by a bound in this associated function
 ...
-1226 |         >: HasQuerySizeLod,
+1242 |         >: HasQuerySizeLod,
      |            ^^^^^^^^^^^^^^^ required by this bound in `SampledImage::<Image<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#9}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>>::query_size_lod`
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
Fixes #360

I used the terminology `level` since that's what WGSL used, but it would also make sense to use `lod` since that's what SPIR-V and GLSL's `texelFetch` use.