### PR TITLE
ci: switch to `jakoch/install-vulkan-sdk-action@v1` for Vulkan SDK + SwiftShader.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,11 +29,6 @@ jobs:
         with:
           version: 1.4.309.0
           cache: true
-      - if: ${{ runner.os == 'Windows' }}
-        name: Install Vulkan Runtime with SwiftShader (Windows)
-        uses: NcStudios/VulkanCI@v1.2
-        with:
-          sdkVersion: 1.4.309.0
       - if: ${{ runner.os == 'Linux' }}
         name: Linux - Install native dependencies
         run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
@@ -93,11 +88,6 @@ jobs:
         with:
           version: 1.4.309.0
           cache: true
-      - if: ${{ runner.os == 'Windows' }}
-        name: Install Vulkan Runtime with SwiftShader (Windows)
-        uses: NcStudios/VulkanCI@v1.2
-        with:
-          sdkVersion: 1.4.309.0
       - name: install rust-toolchain
         run: cargo version
       - name: cargo fetch --locked
@@ -139,11 +129,6 @@ jobs:
         with:
           version: 1.4.309.0
           cache: true
-      - if: ${{ runner.os == 'Windows' }}
-        name: Install Vulkan Runtime with SwiftShader (Windows)
-        uses: NcStudios/VulkanCI@v1.2
-        with:
-          sdkVersion: 1.4.309.0
       - name: install rust-toolchain
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - name: cargo fetch --locked
@@ -164,11 +149,6 @@ jobs:
         with:
           version: 1.4.309.0
           cache: true
-      - if: ${{ runner.os == 'Windows' }}
-        name: Install Vulkan Runtime with SwiftShader (Windows)
-        uses: NcStudios/VulkanCI@v1.2
-        with:
-          sdkVersion: 1.4.309.0
       - if: ${{ runner.os == 'Linux' }}
         name: Linux - Install native dependencies
         run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.2
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.4.309.0
+          vulkan_version: 1.4.309.0
+          install_runtime: true
           cache: true
+          stripdown: true
+
+          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
+          install_swiftshader: true
+          # install_lavapipe: true
       - if: ${{ runner.os == 'Linux' }}
         name: Linux - Install native dependencies
         run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
@@ -84,10 +90,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.2
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.4.309.0
+          vulkan_version: 1.4.309.0
+          install_runtime: true
           cache: true
+          stripdown: true
+
+          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
+          install_swiftshader: true
+          # install_lavapipe: true
       - name: install rust-toolchain
         run: cargo version
       - name: cargo fetch --locked
@@ -125,10 +137,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.2
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.4.309.0
+          vulkan_version: 1.4.309.0
+          install_runtime: true
           cache: true
+          stripdown: true
+
+          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
+          install_swiftshader: true
+          # install_lavapipe: true
       - name: install rust-toolchain
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - name: cargo fetch --locked
@@ -145,10 +163,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.2
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.4.309.0
+          vulkan_version: 1.4.309.0
+          install_runtime: true
           cache: true
+          stripdown: true
+
+          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
+          install_swiftshader: true
+          # install_lavapipe: true
+      - if: ${{ runner.os == 'Windows' }}
+        name: Windows - Use SwiftShader as Vulkan driver
+        # FIXME(eddyb) ideally `jakoch/install-vulkan-sdk-action` should do this.
+        run: |
+          echo "C:/Swiftshader/" >> "$GITHUB_PATH"
+          echo "VK_DRIVER_FILES=C:/Swiftshader/vk_swiftshader_icd.json" >> "$GITHUB_ENV"
       - if: ${{ runner.os == 'Linux' }}
         name: Linux - Install native dependencies
         run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
@@ -199,10 +229,16 @@ jobs:
       - name: Install native dependencies
         run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
       - name: Install Vulkan SDK
-        uses: humbletim/install-vulkan-sdk@v1.2
+        uses: jakoch/install-vulkan-sdk-action@v1
         with:
-          version: 1.4.309.0
+          vulkan_version: 1.4.309.0
+          install_runtime: true
           cache: true
+          stripdown: true
+
+          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
+          install_swiftshader: true
+          # install_lavapipe: true
       - name: Install rustup components
         run: rustup component add rustfmt clippy
       # cargo version is a random command that forces the installation of rust-toolchain


### PR DESCRIPTION
Updating the Vulkan SDK we used in CI came up in:
- https://github.com/Rust-GPU/rust-gpu/pull/379#discussion_r2335335011

Sadly, the [`NcStudios/VulkanCI@v1.2`](https://github.com/NcStudios/VulkanCI/tree/v1.2) action we were using to get SwiftShader on Windows, is stuck on an older version, and doesn't appear to be prompt to update in general.

So this PR replaces [`humbletim/install-vulkan-sdk@v1.2`](https://github.com/humbletim/install-vulkan-sdk/tree/v1.2) + [`NcStudios/VulkanCI@v1.2`](https://github.com/NcStudios/VulkanCI/tree/v1.2) with [`jakoch/install-vulkan-sdk-action@v1`](https://github.com/jakoch/install-vulkan-sdk-action/tree/v1), which supports SwiftShader (or Lavapipe, but I kept it on SwiftShader) for Windows (AFAICT that action downloads SwiftShader/Lavapipe releases from [`jakoch/rasterizers`](https://github.com/jakoch/rasterizers), separately from the Vulkan SDK).

From what I could tell, the [`jakoch/install-vulkan-sdk-action`](https://github.com/jakoch/install-vulkan-sdk-action) repo has a lot more recent activity than the others we were using, and its approach feels more robust long-term (at least in terms of bumping Vulkan SDK versions).