### PR TITLE
accept absolute `target_dir_path` and properly resolve relative ones with `cargo_metadata`

### DIFF
--- a/examples/runners/ash/build.rs
+++ b/examples/runners/ash/build.rs
@@ -1,8 +1,0 @@
-use std::env;
-
-fn main() {
-    // While OUT_DIR is set for both build.rs and compiling the crate, PROFILE is only set in
-    // build.rs. So, export it to crate compilation as well.
-    let profile = env::var("PROFILE").unwrap();
-    println!("cargo:rustc-env=PROFILE={profile}");
-}

--- a/examples/runners/ash/src/main.rs
+++ b/examples/runners/ash/src/main.rs
@@ -124,17 +124,6 @@ pub struct Options {
 }
 
 pub fn main() {
-    // Hack: spirv_builder builds into a custom directory if running under cargo, to not
-    // deadlock, and the default target directory if not. However, packages like `proc-macro2`
-    // have different configurations when being built here vs. when building
-    // rustc_codegen_spirv normally, so we *want* to build into a separate target directory, to
-    // not have to rebuild half the crate graph every time we run. So, pretend we're running
-    // under cargo by setting these environment variables.
-    unsafe {
-        std::env::set_var("OUT_DIR", env!("OUT_DIR"));
-        std::env::set_var("PROFILE", env!("PROFILE"));
-    }
-
     let options = Options::parse();
     let (vert_data, frag_data) = compile_shaders(&options.shader);
 

--- a/examples/runners/wgpu/build.rs
+++ b/examples/runners/wgpu/build.rs
@@ -3,18 +3,16 @@ use std::error::Error;
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS")?;
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH")?;
+    let target_os = env::var("CARGO_CFG_TARGET_OS")?;
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH")?;
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_OS");
     println!("cargo:rerun-if-env-changed=CARGO_CFG_TARGET_ARCH");
-    // While OUT_DIR is set for both build.rs and compiling the crate, PROFILE is only set in
-    // build.rs. So, export it to crate compilation as well.
-    let profile = env::var("PROFILE").unwrap();
-    println!("cargo:rustc-env=PROFILE={profile}");
+
     if target_os != "android" && target_arch != "wasm32" {
         return Ok(());
     }
+    let profile = env::var("PROFILE").unwrap();
     let mut dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     // Strip `$profile/build/*/out`.
     let ok = dir.ends_with("out")
@@ -25,10 +23,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         && dir.ends_with(profile)
         && dir.pop();
     assert!(ok);
-    // NOTE(eddyb) this needs to be distinct from the `--target-dir` value that
-    // `spirv-builder` generates in a similar way from `$OUT_DIR` and `$PROFILE`,
-    // otherwise repeated `cargo build`s will cause build script reruns and the
-    // rebuilding of `rustc_codegen_spirv` (likely due to common proc macro deps).
     let dir = dir.join("example-runner-wgpu-builder");
     let status = std::process::Command::new("cargo")
         .args([

--- a/examples/runners/wgpu/builder/src/main.rs
+++ b/examples/runners/wgpu/builder/src/main.rs
@@ -9,6 +9,9 @@ fn build_shader(path_to_crate: &str, codegen_names: bool) -> Result<(), Box<dyn 
     let path_to_crate = builder_dir.join(path_to_crate);
     let result = SpirvBuilder::new(path_to_crate, "spirv-unknown-vulkan1.1")
         .print_metadata(MetadataPrintout::Full)
+        // Give this spirv-builder a unique target dir, so that rebuilding android and the main wgpu app's target dir
+        // don't clash and break each other's incremental
+        .target_dir_path("example-runner-wgpu-builder")
         .build()?;
     if codegen_names {
         let out_dir = env::var_os("OUT_DIR").unwrap();

--- a/examples/runners/wgpu/src/lib.rs
+++ b/examples/runners/wgpu/src/lib.rs
@@ -236,17 +236,6 @@ pub fn main(
 
     #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
     {
-        // Hack: spirv_builder builds into a custom directory if running under cargo, to not
-        // deadlock, and the default target directory if not. However, packages like `proc-macro2`
-        // have different configurations when being built here vs. when building
-        // rustc_codegen_spirv normally, so we *want* to build into a separate target directory, to
-        // not have to rebuild half the crate graph every time we run. So, pretend we're running
-        // under cargo by setting these environment variables.
-        unsafe {
-            std::env::set_var("OUT_DIR", env!("OUT_DIR"));
-            std::env::set_var("PROFILE", env!("PROFILE"));
-        }
-
         if options.shader == RustGPUShader::Compute {
             return compute::start(&options);
         }


### PR DESCRIPTION
> [!WARNING]  
> The change described in the title has already been merged into main with d416b65572279c8bd5d1b7df9c04800d62061db5 in https://github.com/Rust-GPU/rust-gpu/pull/216. This PR merely serves to document said change, and to adopt the examples.

Thus, the *actual* contents of this PR is:
> remove example build scripts forwarding `PROFILE` env var
>
> no longer necessary since d416b65572279c8bd5d1b7df9c04800d62061db5

@eddyb asked me to split it out of https://github.com/Rust-GPU/rust-gpu/pull/419#discussion_r2426486068

(Are we ok with this sort of PR, or do you want it changed to reflect the actual contents of this PR?)