### PR TITLE
Fix `libm` intrinsics for versions newer than `0.2.11`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.3", features = ["env-filter", "json"] }
 num-traits = { version = "0.2.15", default-features = false }
 glam = { version = ">=0.22, <=0.30", default-features = false }
-# libm 0.2.12 is a breaking change with new intrinsics
-libm = { version = ">=0.2.5, <=0.2.11", default-features = false }
+libm = { version = ">=0.2.5", default-features = false }
 bytemuck = { version = "1.23", features = ["derive"] }
 
 # Enable incremental by default in release mode.


### PR DESCRIPTION
Resolves #242 in another way by allowing to update `libm` dependency

I think that backend tried to replace all the public functions usages inside of `libm` itself, which caused issue #242 in the first place.

Without suggested changes, compilation fails with ICE similar to this one:
```
error: internal compiler error: compiler\rustc_middle\src\ty\mod.rs:1631:13: item_name: no name for DefPath { data: [DisambiguatedDefPathData { data: TypeNs("math"), disambiguator: 0 }, DisambiguatedDefPathData { data: TypeNs("generic"), disambiguator: 0 }, DisambiguatedDefPathData { data: TypeNs("rint"), disambiguator: 0 }, DisambiguatedDefPathData { data: ValueNs("rint_round"), disambiguator: 0 }, DisambiguatedDefPathData { data: Closure, disambiguator: 0 }], krate: crate0 }
```

Note that local `DefId` has `krate` field defined as `LOCAL_CRATE`, or `CrateNum::ZERO`, which `Display` impl is exactly `crate0`