### PR TITLE
Arrayed specialization constants

### DIFF
--- a/crates/rustc_codegen_spirv/src/attr.rs
+++ b/crates/rustc_codegen_spirv/src/attr.rs
@@ -75,6 +75,7 @@ pub enum IntrinsicType {
 pub struct SpecConstant {
     pub id: u32,
     pub default: Option<u32>,
+    pub array_count: Option<u32>,
 }
 
 // NOTE(eddyb) when adding new `#[spirv(...)]` attributes, the tests found inside
@@ -661,6 +662,8 @@ fn parse_spec_constant_attr(
     Ok(SpecConstant {
         id: id.ok_or_else(|| (arg.span(), "expected `spec_constant(id = ...)`".into()))?,
         default,
+        // to be set later
+        array_count: None,
     })
 }
 

--- a/tests/compiletests/ui/dis/spec_constant_array.rs
+++ b/tests/compiletests/ui/dis/spec_constant_array.rs
@@ -1,0 +1,28 @@
+// Tests the various forms of `#[spirv(spec_constant)]`.
+
+// build-pass
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+// compile-flags: -C llvm-args=--disassemble
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+
+// HACK(eddyb) `compiletest` handles `ui\dis\`, but not `ui\\dis\\`, on Windows.
+// normalize-stderr-test "ui/dis/" -> "$$DIR/"
+
+use spirv_std::spirv;
+
+#[spirv(compute(threads(1)))]
+pub fn main(
+    #[spirv(spec_constant(id = 42, default = 69))] array: [u32; 4],
+    #[spirv(storage_buffer, descriptor_set = 0, binding = 0)] out: &mut u32,
+) {
+    *out = array[0] + array[1] + array[2] + array[3];
+}

--- a/tests/compiletests/ui/dis/spec_constant_array.stderr
+++ b/tests/compiletests/ui/dis/spec_constant_array.stderr
@@ -1,0 +1,38 @@
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint GLCompute %1 "main" %2
+OpExecutionMode %1 LocalSize 1 1 1
+%3 = OpString "$DIR/spec_constant_array.rs"
+OpDecorate %4 Block
+OpMemberDecorate %4 0 Offset 0
+OpDecorate %2 Binding 0
+OpDecorate %2 DescriptorSet 0
+OpDecorate %5 SpecId 42
+OpDecorate %6 SpecId 43
+OpDecorate %7 SpecId 44
+OpDecorate %8 SpecId 45
+%9 = OpTypeInt 32 0
+%4 = OpTypeStruct %9
+%10 = OpTypePointer StorageBuffer %4
+%11 = OpTypeVoid
+%12 = OpTypeFunction %11
+%13 = OpTypePointer StorageBuffer %9
+%2 = OpVariable  %10  StorageBuffer
+%14 = OpConstant  %9  0
+%5 = OpSpecConstant  %9  69
+%6 = OpSpecConstant  %9  69
+%7 = OpSpecConstant  %9  69
+%8 = OpSpecConstant  %9  69
+%1 = OpFunction  %11  None %12
+%15 = OpLabel
+OpLine %3 25 4
+%16 = OpInBoundsAccessChain  %13  %2 %14
+OpLine %3 27 11
+%17 = OpIAdd  %9  %5 %6
+%18 = OpIAdd  %9  %17 %7
+OpLine %3 27 4
+%19 = OpIAdd  %9  %18 %8
+OpStore %16 %19
+OpNoLine
+OpReturn
+OpFunctionEnd


### PR DESCRIPTION
Allows spec constants to be declared as arrays:
```rust
// single spec constants currently
#[spirv(spec_constant(id = 12, default = 34))] single: u32,
// spec constant arrays start at `id` and occupy consecutive ids, this uses id 42..46
// the default is the same for all values
#[spirv(spec_constant(id = 42, default = 69))] array: [u32; 4],
```