### PR TITLE
Make `AcceptFirstCompile` public

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -92,7 +92,7 @@ pub use rustc_codegen_spirv_types::Capability;
 pub use rustc_codegen_spirv_types::{CompileResult, ModuleResult};
 
 #[cfg(feature = "watch")]
-pub use self::watch::Watch;
+pub use self::watch::{AcceptFirstCompile, Watch};
 
 #[cfg(feature = "include-target-specs")]
 pub use rustc_codegen_spirv_target_specs::TARGET_SPEC_DIR_PATH;

--- a/tests/difftests/lib/src/scaffold/compute/wgpu.rs
+++ b/tests/difftests/lib/src/scaffold/compute/wgpu.rs
@@ -64,7 +64,6 @@ where
                     #[cfg(target_os = "windows")]
                     dx12: wgpu::Dx12BackendOptions {
                         shader_compiler: wgpu::Dx12Compiler::StaticDxc,
-                        ..Default::default()
                     },
                     ..Default::default()
                 },


### PR DESCRIPTION
This is needed for Rust-GPU/cargo-gpu#112 to add `watch()` method for shader crate builder of `cargo-gpu-build` crate.