### PR TITLE
spirv_asm: use `line_spans` for slightly better source locations.

### DIFF
--- a/tests/compiletests/ui/arch/all_memory_barrier.stderr
+++ b/tests/compiletests/ui/arch/all_memory_barrier.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 78 8
+OpLine %5 82 13
 OpMemoryBarrier %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/all_memory_barrier_with_group_sync.stderr
+++ b/tests/compiletests/ui/arch/all_memory_barrier_with_group_sync.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 42 8
+OpLine %5 47 13
 OpControlBarrier %6 %7 %8
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/device_memory_barrier.stderr
+++ b/tests/compiletests/ui/arch/device_memory_barrier.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 78 8
+OpLine %5 82 13
 OpMemoryBarrier %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/device_memory_barrier_with_group_sync.stderr
+++ b/tests/compiletests/ui/arch/device_memory_barrier_with_group_sync.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 42 8
+OpLine %5 47 13
 OpControlBarrier %6 %7 %8
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/subgroup/subgroup_ballot.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_ballot.stderr
@@ -1,9 +1,9 @@
 %1 = OpFunction  %2  None %3
 %4 = OpFunctionParameter  %2
 %5 = OpLabel
-OpLine %6 373 8
+OpLine %6 378 13
 %7 = OpGroupNonUniformBallot  %8  %9 %4
-OpLine %6 412 8
+OpLine %6 417 13
 %10 = OpGroupNonUniformInverseBallot  %2  %9 %7
 OpNoLine
 OpReturnValue %10

--- a/tests/compiletests/ui/arch/subgroup/subgroup_broadcast_first.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_broadcast_first.stderr
@@ -1,7 +1,7 @@
 %1 = OpFunction  %2  None %3
 %4 = OpFunctionParameter  %2
 %5 = OpLabel
-OpLine %6 340 8
+OpLine %6 344 13
 %7 = OpGroupNonUniformBroadcastFirst  %2  %8 %4
 OpNoLine
 OpReturnValue %7

--- a/tests/compiletests/ui/arch/subgroup/subgroup_elect.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_elect.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 170 8
+OpLine %5 174 13
 %6 = OpGroupNonUniformElect  %2  %7
 OpNoLine
 OpReturnValue %6

--- a/tests/compiletests/ui/arch/workgroup_memory_barrier.stderr
+++ b/tests/compiletests/ui/arch/workgroup_memory_barrier.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 78 8
+OpLine %5 82 13
 OpMemoryBarrier %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/workgroup_memory_barrier_with_group_sync.stderr
+++ b/tests/compiletests/ui/arch/workgroup_memory_barrier_with_group_sync.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 42 8
+OpLine %5 47 13
 OpControlBarrier %6 %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/dis/asm.stderr
+++ b/tests/compiletests/ui/dis/asm.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 9 8
+OpLine %5 13 13
 OpMemoryBarrier %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/dis/asm_add_two_ints.stderr
+++ b/tests/compiletests/ui/dis/asm_add_two_ints.stderr
@@ -2,7 +2,7 @@
 %4 = OpFunctionParameter  %2
 %5 = OpFunctionParameter  %2
 %6 = OpLabel
-OpLine %7 10 8
+OpLine %7 11 13
 %8 = OpIAdd  %2  %4 %5
 OpNoLine
 OpReturnValue %8

--- a/tests/compiletests/ui/dis/complex_image_sample_inst.stderr
+++ b/tests/compiletests/ui/dis/complex_image_sample_inst.stderr
@@ -5,9 +5,11 @@
 %8 = OpFunctionParameter  %9
 %10 = OpFunctionParameter  %9
 %11 = OpLabel
-OpLine %12 18 8
+OpLine %12 38 13
 %13 = OpAccessChain  %14  %15 %16
+OpLine %12 39 13
 %17 = OpLoad  %18  %13
+OpLine %12 46 13
 %19 = OpImageSampleProjExplicitLod  %2  %17 %4 Grad|ConstOffset %5 %7 %20
 OpNoLine
 OpReturnValue %19

--- a/tests/compiletests/ui/lang/asm/block_tracking_fail.stderr
+++ b/tests/compiletests/ui/lang/asm/block_tracking_fail.stderr
@@ -1,24 +1,20 @@
 error: `noreturn` requires a terminator at the end
-  --> $DIR/block_tracking_fail.rs:11:9
+  --> $DIR/block_tracking_fail.rs:11:15
    |
 11 |         asm!("", options(noreturn));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^
 
 error: trailing terminator `OpUnreachable` requires `options(noreturn)`
-  --> $DIR/block_tracking_fail.rs:18:9
+  --> $DIR/block_tracking_fail.rs:18:15
    |
 18 |         asm!("OpUnreachable");
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^
 
 error: expected `OpLabel` after terminator `OpKill`
-  --> $DIR/block_tracking_fail.rs:25:9
+  --> $DIR/block_tracking_fail.rs:26:14
    |
-25 | /         asm!(
-26 | |             "OpKill",
-27 | |             "%sum = OpFAdd _ {x} {x}",
-28 | |             x = in(reg) x,
-29 | |         );
-   | |_________^
+26 |             "OpKill",
+   |              ^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/compiletests/ui/lang/asm/issue-1002.stderr
+++ b/tests/compiletests/ui/lang/asm/issue-1002.stderr
@@ -1,43 +1,32 @@
 error: using `OpReturn` to return from within `asm!` is disallowed
- --> $DIR/issue-1002.rs:9:9
+ --> $DIR/issue-1002.rs:9:15
   |
 9 |         asm!("OpReturn", options(noreturn));
-  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |               ^^^^^^^^
   |
   = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
 
 error: using `OpReturnValue` to return from within `asm!` is disallowed
-  --> $DIR/issue-1002.rs:15:9
+  --> $DIR/issue-1002.rs:16:14
    |
-15 | /         asm!(
-16 | |             "OpReturnValue {x}",
-17 | |             x = in(reg) x,
-18 | |             options(noreturn),
-19 | |         );
-   | |_________^
+16 |             "OpReturnValue {x}",
+   |              ^^^^^^^^^^^^^^^^^
    |
    = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
 
 error: using `OpReturn` to return from within `asm!` is disallowed
-  --> $DIR/issue-1002.rs:25:9
+  --> $DIR/issue-1002.rs:26:14
    |
-25 | /         asm!(
-26 | |             "OpReturn",          // close active block
-27 | |             "%unused = OpLabel", // open new block
-28 | |         );
-   | |_________^
+26 |             "OpReturn",          // close active block
+   |              ^^^^^^^^
    |
    = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
 
 error: using `OpReturnValue` to return from within `asm!` is disallowed
-  --> $DIR/issue-1002.rs:34:9
+  --> $DIR/issue-1002.rs:35:14
    |
-34 | /         asm!(
-35 | |             "OpReturnValue {x}", // close active block
-36 | |             "%unused = OpLabel", // open new block
-37 | |             x = in(reg) x
-38 | |         );
-   | |_________^
+35 |             "OpReturnValue {x}", // close active block
+   |              ^^^^^^^^^^^^^^^^^
    |
    = note: resuming execution, without falling through the end of the `asm!` block, is always undefined behavior
 


### PR DESCRIPTION
Noticed that this should be possible while preparing:
- https://github.com/Rust-GPU/rust-gpu/pull/368

While we can do better than this, I feel like the test diffs speak for themselves.