### PR TITLE
ci: switch vk software impl to lavapipe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -163,10 +163,7 @@ jobs:
           install_runtime: true
           cache: true
           stripdown: true
-
-          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
-          install_swiftshader: true
-          # install_lavapipe: true
+          install_lavapipe: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: ${{ runner.os == 'Windows' }}


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/506

Switches from swiftshader to lavapipe for software rasterization, since swiftshader doesn't support int64 *for whatever reason*. Needed for int64 difftests in https://github.com/Rust-GPU/rust-gpu/pull/502.

### Old description, please ignore

swiftshader download has been giving us a lot of download timeouts, from https://github.com/Rust-GPU/rust-gpu/issues/407:
> 🚀 Installing SwiftShader library...
Error: HttpClientError: API rate limit exceeded for 52.159.244.80. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)

The [install-vulkan-sdk-action](https://github.com/jakoch/install-vulkan-sdk-action) doesn't offer the option to forward credentials either. And I don't think you can use [retry actions](https://github.com/marketplace/actions/retry-step) to retry actual actions, they only support commands.

~~So by far the most low effort "fix" would be to switch to lavapipe and hope their servers don't have weird throttling. And our CI still works.~~ This won't work, both swiftshader and lavapipe artifacts are downloaded from [github releases](https://github.com/jakoch/rasterizers/releases).