### PR TITLE
Fix divide by zero ICE

### DIFF
--- a/tests/compiletests/ui/lang/core/issue-424.rs
+++ b/tests/compiletests/ui/lang/core/issue-424.rs
@@ -1,0 +1,15 @@
+// build-pass
+
+#![no_std]
+
+use core::marker::PhantomData;
+use spirv_std::spirv;
+
+pub struct BitSlice<T, O> {
+    _ord: PhantomData<O>,
+    _typ: PhantomData<[T]>,
+    _mem: [()],
+}
+
+#[spirv(compute(threads(1)))]
+pub fn issue424() {}


### PR DESCRIPTION
We assumed every array/vector/matrix element has a non-zero stride, but `[()]` inside `BitSlice` produced a zero stride which then divides by zero.

Fixes https://github.com/Rust-GPU/rust-gpu/issues/424.