### PR TITLE
spirv-tools: update to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,9 +3205,9 @@ version = "0.9.0"
 
 [[package]]
 name = "spirv-tools"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b10991c25e3adc32c018c528be2cdef16c0cdfaf8581fbeabb033b547a599ec"
+checksum = "863f14733a4ecb68c0bde9ea9b93bc58085a4172e76c8cefe7c810c940f02131"
 dependencies = [
  "memchr",
  "spirv-tools-sys",
@@ -3216,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "spirv-tools-sys"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c78c1a8af381edef1b7ca7d7caea9d6454dccb4b00a35b7b968b44b8212f487"
+checksum = "219df977b2dd5a34a3529a7f7d2be12727abd87e4545abd0d54edd4fa2cfe5a8"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ spirv-builder = { path = "./crates/spirv-builder", version = "=0.9.0", default-f
 spirv-std = { path = "./crates/spirv-std", version = "=0.9.0" }
 spirv-std-types = { path = "./crates/spirv-std/shared", version = "=0.9.0" }
 spirv-std-macros = { path = "./crates/spirv-std/macros", version = "=0.9.0" }
-spirv-tools = { version = "0.12.1", default-features = false }
+spirv-tools = { version = "0.13.0", default-features = false }
 rustc_codegen_spirv = { path = "./crates/rustc_codegen_spirv", version = "=0.9.0", default-features = false }
 rustc_codegen_spirv-types = { path = "./crates/rustc_codegen_spirv-types", version = "=0.9.0" }
 rustc_codegen_spirv-target-specs = { path = "crates/rustc_codegen_spirv-target-specs", version = "=0.9.0" }

--- a/crates/rustc_codegen_spirv/src/target.rs
+++ b/crates/rustc_codegen_spirv/src/target.rs
@@ -37,7 +37,7 @@ impl SpirvTarget {
 
             TargetEnv::Vulkan_1_0
             | TargetEnv::Vulkan_1_1
-            | TargetEnv::WebGPU_0
+            | TargetEnv::WebGPU_0_DEPRECATED
             | TargetEnv::Vulkan_1_1_Spirv_1_4
             | TargetEnv::Vulkan_1_2
             | TargetEnv::Vulkan_1_3


### PR DESCRIPTION
@eddyb there you go! Once this is merged https://github.com/Rust-GPU/rust-gpu/pull/379 is unblocked

Note: the compiletest should be failing and is fixed by https://github.com/Rust-GPU/rust-gpu/pull/379

Why is it not failing??? Cause CI uses installed tools of a previous version -> fix