### PR TITLE
Try dumping, when a SPIR-T pass panics, its in-progress `spirt::Module` state.

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/spirt_passes/mod.rs
@@ -120,7 +120,7 @@ pub(super) fn run_func_passes<P>(
     passes: &[impl AsRef<str>],
     // FIXME(eddyb) this is a very poor approximation of a "profiler" abstraction.
     mut before_pass: impl FnMut(&'static str, &Module) -> P,
-    mut after_pass: impl FnMut(&'static str, &Module, P),
+    mut after_pass: impl FnMut(Option<&Module>, P),
 ) {
     let cx = &module.cx();
 
@@ -156,15 +156,15 @@ pub(super) fn run_func_passes<P>(
 
             let profiler = before_pass("qptr::lower_from_spv_ptrs", module);
             spirt::passes::qptr::lower_from_spv_ptrs(module, layout_config);
-            after_pass("qptr::lower_from_spv_ptrs", module, profiler);
+            after_pass(Some(module), profiler);
 
             let profiler = before_pass("qptr::analyze_uses", module);
             spirt::passes::qptr::analyze_uses(module, layout_config);
-            after_pass("qptr::analyze_uses", module, profiler);
+            after_pass(Some(module), profiler);
 
             let profiler = before_pass("qptr::lift_to_spv_ptrs", module);
             spirt::passes::qptr::lift_to_spv_ptrs(module, layout_config);
-            after_pass("qptr::lift_to_spv_ptrs", module, profiler);
+            after_pass(Some(module), profiler);
 
             continue;
         }
@@ -187,7 +187,7 @@ pub(super) fn run_func_passes<P>(
                 remove_unused_values_in_func(cx, func_def_body);
             }
         }
-        after_pass(full_name, module, profiler);
+        after_pass(Some(module), profiler);
     }
 }
 


### PR DESCRIPTION
While SPIR-T passes should, in principle, never panic, it can still happen (esp. with WIP code, where e.g. `assert!`s or `todo!()`s might be overrepresented etc.), and before this PR, the partially modified SPIR-T module would be completely lost in the `--dump-spirt-passes` output.

And because incomplete SPIR-T mutation could result in extremely malformed modules, this PR also wraps the SPIR-T pretty-printing in `std::panic::catch_unwind`, removing one pass' "after" state, at a time, from the pretty-printed versions, while it still panics, and showing an extra warning (with all the pass names that couldn't be printed) if that was necessary at all.

Also, there's a minor ergonomic fix in that `after_pass` doesn't need to also be passed the same string as `before_pass` (since `SpirtDumpGuard` is tracking it anyway).