### PR TITLE
`glam`-infication of `spirv-std`

### DIFF
--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
+use glam::UVec2;
 
 mod atomics;
 mod barrier;
@@ -175,9 +176,9 @@ pub fn read_clock_khr<const SCOPE: u32>() -> u64 {
 /// bits and the second component containing the 32 most significant bits.'
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpReadClockKHR")]
-pub fn read_clock_uvec2_khr<V: Vector<u32, 2>, const SCOPE: u32>() -> V {
+pub fn read_clock_uvec2_khr<const SCOPE: u32>() -> UVec2 {
     unsafe {
-        let mut result = V::default();
+        let mut result = UVec2::default();
 
         asm! {
             "%uint = OpTypeInt 32 0",

--- a/crates/spirv-std/src/float.rs
+++ b/crates/spirv-std/src/float.rs
@@ -1,8 +1,8 @@
 //! Traits and helper functions related to floats.
 
-use crate::vector::Vector;
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
+use glam::{Vec2, Vec4};
 
 /// Abstract trait representing a SPIR-V floating point type.
 ///
@@ -25,7 +25,7 @@ unsafe impl Float for f64 {
 /// Converts two f32 values (floats) into two f16 values (halfs). The result is a u32, with the low
 /// 16 bits being the first f16, and the high 16 bits being the second f16.
 #[spirv_std_macros::gpu_only]
-pub fn vec2_to_f16x2(vec: impl Vector<f32, 2>) -> u32 {
+pub fn vec2_to_f16x2(vec: Vec2) -> u32 {
     let result;
     unsafe {
         asm!(
@@ -44,7 +44,7 @@ pub fn vec2_to_f16x2(vec: impl Vector<f32, 2>) -> u32 {
 /// Converts two f16 values (halfs) into two f32 values (floats). The parameter is a u32, with the
 /// low 16 bits being the first f16, and the high 16 bits being the second f16.
 #[spirv_std_macros::gpu_only]
-pub fn f16x2_to_vec2<V: Vector<f32, 2>>(int: u32) -> V {
+pub fn f16x2_to_vec2(int: u32) -> Vec2 {
     let mut result = Default::default();
     unsafe {
         asm!(
@@ -70,14 +70,14 @@ pub fn f32_to_f16(float: f32) -> u32 {
 /// not being universal - the upper 16 bits are ignored.
 #[spirv_std_macros::gpu_only]
 pub fn f16_to_f32(packed: u32) -> f32 {
-    f16x2_to_vec2::<glam::Vec2>(packed).x
+    f16x2_to_vec2(packed).x
 }
 
 /// Packs a vec4 into 4 8-bit signed integers. See
 /// [PackSnorm4x8](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for exact
 /// semantics.
 #[spirv_std_macros::gpu_only]
-pub fn vec4_to_u8x4_snorm(vec: impl Vector<f32, 4>) -> u32 {
+pub fn vec4_to_u8x4_snorm(vec: Vec4) -> u32 {
     let result;
     unsafe {
         asm!(
@@ -97,7 +97,7 @@ pub fn vec4_to_u8x4_snorm(vec: impl Vector<f32, 4>) -> u32 {
 /// [PackUnorm4x8](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for exact
 /// semantics.
 #[spirv_std_macros::gpu_only]
-pub fn vec4_to_u8x4_unorm(vec: impl Vector<f32, 4>) -> u32 {
+pub fn vec4_to_u8x4_unorm(vec: Vec4) -> u32 {
     let result;
     unsafe {
         asm!(
@@ -117,7 +117,7 @@ pub fn vec4_to_u8x4_unorm(vec: impl Vector<f32, 4>) -> u32 {
 /// [PackSnorm2x16](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for exact
 /// semantics.
 #[spirv_std_macros::gpu_only]
-pub fn vec2_to_u16x2_snorm(vec: impl Vector<f32, 2>) -> u32 {
+pub fn vec2_to_u16x2_snorm(vec: Vec2) -> u32 {
     let result;
     unsafe {
         asm!(
@@ -137,7 +137,7 @@ pub fn vec2_to_u16x2_snorm(vec: impl Vector<f32, 2>) -> u32 {
 /// [PackUnorm2x16](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for exact
 /// semantics.
 #[spirv_std_macros::gpu_only]
-pub fn vec2_to_u16x2_unorm(vec: impl Vector<f32, 2>) -> u32 {
+pub fn vec2_to_u16x2_unorm(vec: Vec2) -> u32 {
     let result;
     unsafe {
         asm!(
@@ -157,7 +157,7 @@ pub fn vec2_to_u16x2_unorm(vec: impl Vector<f32, 2>) -> u32 {
 /// [UnpackSnorm4x8](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for exact
 /// semantics.
 #[spirv_std_macros::gpu_only]
-pub fn u8x4_to_vec4_snorm<V: Vector<f32, 4>>(int: u32) -> V {
+pub fn u8x4_to_vec4_snorm(int: u32) -> Vec4 {
     let mut result = Default::default();
     unsafe {
         asm!(
@@ -176,7 +176,7 @@ pub fn u8x4_to_vec4_snorm<V: Vector<f32, 4>>(int: u32) -> V {
 /// [UnpackSnorm4x8](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for exact
 /// semantics.
 #[spirv_std_macros::gpu_only]
-pub fn u8x4_to_vec4_unorm<V: Vector<f32, 4>>(int: u32) -> V {
+pub fn u8x4_to_vec4_unorm(int: u32) -> Vec4 {
     let mut result = Default::default();
     unsafe {
         asm!(
@@ -195,7 +195,7 @@ pub fn u8x4_to_vec4_unorm<V: Vector<f32, 4>>(int: u32) -> V {
 /// [UnpackSnorm2x16](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for
 /// exact semantics.
 #[spirv_std_macros::gpu_only]
-pub fn u16x2_to_vec2_snorm<V: Vector<f32, 2>>(int: u32) -> V {
+pub fn u16x2_to_vec2_snorm(int: u32) -> Vec2 {
     let mut result = Default::default();
     unsafe {
         asm!(
@@ -214,7 +214,7 @@ pub fn u16x2_to_vec2_snorm<V: Vector<f32, 2>>(int: u32) -> V {
 /// [UnpackUnorm2x16](https://www.khronos.org/registry/SPIR-V/specs/1.0/GLSL.std.450.html) for
 /// exact semantics.
 #[spirv_std_macros::gpu_only]
-pub fn u16x2_to_vec2_unorm<V: Vector<f32, 2>>(int: u32) -> V {
+pub fn u16x2_to_vec2_unorm(int: u32) -> Vec2 {
     let mut result = Default::default();
     unsafe {
         asm!(

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -4,9 +4,9 @@
 #![allow(clippy::bad_bit_mask)]
 
 use crate::matrix::Matrix4x3;
-use crate::vector::Vector;
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
+use glam::{UVec2, Vec2, Vec3};
 
 /// An acceleration structure type which is an opaque reference to an
 /// acceleration structure handle as defined in the client API specification.
@@ -48,7 +48,7 @@ impl AccelerationStructure {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpConvertUToAccelerationStructureKHR")]
     #[inline]
-    pub unsafe fn from_vec(id: impl Vector<u32, 2>) -> AccelerationStructure {
+    pub unsafe fn from_vec(id: UVec2) -> AccelerationStructure {
         unsafe {
             // FIXME(eddyb) `let mut result = T::default()` uses (for `asm!`), with this.
             let mut result_slot = core::mem::MaybeUninit::uninit();
@@ -102,9 +102,9 @@ impl AccelerationStructure {
         sbt_offset: i32,
         sbt_stride: i32,
         miss_index: i32,
-        ray_origin: impl Vector<f32, 3>,
+        ray_origin: Vec3,
         ray_tmin: f32,
-        ray_direction: impl Vector<f32, 3>,
+        ray_direction: Vec3,
         ray_tmax: f32,
         payload: &mut T,
     ) {
@@ -261,9 +261,9 @@ impl RayQuery {
         acceleration_structure: &AccelerationStructure,
         ray_flags: RayFlags,
         cull_mask: u32,
-        ray_origin: impl Vector<f32, 3>,
+        ray_origin: Vec3,
         ray_tmin: f32,
-        ray_direction: impl Vector<f32, 3>,
+        ray_direction: Vec3,
         ray_tmax: f32,
     ) {
         unsafe {
@@ -732,7 +732,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetIntersectionBarycentricsKHR")]
     #[inline]
-    pub unsafe fn get_candidate_intersection_barycentrics<V: Vector<f32, 2>>(&self) -> V {
+    pub unsafe fn get_candidate_intersection_barycentrics(&self) -> Vec2 {
         unsafe {
             let mut result = Default::default();
 
@@ -760,7 +760,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetIntersectionBarycentricsKHR")]
     #[inline]
-    pub unsafe fn get_committed_intersection_barycentrics<V: Vector<f32, 2>>(&self) -> V {
+    pub unsafe fn get_committed_intersection_barycentrics(&self) -> Vec2 {
         unsafe {
             let mut result = Default::default();
 
@@ -861,7 +861,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetIntersectionObjectRayDirectionKHR")]
     #[inline]
-    pub unsafe fn get_candidate_intersection_object_ray_direction<V: Vector<f32, 3>>(&self) -> V {
+    pub unsafe fn get_candidate_intersection_object_ray_direction(&self) -> Vec3 {
         unsafe {
             let mut result = Default::default();
 
@@ -888,7 +888,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetIntersectionObjectRayDirectionKHR")]
     #[inline]
-    pub unsafe fn get_committed_intersection_object_ray_direction<V: Vector<f32, 3>>(&self) -> V {
+    pub unsafe fn get_committed_intersection_object_ray_direction(&self) -> Vec3 {
         unsafe {
             let mut result = Default::default();
 
@@ -912,7 +912,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetIntersectionObjectRayOriginKHR")]
     #[inline]
-    pub unsafe fn get_candidate_intersection_object_ray_origin<V: Vector<f32, 3>>(&self) -> V {
+    pub unsafe fn get_candidate_intersection_object_ray_origin(&self) -> Vec3 {
         unsafe {
             let mut result = Default::default();
 
@@ -939,7 +939,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetIntersectionObjectRayOriginKHR")]
     #[inline]
-    pub unsafe fn get_committed_intersection_object_ray_origin<V: Vector<f32, 3>>(&self) -> V {
+    pub unsafe fn get_committed_intersection_object_ray_origin(&self) -> Vec3 {
         unsafe {
             let mut result = Default::default();
 
@@ -960,7 +960,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetWorldRayDirectionKHR")]
     #[inline]
-    pub unsafe fn get_world_ray_direction<V: Vector<f32, 3>>(&self) -> V {
+    pub unsafe fn get_world_ray_direction(&self) -> Vec3 {
         unsafe {
             let mut result = Default::default();
 
@@ -980,7 +980,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetWorldRayOriginKHR")]
     #[inline]
-    pub unsafe fn get_world_ray_origin<V: Vector<f32, 3>>(&self) -> V {
+    pub unsafe fn get_world_ray_origin(&self) -> Vec3 {
         unsafe {
             let mut result = Default::default();
 
@@ -1053,7 +1053,7 @@ impl RayQuery {
     #[spirv_std_macros::gpu_only]
     #[doc(alias = "OpRayQueryGetIntersectionTriangleVertexPositionsKHR")]
     #[inline]
-    pub unsafe fn get_intersection_triangle_vertex_positions<V: Vector<f32, 3>>(&self) -> [V; 3] {
+    pub unsafe fn get_intersection_triangle_vertex_positions(&self) -> [Vec3; 3] {
         unsafe {
             let mut result = Default::default();
 

--- a/tests/compiletests/ui/arch/read_clock_khr.rs
+++ b/tests/compiletests/ui/arch/read_clock_khr.rs
@@ -12,6 +12,5 @@ use spirv_std::{
 pub fn main() {
     let clock_time = unsafe { read_clock_khr::<{ Scope::Subgroup as u32 }>() };
 
-    let clock_time_uvec2: UVec2 =
-        unsafe { read_clock_uvec2_khr::<_, { Scope::Subgroup as u32 }>() };
+    let clock_time_uvec2: UVec2 = unsafe { read_clock_uvec2_khr::<{ Scope::Subgroup as u32 }>() };
 }


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/394 (due to conflicts)

see https://github.com/Rust-GPU/rust-gpu/issues/393

> How are people feeling on replacing all the **trivial** `impl Vector<f32, 4>` with a plain `glam::Vec4`? 
> 
> pro:
> * clearer to read
> * functions returning `V: Vector` don't need any explicit declarations that it's a `Vec2`, in case of ambiguity:
https://github.com/Rust-GPU/rust-gpu/blob/fb42c2b1fe5454f7673163be9efe4bfe9e9807a2/crates/spirv-std/src/float.rs#L225
> 
> contra:
> * Both `Vec3` and `Vec3A` impl `Vector<f32, 3>`, so you can't use them interchangeably anymore. We expect most people to use `Vec3`, and conversion is a trivial `From::from`.
> 
> Cases where we are generic on the vector element type, or element count, or both should remain as generic, eg:
> https://github.com/Rust-GPU/rust-gpu/blob/fb42c2b1fe5454f7673163be9efe4bfe9e9807a2/crates/spirv-std/src/arch/subgroup.rs#L336

closes https://github.com/Rust-GPU/rust-gpu/issues/393