### PR TITLE
derive spirv vector on user structs

### DIFF
--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -87,8 +87,8 @@
 /// Public re-export of the `spirv-std-macros` crate.
 #[macro_use]
 pub extern crate spirv_std_macros as macros;
-pub use macros::spirv;
 pub use macros::{debug_printf, debug_printfln};
+pub use macros::{spirv, spirv_vector};
 
 pub mod arch;
 pub mod byte_addressable_buffer;

--- a/crates/spirv-std/src/vector.rs
+++ b/crates/spirv-std/src/vector.rs
@@ -7,9 +7,10 @@ use glam::{Vec3Swizzles, Vec4Swizzles};
 
 /// Abstract trait representing a SPIR-V vector type.
 ///
-/// To implement this trait, your struct must be marked with:
+/// To derive this trait, mark your struct with:
 /// ```no_run
-/// #[cfg_attr(target_arch = "spirv", rust_gpu::vector::v1)]
+/// #[spirv_std::spirv_vector]
+/// # #[derive(Copy, Clone, Default)]
 /// # struct Bla(f32, f32);
 /// ```
 ///
@@ -32,8 +33,8 @@ use glam::{Vec3Swizzles, Vec4Swizzles};
 ///
 /// # Example
 /// ```no_run
+/// #[spirv_std::spirv_vector]
 /// #[derive(Copy, Clone, Default)]
-/// #[cfg_attr(target_arch = "spirv", rust_gpu::vector::v1)]
 /// struct MyColor {
 ///     r: f32,
 ///     b: f32,
@@ -44,7 +45,8 @@ use glam::{Vec3Swizzles, Vec4Swizzles};
 ///
 /// # Safety
 /// * Must only be implemented on types that the spirv codegen emits as valid `OpTypeVector`. This includes all structs
-///   marked with `#[rust_gpu::vector::v1]`, like [`glam`]'s non-SIMD "scalar" vector types.
+///   marked with `#[rust_gpu::vector::v1]`, which `#[spirv_std::spirv_vector]` expands into or [`glam`]'s non-SIMD
+/// "scalar" vector types use directly.
 /// * `VectorOrScalar::DIM == N`, since const equality is behind rustc feature `associated_const_equality`
 // Note(@firestar99) I would like to have these two generics be associated types instead. Doesn't make much sense for
 // a vector type to implement this interface multiple times with different Scalar types or N, after all.

--- a/tests/compiletests/ui/glam/invalid_vector_type_macro.rs
+++ b/tests/compiletests/ui/glam/invalid_vector_type_macro.rs
@@ -1,0 +1,33 @@
+// build-fail
+
+use core::num::NonZeroU32;
+use spirv_std::glam::Vec2;
+use spirv_std::spirv;
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone, Default)]
+pub struct FewerFields {
+    _v: f32,
+}
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone, Default)]
+pub struct TooManyFields {
+    _x: f32,
+    _y: f32,
+    _z: f32,
+    _w: f32,
+    _v: f32,
+}
+
+// wrong member types fails too early
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone, Default)]
+pub struct DifferentTypes {
+    _x: f32,
+    _y: u32,
+}
+
+#[spirv(fragment)]
+pub fn entry(_: FewerFields, _: TooManyFields, #[spirv(flat)] _: DifferentTypes) {}

--- a/tests/compiletests/ui/glam/invalid_vector_type_macro.stderr
+++ b/tests/compiletests/ui/glam/invalid_vector_type_macro.stderr
@@ -1,0 +1,20 @@
+error: `#[spirv(vector)]` must have 2, 3 or 4 members
+  --> $DIR/invalid_vector_type_macro.rs:9:1
+   |
+LL | pub struct FewerFields {
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[spirv(vector)]` must have 2, 3 or 4 members
+  --> $DIR/invalid_vector_type_macro.rs:15:1
+   |
+LL | pub struct TooManyFields {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `#[spirv(vector)]` member types must all be the same
+  --> $DIR/invalid_vector_type_macro.rs:27:1
+   |
+LL | pub struct DifferentTypes {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+

--- a/tests/compiletests/ui/glam/invalid_vector_type_macro2.rs
+++ b/tests/compiletests/ui/glam/invalid_vector_type_macro2.rs
@@ -1,0 +1,42 @@
+// build-fail
+// normalize-stderr-test "\S*/crates/spirv-std/src/" -> "$$SPIRV_STD_SRC/"
+
+use core::num::NonZeroU32;
+use spirv_std::glam::Vec2;
+use spirv_std::spirv;
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone, Default)]
+pub struct ZstVector;
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone, Default)]
+pub struct NotVectorField {
+    _x: Vec2,
+    _y: Vec2,
+}
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone)]
+pub struct NotVectorField2 {
+    _x: NonZeroU32,
+    _y: NonZeroU32,
+}
+
+impl Default for NotVectorField2 {
+    fn default() -> Self {
+        Self {
+            _x: NonZeroU32::new(1).unwrap(),
+            _y: NonZeroU32::new(1).unwrap(),
+        }
+    }
+}
+
+#[spirv(fragment)]
+pub fn entry(
+    // workaround to ZST loading
+    #[spirv(storage_class, descriptor_set = 0, binding = 0)] _: &(ZstVector, i32),
+    _: NotVectorField,
+    #[spirv(flat)] _: NotVectorField2,
+) {
+}

--- a/tests/compiletests/ui/glam/invalid_vector_type_macro2.stderr
+++ b/tests/compiletests/ui/glam/invalid_vector_type_macro2.stderr
@@ -1,0 +1,113 @@
+error: Vector ZST not allowed
+  --> $DIR/invalid_vector_type_macro2.rs:9:1
+   |
+LL | / #[derive(Copy, Clone, Default)]
+LL | | pub struct ZstVector;
+   | |_____________________^
+
+error[E0412]: cannot find type `ZstVector` in this scope
+  --> $DIR/invalid_vector_type_macro2.rs:38:67
+   |
+LL |     #[spirv(storage_class, descriptor_set = 0, binding = 0)] _: &(ZstVector, i32),
+   |                                                                   ^^^^^^^^^ not found in this scope
+
+error: unknown argument to spirv attribute
+  --> $DIR/invalid_vector_type_macro2.rs:38:13
+   |
+LL |     #[spirv(storage_class, descriptor_set = 0, binding = 0)] _: &(ZstVector, i32),
+   |             ^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `Vec2: Scalar` is not satisfied
+  --> $DIR/invalid_vector_type_macro2.rs:15:9
+   |
+LL |     _x: Vec2,
+   |         ^^^^ the trait `Scalar` is not implemented for `Vec2`
+   |
+   = help: the following other types implement trait `Scalar`:
+             bool
+             f32
+             f64
+             i16
+             i32
+             i64
+             i8
+             u16
+           and 3 others
+note: required by a bound in `spirv_std::ScalarOrVector::Scalar`
+  --> $SPIRV_STD_SRC/scalar_or_vector.rs:18:18
+   |
+LL |     type Scalar: Scalar;
+   |                  ^^^^^^ required by this bound in `ScalarOrVector::Scalar`
+
+error[E0277]: the trait bound `Vec2: Scalar` is not satisfied
+  --> $DIR/invalid_vector_type_macro2.rs:12:1
+   |
+LL | #[spirv_std::spirv_vector]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Scalar` is not implemented for `Vec2`
+   |
+   = help: the following other types implement trait `Scalar`:
+             bool
+             f32
+             f64
+             i16
+             i32
+             i64
+             i8
+             u16
+           and 3 others
+note: required by a bound in `Vector`
+  --> $SPIRV_STD_SRC/vector.rs:56:28
+   |
+LL | pub unsafe trait Vector<T: Scalar, const N: usize>: ScalarOrVector<Scalar = T> {}
+   |                            ^^^^^^ required by this bound in `Vector`
+   = note: this error originates in the attribute macro `spirv_std::spirv_vector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `NonZero<u32>: Scalar` is not satisfied
+  --> $DIR/invalid_vector_type_macro2.rs:22:9
+   |
+LL |     _x: NonZeroU32,
+   |         ^^^^^^^^^^ the trait `Scalar` is not implemented for `NonZero<u32>`
+   |
+   = help: the following other types implement trait `Scalar`:
+             bool
+             f32
+             f64
+             i16
+             i32
+             i64
+             i8
+             u16
+           and 3 others
+note: required by a bound in `spirv_std::ScalarOrVector::Scalar`
+  --> $SPIRV_STD_SRC/scalar_or_vector.rs:18:18
+   |
+LL |     type Scalar: Scalar;
+   |                  ^^^^^^ required by this bound in `ScalarOrVector::Scalar`
+
+error[E0277]: the trait bound `NonZero<u32>: Scalar` is not satisfied
+  --> $DIR/invalid_vector_type_macro2.rs:19:1
+   |
+LL | #[spirv_std::spirv_vector]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Scalar` is not implemented for `NonZero<u32>`
+   |
+   = help: the following other types implement trait `Scalar`:
+             bool
+             f32
+             f64
+             i16
+             i32
+             i64
+             i8
+             u16
+           and 3 others
+note: required by a bound in `Vector`
+  --> $SPIRV_STD_SRC/vector.rs:56:28
+   |
+LL | pub unsafe trait Vector<T: Scalar, const N: usize>: ScalarOrVector<Scalar = T> {}
+   |                            ^^^^^^ required by this bound in `Vector`
+   = note: this error originates in the attribute macro `spirv_std::spirv_vector` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 7 previous errors
+
+Some errors have detailed explanations: E0277, E0412.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/compiletests/ui/glam/spirv_vector_macro.rs
+++ b/tests/compiletests/ui/glam/spirv_vector_macro.rs
@@ -1,0 +1,33 @@
+// build-pass
+// only-vulkan1.2
+// compile-flags: -C target-feature=+GroupNonUniform,+GroupNonUniformShuffleRelative,+ext:SPV_KHR_vulkan_memory_model
+// compile-flags: -C llvm-args=--disassemble
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+
+use spirv_std::arch::subgroup_shuffle_up;
+use spirv_std::glam::Vec3;
+use spirv_std::spirv;
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone, Default)]
+pub struct MyColor {
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+}
+
+#[spirv(compute(threads(32)))]
+pub fn main(
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] input: &Vec3,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] output: &mut MyColor,
+) {
+    let color = MyColor {
+        r: input.x,
+        g: input.y,
+        b: input.z,
+    };
+    // any function that accepts a `VectorOrScalar` would do
+    *output = subgroup_shuffle_up(color, 5);
+}

--- a/tests/compiletests/ui/glam/spirv_vector_macro.stderr
+++ b/tests/compiletests/ui/glam/spirv_vector_macro.stderr
@@ -1,0 +1,53 @@
+; SPIR-V
+; Version: 1.5
+; Generator: rspirv
+; Bound: 31
+OpCapability Shader
+OpCapability GroupNonUniform
+OpCapability GroupNonUniformShuffleRelative
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %1 "main" %2 %3
+OpExecutionMode %1 LocalSize 32 1 1
+OpName %2 "input"
+OpName %3 "output"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpDecorate %2 NonWritable
+OpDecorate %2 Binding 0
+OpDecorate %2 DescriptorSet 0
+OpDecorate %3 Binding 1
+OpDecorate %3 DescriptorSet 0
+%7 = OpTypeFloat 32
+%8 = OpTypeVector %7 3
+%6 = OpTypeStruct %8
+%9 = OpTypePointer StorageBuffer %6
+%10 = OpTypeVoid
+%11 = OpTypeFunction %10
+%12 = OpTypePointer StorageBuffer %8
+%2 = OpVariable  %9  StorageBuffer
+%13 = OpTypeInt 32 0
+%14 = OpConstant  %13  0
+%3 = OpVariable  %9  StorageBuffer
+%15 = OpTypePointer StorageBuffer %7
+%16 = OpConstant  %13  1
+%17 = OpConstant  %13  2
+%18 = OpConstant  %13  3
+%19 = OpConstant  %13  5
+%1 = OpFunction  %10  None %11
+%20 = OpLabel
+%21 = OpInBoundsAccessChain  %12  %2 %14
+%22 = OpInBoundsAccessChain  %12  %3 %14
+%23 = OpInBoundsAccessChain  %15  %21 %14
+%24 = OpLoad  %7  %23
+%25 = OpInBoundsAccessChain  %15  %21 %16
+%26 = OpLoad  %7  %25
+%27 = OpInBoundsAccessChain  %15  %21 %17
+%28 = OpLoad  %7  %27
+%29 = OpCompositeConstruct  %8  %24 %26 %28
+%30 = OpGroupNonUniformShuffleUp  %8  %18 %29 %19
+OpStore %22 %30
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/compiletests/ui/glam/spirv_vector_macro_generic.rs
+++ b/tests/compiletests/ui/glam/spirv_vector_macro_generic.rs
@@ -1,0 +1,34 @@
+// build-pass
+// only-vulkan1.2
+// compile-flags: -C target-feature=+GroupNonUniform,+GroupNonUniformShuffleRelative,+ext:SPV_KHR_vulkan_memory_model
+// compile-flags: -C llvm-args=--disassemble
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+
+use spirv_std::Scalar;
+use spirv_std::arch::subgroup_shuffle_up;
+use spirv_std::glam::Vec3;
+use spirv_std::spirv;
+
+#[spirv_std::spirv_vector]
+#[derive(Copy, Clone, Default)]
+pub struct Vec<T: Scalar> {
+    pub x: T,
+    pub y: T,
+    pub z: T,
+}
+
+#[spirv(compute(threads(32)))]
+pub fn main(
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] input: &Vec<i32>,
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] output: &mut Vec<f32>,
+) {
+    let vec = Vec {
+        x: input.x as f32,
+        y: input.y as f32,
+        z: input.z as f32,
+    };
+    // any function that accepts a `VectorOrScalar` would do
+    *output = subgroup_shuffle_up(vec, 5);
+}

--- a/tests/compiletests/ui/glam/spirv_vector_macro_generic.stderr
+++ b/tests/compiletests/ui/glam/spirv_vector_macro_generic.stderr
@@ -1,0 +1,63 @@
+; SPIR-V
+; Version: 1.5
+; Generator: rspirv
+; Bound: 39
+OpCapability Shader
+OpCapability GroupNonUniform
+OpCapability GroupNonUniformShuffleRelative
+OpCapability VulkanMemoryModel
+OpExtension "SPV_KHR_vulkan_memory_model"
+OpMemoryModel Logical Vulkan
+OpEntryPoint GLCompute %1 "main" %2 %3
+OpExecutionMode %1 LocalSize 32 1 1
+OpName %2 "input"
+OpName %3 "output"
+OpDecorate %6 Block
+OpMemberDecorate %6 0 Offset 0
+OpDecorate %7 Block
+OpMemberDecorate %7 0 Offset 0
+OpDecorate %2 NonWritable
+OpDecorate %2 Binding 0
+OpDecorate %2 DescriptorSet 0
+OpDecorate %3 Binding 1
+OpDecorate %3 DescriptorSet 0
+%8 = OpTypeInt 32 1
+%9 = OpTypeVector %8 3
+%6 = OpTypeStruct %9
+%10 = OpTypePointer StorageBuffer %6
+%11 = OpTypeFloat 32
+%12 = OpTypeVector %11 3
+%7 = OpTypeStruct %12
+%13 = OpTypePointer StorageBuffer %7
+%14 = OpTypeVoid
+%15 = OpTypeFunction %14
+%16 = OpTypePointer StorageBuffer %9
+%2 = OpVariable  %10  StorageBuffer
+%17 = OpTypeInt 32 0
+%18 = OpConstant  %17  0
+%19 = OpTypePointer StorageBuffer %12
+%3 = OpVariable  %13  StorageBuffer
+%20 = OpTypePointer StorageBuffer %8
+%21 = OpConstant  %17  1
+%22 = OpConstant  %17  2
+%23 = OpConstant  %17  3
+%24 = OpConstant  %17  5
+%1 = OpFunction  %14  None %15
+%25 = OpLabel
+%26 = OpInBoundsAccessChain  %16  %2 %18
+%27 = OpInBoundsAccessChain  %19  %3 %18
+%28 = OpInBoundsAccessChain  %20  %26 %18
+%29 = OpLoad  %8  %28
+%30 = OpConvertSToF  %11  %29
+%31 = OpInBoundsAccessChain  %20  %26 %21
+%32 = OpLoad  %8  %31
+%33 = OpConvertSToF  %11  %32
+%34 = OpInBoundsAccessChain  %20  %26 %22
+%35 = OpLoad  %8  %34
+%36 = OpConvertSToF  %11  %35
+%37 = OpCompositeConstruct  %12  %30 %33 %36
+%38 = OpGroupNonUniformShuffleUp  %12  %23 %37 %24
+OpStore %27 %38
+OpNoLine
+OpReturn
+OpFunctionEnd


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/380

Since https://github.com/Rust-GPU/rust-gpu/pull/380 already implements all the infrastructure to declare spirv vectors properly in glam, may as well expose it to our end users and allow them to declare their own vector types. The `spirv_vector` proc macro expands to the same `rust_gpu::vector::v1` glam uses, but additionally implements `spirv_std::vector::Vector` and `spirv_std::vector::VectorOrScalar` on the type, so it can be used in eg. subgroup intrinsics.

Example:
https://github.com/Rust-GPU/rust-gpu/blob/6be1bffa201b348ebb63d1cf30ed43bf96f8abe2/tests/compiletests/ui/glam/spirv_vector_macro.rs#L13-L33

First two commits just move some code around, so best reviewed commit by commit. 

close https://github.com/Rust-GPU/rust-gpu/issues/410