### PR TITLE
Fix the CPU sky-shader demo.

### DIFF
--- a/examples/runners/cpu/src/main.rs
+++ b/examples/runners/cpu/src/main.rs
@@ -140,7 +140,7 @@ fn main() {
                 * vec2(WIDTH as f32, HEIGHT as f32);
 
             // evaluate the fragment shader for the specific pixel
-            let color = shader_module::fs(&push_constants, frag_coord, 1);
+            let color = shader_module::fs(&push_constants, frag_coord, 100);
 
             color_u32_from_vec4(color)
         })


### PR DESCRIPTION
It's supposed to produce a landscape with a small white sun, blue sky, and yellow ground. Instead it produces a small white sun and everything else is black. The problem is with the
`sun_intensity_extra_spec_const_factor` argument to `sky_shader::fs`.

- When running on the GPU, `sky_shader::fs` is called from `main_fs`, which has a spec_constant with a default value of 100.

- When running on the CPU, `sky_shader::fs` is called directly from the CPU shader's `main`, and it passes 1.

In other words, the CPU shader's sun intensity is 100x too small, which explains why it's so dark. This commit changes the value to 100, which makes the CPU shader produce the expected result.

(The shader later divides the intensity value by 100. There are comments about integration testing for specialization constants that I don't understand.)