### PR TITLE
subgroup: fix docs and broadcast const variant

### DIFF
--- a/tests/compiletests/ui/arch/subgroup/subgroup_broadcast.rs
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_broadcast.rs
@@ -1,0 +1,25 @@
+// build-pass
+// compile-flags: -C target-feature=+GroupNonUniform,+GroupNonUniformBallot,+ext:SPV_KHR_vulkan_memory_model
+// compile-flags: -C llvm-args=--disassemble-fn=subgroup_broadcast::disassembly
+// normalize-stderr-test "OpLine .*\n" -> ""
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+
+use spirv_std::arch::{GroupOperation, SubgroupMask};
+use spirv_std::spirv;
+
+unsafe fn disassembly(value: i32, id: u32) -> i32 {
+    spirv_std::arch::subgroup_broadcast(value, id)
+}
+
+#[spirv(compute(threads(32, 1, 1)))]
+pub fn main() {
+    unsafe {
+        disassembly(42, 5);
+    }
+}

--- a/tests/compiletests/ui/arch/subgroup/subgroup_broadcast.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_broadcast.stderr
@@ -1,0 +1,8 @@
+%1 = OpFunction  %2  None %3
+%4 = OpFunctionParameter  %2
+%5 = OpFunctionParameter  %6
+%7 = OpLabel
+%9 = OpGroupNonUniformBroadcast  %2  %10 %4 %5
+OpNoLine
+OpReturnValue %9
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/subgroup/subgroup_broadcast_const.rs
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_broadcast_const.rs
@@ -1,0 +1,18 @@
+// build-pass
+// compile-flags: -C target-feature=+GroupNonUniform,+GroupNonUniformBallot,+ext:SPV_KHR_vulkan_memory_model
+// compile-flags: -C llvm-args=--disassemble-fn=subgroup_broadcast_const::disassembly
+// normalize-stderr-test "OpLine .*\n" -> ""
+
+use spirv_std::arch::{GroupOperation, SubgroupMask};
+use spirv_std::spirv;
+
+unsafe fn disassembly(value: i32) -> i32 {
+    spirv_std::arch::subgroup_broadcast_const::<_, 5>(value)
+}
+
+#[spirv(compute(threads(32, 1, 1)))]
+pub fn main() {
+    unsafe {
+        disassembly(-42);
+    }
+}

--- a/tests/compiletests/ui/arch/subgroup/subgroup_broadcast_const.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_broadcast_const.stderr
@@ -1,0 +1,7 @@
+%1 = OpFunction  %2  None %3
+%4 = OpFunctionParameter  %2
+%5 = OpLabel
+%7 = OpGroupNonUniformBroadcast  %2  %8 %4 %9
+OpNoLine
+OpReturnValue %7
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_0_fail.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_0_fail.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation panicked: `ClusterSize` must be at least 1
-  --> $SPIRV_STD_SRC/arch/subgroup.rs:825:1
+  --> $SPIRV_STD_SRC/arch/subgroup.rs:868:1
    |
 LL | / macro_subgroup_op_clustered!(impl Integer, "OpGroupNonUniformIAdd", subgroup_clustered_i_add; r"
 LL | | An integer add group operation of all `value` operands contributed by active invocations in the group.
@@ -13,7 +13,7 @@ LL | | ");
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `macro_subgroup_op_clustered` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $SPIRV_STD_SRC/arch/subgroup.rs:825:1
+  --> $SPIRV_STD_SRC/arch/subgroup.rs:868:1
    |
 LL | / macro_subgroup_op_clustered!(impl Integer, "OpGroupNonUniformIAdd", subgroup_clustered_i_add; r"
 LL | | An integer add group operation of all `value` operands contributed by active invocations in the group.

--- a/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_non_power_of_two_fail.stderr
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_cluster_size_non_power_of_two_fail.stderr
@@ -1,5 +1,5 @@
 error[E0080]: evaluation panicked: `ClusterSize` must be a power of 2
-  --> $SPIRV_STD_SRC/arch/subgroup.rs:825:1
+  --> $SPIRV_STD_SRC/arch/subgroup.rs:868:1
    |
 LL | / macro_subgroup_op_clustered!(impl Integer, "OpGroupNonUniformIAdd", subgroup_clustered_i_add; r"
 LL | | An integer add group operation of all `value` operands contributed by active invocations in the group.
@@ -13,7 +13,7 @@ LL | | ");
    = note: this error originates in the macro `$crate::panic::panic_2021` which comes from the expansion of the macro `macro_subgroup_op_clustered` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 note: erroneous constant encountered
-  --> $SPIRV_STD_SRC/arch/subgroup.rs:825:1
+  --> $SPIRV_STD_SRC/arch/subgroup.rs:868:1
    |
 LL | / macro_subgroup_op_clustered!(impl Integer, "OpGroupNonUniformIAdd", subgroup_clustered_i_add; r"
 LL | | An integer add group operation of all `value` operands contributed by active invocations in the group.


### PR DESCRIPTION
* fix broadcast docs as reported by @nazar-pc in https://github.com/Rust-GPU/rust-gpu/pull/306/files/88eb6e3b2cfb30188aa9164d529738eddeaa77dd#r2413686865
* adds `subgroup_broadcast_const` variant
  * prior to `spv1.5` or `vulkan1.2`, the `OpGroupNonUniformBroadcast`'s `id` param must be a constant
  * you can't actually use our `subgroup_broadcast`, even if the `id` is a constant as we'll emit it as a dynamic param instead
  * `subgroup_broadcast_const` accepts `id` as a const generic and ensures it's emitted as a constant
* Question: In the newer spirv specs they refactored the docs to respect the new "tangle" definitions, should I also update the docs of our intrinsics?