### PR TITLE
Return `JoinHandle` of watching thread to the caller

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -91,6 +91,9 @@ use thiserror::Error;
 pub use rustc_codegen_spirv_types::Capability;
 pub use rustc_codegen_spirv_types::{CompileResult, ModuleResult};
 
+#[cfg(feature = "watch")]
+pub use self::watch::Watch;
+
 #[cfg(feature = "include-target-specs")]
 pub use rustc_codegen_spirv_target_specs::TARGET_SPEC_DIR_PATH;
 

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -187,6 +187,7 @@ fn maybe_watch(
                     }
                 })
                 .expect("Configuration is correct for watching")
+                .first_compile
                 .unwrap()
         } else {
             handle_compile_result(builder.build().unwrap())


### PR DESCRIPTION
This would be useful for Rust-GPU/cargo-gpu#112 to state via the Rust's type system that watch thread should never return by joining it.