### PR TITLE
ash runner: update ash-molten to my fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,9 +196,8 @@ dependencies = [
 
 [[package]]
 name = "ash-molten"
-version = "0.20.0+1.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4c4960621009149a2877457f6875185b894fe1b4f7a602167a3ac00758dc40"
+version = "0.19.0+1.2.8"
+source = "git+https://github.com/Firestar99/ash-molten.git?rev=784b5e0d3b19337ae6f1251784f04fafbef6ca95#784b5e0d3b19337ae6f1251784f04fafbef6ca95"
 dependencies = [
  "anyhow",
  "ash",

--- a/examples/runners/ash/Cargo.toml
+++ b/examples/runners/ash/Cargo.toml
@@ -26,4 +26,4 @@ anyhow = "1.0.98"
 bytemuck.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
-ash-molten = { version = "0.20", features = ["pre-built"] }
+ash-molten = { git = "https://github.com/Firestar99/ash-molten.git", rev = "784b5e0d3b19337ae6f1251784f04fafbef6ca95", features = ["pre-built"] }


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/419

just updates ash-molten to my fork

> I don't have a Mac to test this on, let's just try raising the version

see https://github.com/EmbarkStudios/ash-molten/pull/89