### PR TITLE
Create nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/Cargo.lock
 .github/install-spirv-tools/Cargo.lock
 rustc-ice-*.txt
 .idea
+.direnv

--- a/android.nix
+++ b/android.nix
@@ -9,9 +9,9 @@
 # (you can also replace `cargo apk build` with `cargo apk run` to launch it,
 # via `adb`, into either the Android Emulator, or a physical Android device)
 
-let
-  pkgs = import <nixpkgs> {};
-in with pkgs; mkShell rec {
+{ pkgs, rustToolchain, ... }:
+
+with pkgs; mkShell rec {
   # Workaround for https://github.com/NixOS/nixpkgs/issues/60919.
   # NOTE(eddyb) needed only in debug mode (warnings about needing optimizations
   # turn into errors due to `-Werror`, for at least `spirv-tools-sys`).
@@ -20,15 +20,17 @@ in with pkgs; mkShell rec {
   # Allow cargo to download crates (even inside `nix-shell --pure`).
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-  nativeBuildInputs = [ rustup cargo-apk jdk ];
+  nativeBuildInputs = [ rustToolchain cargo-apk jdk ];
 
-  ANDROID_SDK_ROOT = let
-    androidComposition = androidenv.composeAndroidPackages {
-      abiVersions = [ "arm64-v8a" "x86_64" ];
-      includeNDK = true;
-      platformVersions = [ "30" ];
-    };
-  in "${androidComposition.androidsdk}/libexec/android-sdk";
+  ANDROID_SDK_ROOT =
+    let
+      androidComposition = androidenv.composeAndroidPackages {
+        abiVersions = [ "arm64-v8a" "x86_64" ];
+        includeNDK = true;
+        platformVersions = [ "30" ];
+      };
+    in
+    "${androidComposition.androidsdk}/libexec/android-sdk";
 
   ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762943920,
+        "narHash": "sha256-ITeH8GBpQTw9457ICZBddQEBjlXMmilML067q0e6vqY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1763174172,
+        "narHash": "sha256-u6dcvXk2K6eYVYhmfiN3xmhIf3yUo5KPwm79UOD37Jo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "89af6762b01409edbb595888a69311e8e5954110",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "rust-gpu";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+          config.allowUnfree = true;
+        };
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      in
+      {
+        devShells = {
+          default = pkgs.callPackage ./shell.nix { inherit rustToolchain; };
+          android = pkgs.callPackage ./android.nix { inherit rustToolchain; };
+        };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,6 @@
-let
-  pkgs = import <nixpkgs> {};
-in with pkgs; stdenv.mkDerivation rec {
-  name = "rust-gpu";
+{ pkgs, rustToolchain, ... }:
 
+with pkgs; mkShell {
   # Workaround for https://github.com/NixOS/nixpkgs/issues/60919.
   # NOTE(eddyb) needed only in debug mode (warnings about needing optimizations
   # turn into errors due to `-Werror`, for at least `spirv-tools-sys`).
@@ -11,16 +9,20 @@ in with pkgs; stdenv.mkDerivation rec {
   # Allow cargo to download crates (even inside `nix-shell --pure`).
   SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-  nativeBuildInputs = [ rustup ];
+  nativeBuildInputs = [ rustToolchain ];
 
   # Runtime dependencies (for the example runners).
-  LD_LIBRARY_PATH = with xorg; lib.makeLibraryPath [
+  LD_LIBRARY_PATH = with pkgs.xorg; lib.makeLibraryPath [
     vulkan-loader
 
     # NOTE(eddyb) winit really wants `libxkbcommon` on Wayland for some reason
     # (see https://github.com/rust-windowing/winit/issues/1760 for more info).
-    wayland libxkbcommon
+    wayland
+    libxkbcommon
 
-    libX11 libXcursor libXi libXrandr
+    libX11
+    libXcursor
+    libXi
+    libXrandr
   ];
 }


### PR DESCRIPTION
I have created a nix flake, that will fetch the required rust toolchain using [rust-overlay](https://github.com/oxalica/rust-overlay).
By doing this, the toolchain does not need to be installed into the user environment directly.
I also added an `.envrc`, this will allow to directly drop into a devshell if eg. [direnv](https://github.com/direnv/direnv) is used.