### PR TITLE
Add `naga-wgsl` target v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -237,6 +246,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
@@ -544,6 +559,15 @@ checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
  "serde",
  "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
  "unicode-width",
 ]
 
@@ -2098,11 +2122,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
- "codespan-reporting",
+ "codespan-reporting 0.12.0",
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
@@ -2113,9 +2137,34 @@ dependencies = [
  "once_cell",
  "petgraph",
  "rustc-hash",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
  "thiserror 2.0.18",
  "unicode-ident",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2630921705b9b01dcdd0b6864b9562ca3c1951eecd0f0c4f5f04f61e412647"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.9.1",
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting 0.13.1",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "petgraph",
+ "rustc-hash",
+ "spirv 0.4.0+sdk-1.4.341.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2906,7 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cf3a93856b6e5946537278df0d3075596371b1950ccff012f02b0f7eafec8d"
 dependencies = [
  "rustc-hash",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
 ]
 
 [[package]]
@@ -2941,6 +2990,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "naga 29.0.1",
  "object 0.37.3",
  "pretty_assertions",
  "regex",
@@ -2953,6 +3003,7 @@ dependencies = [
  "spirt",
  "spirv-std-types",
  "spirv-tools",
+ "strum",
  "termcolor",
  "thorin-dwp",
  "tracing",
@@ -2968,7 +3019,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "spirv",
+ "spirv 0.3.0+sdk-1.3.268.0",
  "thiserror 2.0.18",
 ]
 
@@ -3356,6 +3407,15 @@ checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
  "bitflags 2.10.0",
  "serde",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -4320,7 +4380,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "js-sys",
  "log",
- "naga",
+ "naga 27.0.3",
  "parking_lot",
  "portable-atomic",
  "profiling",
@@ -4342,8 +4402,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.10.0",
  "bytemuck",
  "cfg_aliases",
@@ -4351,7 +4411,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "log",
- "naga",
+ "naga 27.0.3",
  "once_cell",
  "parking_lot",
  "portable-atomic",
@@ -4403,7 +4463,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.10.0",
  "block",
  "bytemuck",
@@ -4422,7 +4482,7 @@ dependencies = [
  "libloading",
  "log",
  "metal",
- "naga",
+ "naga 27.0.3",
  "ndk-sys",
  "objc",
  "once_cell",

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -20,10 +20,10 @@ crate-type = ["dylib"]
 default = ["use-compiled-tools"]
 # If enabled, uses spirv-tools binaries installed in PATH, instead of
 # compiling and linking the spirv-tools C++ code
-use-installed-tools = ["spirv-tools/use-installed-tools"]
+use-installed-tools = ["spirv-tools/use-installed-tools", "naga"]
 # If enabled will compile and link the C++ code for the spirv tools, the compiled
 # version is preferred if both this and `use-installed-tools` are enabled
-use-compiled-tools = ["spirv-tools/use-compiled-tools"]
+use-compiled-tools = ["spirv-tools/use-compiled-tools", "naga"]
 # If enabled, this will not check whether the current rustc version is set to the
 # appropriate channel. rustc_cogeden_spirv requires a specific nightly version,
 # and will likely produce compile errors when built against a different toolchain.

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -61,6 +61,8 @@ itertools = "0.14.0"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-tree = "0.4.0"
+naga = { version = "29.0.1", features = ["spv-in", "wgsl-out"] }
+strum = { version = "0.27.2", features = ["derive"] }
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/crates/rustc_codegen_spirv/Cargo.toml
+++ b/crates/rustc_codegen_spirv/Cargo.toml
@@ -29,6 +29,7 @@ use-compiled-tools = ["spirv-tools/use-compiled-tools"]
 # and will likely produce compile errors when built against a different toolchain.
 # Enable this feature to be able to experiment with other versions.
 skip-toolchain-check = []
+naga = ["dep:naga"]
 
 [dependencies]
 # HACK(eddyb) these only exist to unify features across dependency trees,
@@ -61,7 +62,7 @@ itertools = "0.14.0"
 tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-tree = "0.4.0"
-naga = { version = "29.0.1", features = ["spv-in", "wgsl-out"] }
+naga = { version = "29.0.1", features = ["spv-in", "wgsl-out"], optional = true }
 strum = { version = "0.27.2", features = ["derive"] }
 
 [dev-dependencies]

--- a/crates/rustc_codegen_spirv/src/lib.rs
+++ b/crates/rustc_codegen_spirv/src/lib.rs
@@ -127,6 +127,7 @@ mod custom_decorations;
 mod custom_insts;
 mod link;
 mod linker;
+mod naga_transpile;
 mod spirv_type;
 mod spirv_type_constraints;
 mod symbols;

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -321,7 +321,7 @@ fn post_link_single_module(
         drop(save_modules_timer);
     }
 
-    if let Some(transpile) = should_transpile(sess) {
+    if let Ok(Some(transpile)) = should_transpile(sess) {
         transpile(sess, cg_args, &spv_binary, out_filename).ok();
     }
 }

--- a/crates/rustc_codegen_spirv/src/link.rs
+++ b/crates/rustc_codegen_spirv/src/link.rs
@@ -3,6 +3,7 @@ use crate::maybe_pqp_cg_ssa as rustc_codegen_ssa;
 
 use crate::codegen_cx::{CodegenArgs, SpirvMetadata};
 use crate::linker;
+use crate::naga_transpile::should_transpile;
 use crate::target::{SpirvTarget, SpirvTargetVariant};
 use ar::{Archive, GnuBuilder, Header};
 use rspirv::binary::Assemble;
@@ -318,6 +319,10 @@ fn post_link_single_module(
         }
 
         drop(save_modules_timer);
+    }
+
+    if let Some(transpile) = should_transpile(sess) {
+        transpile(sess, cg_args, &spv_binary, out_filename).ok();
     }
 }
 

--- a/crates/rustc_codegen_spirv/src/naga_transpile.rs
+++ b/crates/rustc_codegen_spirv/src/naga_transpile.rs
@@ -1,0 +1,79 @@
+use crate::codegen_cx::CodegenArgs;
+use crate::target::{NagaTarget, SpirvTarget};
+use rustc_session::Session;
+use rustc_span::ErrorGuaranteed;
+use std::path::Path;
+
+pub type NagaTranspile = fn(
+    sess: &Session,
+    cg_args: &CodegenArgs,
+    spv_binary: &[u32],
+    out_filename: &Path,
+) -> Result<(), ErrorGuaranteed>;
+
+pub fn should_transpile(sess: &Session) -> Option<NagaTranspile> {
+    let target = SpirvTarget::parse_target(sess.opts.target_triple.tuple())
+        .expect("parsing should fail earlier");
+    match target {
+        SpirvTarget::Naga(NagaTarget::NAGA_WGSL) => Some(transpile::wgsl_transpile),
+        _ => None,
+    }
+}
+
+mod transpile {
+    use crate::codegen_cx::CodegenArgs;
+    use naga::error::ShaderError;
+    use naga::valid::Capabilities;
+    use rustc_session::Session;
+    use rustc_span::ErrorGuaranteed;
+    use std::path::Path;
+
+    pub fn wgsl_transpile(
+        sess: &Session,
+        _cg_args: &CodegenArgs,
+        spv_binary: &[u32],
+        out_filename: &Path,
+    ) -> Result<(), ErrorGuaranteed> {
+        // these should be params via spirv-builder
+        let opts = naga::front::spv::Options::default();
+        let capabilities = Capabilities::all();
+        let writer_flags = naga::back::wgsl::WriterFlags::empty();
+
+        let module = naga::front::spv::parse_u8_slice(bytemuck::cast_slice(spv_binary), &opts)
+            .map_err(|err| {
+                sess.dcx().err(format!(
+                    "Naga failed to parse spv: \n{}",
+                    ShaderError {
+                        source: String::new(),
+                        label: None,
+                        inner: Box::new(err),
+                    }
+                ))
+            })?;
+        let mut validator =
+            naga::valid::Validator::new(naga::valid::ValidationFlags::default(), capabilities);
+        let info = validator.validate(&module).map_err(|err| {
+            sess.dcx().err(format!(
+                "Naga validation failed: \n{}",
+                ShaderError {
+                    source: String::new(),
+                    label: None,
+                    inner: Box::new(err),
+                }
+            ))
+        })?;
+
+        let wgsl_dst = out_filename.with_extension("wgsl");
+        let wgsl = naga::back::wgsl::write_string(&module, &info, writer_flags).map_err(|err| {
+            sess.dcx()
+                .err(format!("Naga failed to write wgsl : \n{err}"))
+        })?;
+
+        std::fs::write(&wgsl_dst, wgsl).map_err(|err| {
+            sess.dcx()
+                .err(format!("failed to write wgsl to file: {err}"))
+        })?;
+
+        Ok(())
+    }
+}

--- a/tests/compiletests/Cargo.toml
+++ b/tests/compiletests/Cargo.toml
@@ -15,7 +15,7 @@ use-compiled-tools = ["rustc_codegen_spirv/use-compiled-tools"]
 
 [dependencies]
 compiletest = { version = "0.11.2", package = "compiletest_rs" }
-rustc_codegen_spirv = { workspace = true }
+rustc_codegen_spirv = { workspace = true, features = ["naga"] }
 rustc_codegen_spirv-types = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 itertools = "0.14.0"


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/491
Supersedes https://github.com/Rust-GPU/rust-gpu/pull/280

Adds `spirv-unknown-naga-wgsl` target for built-in naga transpilation to wgsl. Further naga targets could be added easily.

Quite a lot compiletest fail with naga, common reasons include:
* unsupported extensions & capabilities (mesh shader, ray tracing etc.)
* no support for `u8` & `i8`
* unknown instructions
* > Vertex shaders must return a `@builtin(position)` output value

For now, I'd just accept that any naga targets won't pass our compiletest suite and not add a CI step for that.