### PR TITLE
ci: don't install swiftshader where not necessary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
       - main
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 name: CI
 
@@ -32,10 +33,6 @@ jobs:
           install_runtime: true
           cache: true
           stripdown: true
-
-          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
-          install_swiftshader: true
-          # install_lavapipe: true
       - if: ${{ runner.os == 'Linux' }}
         name: Linux - Install native dependencies
         run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
@@ -97,10 +94,6 @@ jobs:
           install_runtime: true
           cache: true
           stripdown: true
-
-          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
-          install_swiftshader: true
-          # install_lavapipe: true
       - name: install rust-toolchain
         run: cargo version
       - name: cargo fetch --locked
@@ -145,10 +138,6 @@ jobs:
           install_runtime: true
           cache: true
           stripdown: true
-
-          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
-          install_swiftshader: true
-          # install_lavapipe: true
       - name: install rust-toolchain
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - name: cargo fetch --locked
@@ -240,10 +229,6 @@ jobs:
           install_runtime: true
           cache: true
           stripdown: true
-
-          # FIXME(eddyb) consider using lavapipe instead, or even trying both.
-          install_swiftshader: true
-          # install_lavapipe: true
       # cargo version is a random command that forces the installation of rust-toolchain
       - name: install rust-toolchain
         run: cargo version


### PR DESCRIPTION
Split out of https://github.com/Rust-GPU/rust-gpu/pull/489

Makes only the difftest install swiftshader (though it's technically only needed on windows). This should hopefully reduce the amount of swiftshader download failures we're seeing, before we're able to find a more permanent solution. See https://github.com/Rust-GPU/rust-gpu/issues/407 for details.

Also allow `workflow_dispatch` so we can launch CI pipelines manually on random branches without opening a PR.