### PR TITLE
make `image::fetch()` implicitly declare lod 0

### DIFF
--- a/crates/spirv-std/src/image.rs
+++ b/crates/spirv-std/src/image.rs
@@ -144,21 +144,7 @@ impl<
     where
         I: Integer,
     {
-        let mut result = SampledType::Vec4::default();
-        unsafe {
-            asm! {
-                "OpDecorate %image NonUniform",
-                "OpDecorate %result NonUniform",
-                "%image = OpLoad _ {this}",
-                "%coordinate = OpLoad _ {coordinate}",
-                "%result = OpImageFetch typeof*{result} %image %coordinate",
-                "OpStore {result} %result",
-                result = in(reg) &mut result,
-                this = in(reg) self,
-                coordinate = in(reg) &coordinate,
-            }
-        }
-        result.truncate_into()
+        self.fetch_with_lod(coordinate, 0)
     }
 
     /// Fetch a single texel at a mipmap `lod` with a sampler set at compile time

--- a/tests/compiletests/ui/image/gather_err.stderr
+++ b/tests/compiletests/ui/image/gather_err.stderr
@@ -9,7 +9,7 @@ LL |     let r1: glam::Vec4 = image1d.gather(*sampler, 0.0f32, 0);
              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-  --> $SPIRV_STD_SRC/image.rs:214:15
+  --> $SPIRV_STD_SRC/image.rs:200:15
    |
 LL |     pub fn gather<F>(
    |            ------ required by a bound in this associated function
@@ -28,7 +28,7 @@ LL |     let r2: glam::Vec4 = image3d.gather(*sampler, v3, 0);
              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
              Image<SampledType, 4, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#1}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::gather`
-  --> $SPIRV_STD_SRC/image.rs:214:15
+  --> $SPIRV_STD_SRC/image.rs:200:15
    |
 LL |     pub fn gather<F>(
    |            ------ required by a bound in this associated function

--- a/tests/compiletests/ui/image/query/query_levels_err.stderr
+++ b/tests/compiletests/ui/image/query/query_levels_err.stderr
@@ -10,7 +10,7 @@ LL |     *output = image.query_levels();
              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_levels`
-  --> $SPIRV_STD_SRC/image.rs:985:15
+  --> $SPIRV_STD_SRC/image.rs:971:15
    |
 LL |     pub fn query_levels(&self) -> u32
    |            ------------ required by a bound in this associated function

--- a/tests/compiletests/ui/image/query/query_lod_err.stderr
+++ b/tests/compiletests/ui/image/query/query_lod_err.stderr
@@ -10,7 +10,7 @@ LL |     *output = image.query_lod(*sampler, glam::Vec2::new(0.0, 1.0));
              Image<SampledType, 2, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
              Image<SampledType, 3, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_lod`
-  --> $SPIRV_STD_SRC/image.rs:1015:15
+  --> $SPIRV_STD_SRC/image.rs:1001:15
    |
 LL |     pub fn query_lod(
    |            --------- required by a bound in this associated function

--- a/tests/compiletests/ui/image/query/query_size_err.stderr
+++ b/tests/compiletests/ui/image/query/query_size_err.stderr
@@ -15,7 +15,7 @@ LL |     *output = image.query_size();
              Image<SampledType, 2, DEPTH, ARRAYED, 0, 2, FORMAT, COMPONENTS>
            and 6 others
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, MULTISAMPLED, SAMPLED, FORMAT, COMPONENTS>::query_size`
-  --> $SPIRV_STD_SRC/image.rs:1051:15
+  --> $SPIRV_STD_SRC/image.rs:1037:15
    |
 LL |     pub fn query_size<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(&self) -> Size
    |            ---------- required by a bound in this associated function

--- a/tests/compiletests/ui/image/query/query_size_lod_err.stderr
+++ b/tests/compiletests/ui/image/query/query_size_lod_err.stderr
@@ -10,7 +10,7 @@ LL |     *output = image.query_size_lod(0);
              Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `Image::<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#7}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>::query_size_lod`
-  --> $SPIRV_STD_SRC/image.rs:1098:15
+  --> $SPIRV_STD_SRC/image.rs:1084:15
    |
 LL |     pub fn query_size_lod<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(
    |            -------------- required by a bound in this associated function

--- a/tests/compiletests/ui/image/query/sampled_image_rect_query_size_lod_err.stderr
+++ b/tests/compiletests/ui/image/query/sampled_image_rect_query_size_lod_err.stderr
@@ -10,7 +10,7 @@ LL |     *output = rect_sampled.query_size_lod(0);
              Image<SampledType, 2, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
              Image<SampledType, 3, DEPTH, ARRAYED, 0, SAMPLED, FORMAT, COMPONENTS>
 note: required by a bound in `SampledImage::<Image<SampledType, DIM, DEPTH, ARRAYED, spirv_std::::image::{impl#9}::{constant#0}, SAMPLED, FORMAT, COMPONENTS>>::query_size_lod`
-  --> /image.rs:1267:12
+  --> /image.rs:1253:12
    |
 LL |     pub fn query_size_lod<Size: ImageSizeQuery<u32, DIM, ARRAYED> + Default>(
    |            -------------- required by a bound in this associated function


### PR DESCRIPTION
* glsl [`texelFetch(sampler, coordinate, lod)`](https://docs.gl/sl4/texelFetch) takes the lod as an explicit parameter, so you can't emit a texel fetch in glsl without explicit lod
* naga doesn't understand texel fetch without explicit lod