### PR TITLE
`Debug` for `CargoCmd`

### DIFF
--- a/crates/spirv-builder/src/cargo_cmd.rs
+++ b/crates/spirv-builder/src/cargo_cmd.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 use std::ops::{Deref, DerefMut};
 use std::process::Command;
 
@@ -107,12 +107,18 @@ impl Default for CargoCmd {
     }
 }
 
-impl Display for CargoCmd {
+impl Debug for CargoCmd {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CargoCmd")
             .field("cargo", &self.cargo)
             .field("env_vars", &self.env_var_report())
             .finish()
+    }
+}
+
+impl From<CargoCmd> for Command {
+    fn from(cmd: CargoCmd) -> Self {
+        cmd.cargo
     }
 }
 

--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -1059,7 +1059,7 @@ fn invoke_rustc(builder: &SpirvBuilder) -> Result<PathBuf, SpirvBuilderError> {
     );
 
     cargo.stderr(Stdio::inherit()).current_dir(path_to_crate);
-    log::debug!("building shaders with `{cargo}`");
+    log::debug!("building shaders with `{cargo:?}`");
     let build = cargo.output().expect("failed to execute cargo build");
 
     // `get_last_artifact` has the side-effect of printing invalid lines, so


### PR DESCRIPTION
Fix `CargoCmd` to implement `Debug` instead of `Display` (which was presumably a typo).
Also implement `From<CargoCmd>` for `Command` which will be useful a bit later (as a part of Rust-GPU/cargo-gpu#112).