### PR TITLE
rustup: update to `nightly-2025-06-30`.

### DIFF
--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -18,9 +18,9 @@ use std::{env, fs, mem};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain.toml");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2025-06-23"
+channel = "nightly-2025-06-30"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = be19eda0dc4c22c5cf5f1b48fd163acf9bd4b0a6"#;
+# commit_hash = 35f6036521777bdc0dcea1f980be4c192962a168"#;
 
 fn rustc_output(arg: &str) -> Result<String, Box<dyn Error>> {
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -3035,7 +3035,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
         todo!()
     }
 
-    fn filter_landing_pad(&mut self, _pers_fn: Self::Function) -> (Self::Value, Self::Value) {
+    fn filter_landing_pad(&mut self, _pers_fn: Self::Function) {
         todo!()
     }
 

--- a/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
+++ b/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
@@ -74,7 +74,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             Some(size) => size,
             None => return self.load_err(original_type, result_type),
         };
-        if element_size_bytes.bytes() % 4 != 0 {
+        if !element_size_bytes.bytes().is_multiple_of(4) {
             return self.load_err(original_type, result_type);
         }
         let element_size_words = (element_size_bytes.bytes() / 4) as u32;
@@ -148,7 +148,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .iter()
                     .zip(field_offsets)
                     .map(|(&field_type, byte_offset)| {
-                        if byte_offset.bytes() % 4 != 0 {
+                        if !byte_offset.bytes().is_multiple_of(4) {
                             return None;
                         }
                         let word_offset = (byte_offset.bytes() / 4) as u32;
@@ -276,7 +276,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             Some(size) => size,
             None => return self.store_err(original_type, value),
         };
-        if element_size_bytes.bytes() % 4 != 0 {
+        if !element_size_bytes.bytes().is_multiple_of(4) {
             return self.store_err(original_type, value);
         }
         let element_size_words = (element_size_bytes.bytes() / 4) as u32;
@@ -343,7 +343,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 ..
             } => {
                 for (index, byte_offset) in field_offsets.iter().enumerate() {
-                    if byte_offset.bytes() % 4 != 0 {
+                    if !byte_offset.bytes().is_multiple_of(4) {
                         return self.store_err(original_type, value);
                     }
                     let word_offset = (byte_offset.bytes() / 4) as u32;

--- a/crates/rustc_codegen_spirv/src/linker/test.rs
+++ b/crates/rustc_codegen_spirv/src/linker/test.rs
@@ -159,7 +159,6 @@ fn link_with_linker_opts(
                 Default::default(),
                 Default::default(),
                 target,
-                Default::default(),
                 rustc_interface::util::rustc_version_str().unwrap_or("unknown"),
                 Default::default(),
                 &rustc_driver_impl::USING_INTERNAL_FEATURES,

--- a/crates/spirv-std/src/byte_addressable_buffer.rs
+++ b/crates/spirv-std/src/byte_addressable_buffer.rs
@@ -71,7 +71,7 @@ pub struct ByteAddressableBuffer<T> {
 
 fn bounds_check<T>(data: &[u32], byte_index: u32) {
     let sizeof = mem::size_of::<T>() as u32;
-    if byte_index % 4 != 0 {
+    if !byte_index.is_multiple_of(4) {
         panic!("`byte_index` should be a multiple of 4");
     }
     let last_byte = byte_index + sizeof;

--- a/examples/shaders/compute-shader/src/lib.rs
+++ b/examples/shaders/compute-shader/src/lib.rs
@@ -24,7 +24,7 @@ pub fn collatz(mut n: u32) -> Option<u32> {
         return None;
     }
     while n != 1 {
-        n = if n % 2 == 0 {
+        n = if n.is_multiple_of(2) {
             n / 2
         } else {
             // Overflow? (i.e. 3*n + 1 > 0xffff_ffff)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2025-06-23"
+channel = "nightly-2025-06-30"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = be19eda0dc4c22c5cf5f1b48fd163acf9bd4b0a6
+# commit_hash = 35f6036521777bdc0dcea1f980be4c192962a168
 
 # Whenever changing the nightly channel, update the commit hash above, and
 # change `REQUIRED_RUST_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` too.

--- a/tests/difftests/bin/src/runner.rs
+++ b/tests/difftests/bin/src/runner.rs
@@ -498,7 +498,7 @@ impl Runner {
         match output_type {
             OutputType::Raw => output1 == output2,
             OutputType::F32 => {
-                if output1.len() % 4 != 0 {
+                if !output1.len().is_multiple_of(4) {
                     return false;
                 }
 
@@ -527,7 +527,7 @@ impl Runner {
                 }
             }
             OutputType::F64 => {
-                if output1.len() % 8 != 0 {
+                if !output1.len().is_multiple_of(8) {
                     return false;
                 }
 

--- a/tests/difftests/lib/src/scaffold/compute/wgpu.rs
+++ b/tests/difftests/lib/src/scaffold/compute/wgpu.rs
@@ -256,7 +256,7 @@ impl ComputeBackend for WgpuBackend {
         buffers: Vec<BufferConfig>,
     ) -> anyhow::Result<Vec<Vec<u8>>> {
         // Convert bytes to u32 words
-        if spirv_bytes.len() % 4 != 0 {
+        if !spirv_bytes.len().is_multiple_of(4) {
             anyhow::bail!("SPIR-V binary length is not a multiple of 4");
         }
         let spirv_words: Vec<u32> = bytemuck::cast_slice(spirv_bytes).to_vec();

--- a/tests/difftests/lib/src/scaffold/shader/rust_gpu_shader.rs
+++ b/tests/difftests/lib/src/scaffold/shader/rust_gpu_shader.rs
@@ -77,7 +77,7 @@ impl WgpuShader for RustComputeShader {
     ) -> anyhow::Result<(wgpu::ShaderModule, Option<String>)> {
         let (shader_bytes, entry_point) = self.spirv_bytes()?;
 
-        if shader_bytes.len() % 4 != 0 {
+        if !shader_bytes.len().is_multiple_of(4) {
             anyhow::bail!("SPIR-V binary length is not a multiple of 4");
         }
         let shader_words: Vec<u32> = bytemuck::cast_slice(&shader_bytes).to_vec();


### PR DESCRIPTION
- `filter_landing_pad` no longer has a return value.
- `build_session` no longer has the `sysroot` argument.
- `manual_is_multiple_of` clippy lint was enabled.
