### PR TITLE
spirv-builder: check and clippy shortcuts

### DIFF
--- a/crates/spirv-builder/src/lib.rs
+++ b/crates/spirv-builder/src/lib.rs
@@ -719,6 +719,24 @@ impl SpirvBuilder {
         self
     }
 
+    /// Shortcut for `cargo check`
+    pub fn check(&mut self) -> Result<CompileResult, SpirvBuilderError> {
+        self.run_cargo_cmd("check")
+    }
+
+    /// Shortcut for `cargo clippy`
+    pub fn clippy(&mut self) -> Result<CompileResult, SpirvBuilderError> {
+        self.run_cargo_cmd("clippy")
+    }
+
+    /// Run the supplied cargo cmd, and ensure to reset the state so [`Self::build`] still works as normal
+    fn run_cargo_cmd(&mut self, cmd: &str) -> Result<CompileResult, SpirvBuilderError> {
+        let old = self.cargo_cmd.replace(cmd.into());
+        let result = self.build();
+        self.cargo_cmd = old;
+        result
+    }
+
     /// Builds the module
     pub fn build(&self) -> Result<CompileResult, SpirvBuilderError> {
         let metadata_file = invoke_rustc(self)?;


### PR DESCRIPTION
@nazar-pc ashed in https://github.com/Rust-GPU/cargo-gpu/pull/131#issuecomment-3691984086:

> I'd appreciate some simple [to run `cargo gpu clippy` and `check`] way through `cargo-gpu-install`.

So I added these shortcuts, so you can run clippy in your build script, and afterwards still build your shaders without having to clone the `SpirvBuilder`. 