### PR TITLE
fix glam dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ difftest = { path = "tests/difftests/lib" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json"] }
 num-traits = { version = "0.2.15", default-features = false }
-glam = { version = ">=0.22, <=0.30", default-features = false }
+glam = { version = ">=0.22, <=0.30.7", default-features = false }
 libm = { version = "0.2.5", default-features = false }
 bytemuck = { version = "1.23", features = ["derive"] }
 


### PR DESCRIPTION
glam 0.30.8 includes  [spirv: vector attribute bitshifter/glam-rs#676](https://github.com/bitshifter/glam-rs/pull/676) thats needed for #380, until #380 is merged we need to limit glam to 0.30.7