### PR TITLE
abi: use `PassMode::Direct` even for data types that can be passed as scalar pairs.

### DIFF
--- a/crates/rustc_codegen_spirv/src/abi.rs
+++ b/crates/rustc_codegen_spirv/src/abi.rs
@@ -69,6 +69,15 @@ pub(crate) fn provide(providers: &mut Providers) {
             // <https://github.com/rust-lang/rust/commit/eaaa03faf77b157907894a4207d8378ecaec7b45>
             arg.make_direct_deprecated();
 
+            // FIXME(eddyb) detect `#[rust_gpu::vector::v1]` more specifically,
+            // to avoid affecting anything should actually be passed as a pair.
+            if let PassMode::Pair(..) = arg.mode {
+                // HACK(eddyb) this avoids breaking e.g. `&[T]` pairs.
+                if let TyKind::Adt(..) = arg.layout.ty.kind() {
+                    arg.mode = PassMode::Direct(ArgAttributes::new());
+                }
+            }
+
             // Avoid pointlessly passing ZSTs, just like the official Rust ABI.
             if arg.layout.is_zst() {
                 arg.mode = PassMode::Ignore;


### PR DESCRIPTION
Ideally this change would apply only to `#[rust_gpu::vector::v1]` types (as they're the ones which can end up being passed as pairs when they have only 2 components, e.g. `glam::{Vec2,IVec2,UVec2}` etc.), but checking that from a query override (which is where this logic is right now) isn't exactly trivial.

However, I don't expect doing this across the board (i.e. to all `struct`s and `enum`s that would've gotten passed as two scalar args) to cause any issues, not even performance ones (at least on reasonable drivers).

Motivated by (and unlocks):
- #380 

More specifically, it should remove the dependency on this other PR:
- #381
(still want to land that, but it makes more sense as an diagnostic UX improvement, while semantically IMO we should not be decomposing and recomposing vector types just because we're not using `#[repr(simd)]` anymore)