### PR TITLE
ci: fix swiftshader rate limit exceeded

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,6 +169,11 @@ jobs:
           # install_lavapipe: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - if: ${{ runner.os == 'Windows' }}
+        name: Windows - Register Driver in Registry
+        shell: pwsh
+        run: |
+          reg add "HKLM\SOFTWARE\Khronos\Vulkan\Drivers" /v "$env:VK_DRIVER_FILES" /t REG_DWORD /d 0 /f
       - if: ${{ runner.os == 'Linux' }}
         name: Linux - Install native dependencies
         run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev


### PR DESCRIPTION
I've upstreamed some changes to `install-vulkan-sdk-action` and the maintainer made some fixes, and want to test them in our pipeline:
* Pass the github token to the action to fix timeouts: https://github.com/jakoch/install-vulkan-sdk-action/issues/544
  * hopefully fixes https://github.com/Rust-GPU/rust-gpu/issues/407 once and for all
* The action now exports `VK_DRIVER_FILES` on its own, so we don't need to that explicitly: https://github.com/jakoch/install-vulkan-sdk-action/pull/545
* use `*-latest` OS for windows and linux
  * upgrades `windows-2022` to `windows-2025`. This seems to change [vulkan driver discovery](https://github.com/jakoch/install-vulkan-sdk-action/issues/547#issuecomment-3719074065), so we need to register the driver in the windows registry.
  
I've asked if the registry entry could be added by the action itself: https://github.com/jakoch/install-vulkan-sdk-action/issues/547

~~This PR also serves as a testing ground for that patch and should showcase that *in some scenarios* setting `VK_DRIVER_FILES` without *formally* adding the driver to the windows registry is sufficient. See https://github.com/jakoch/install-vulkan-sdk-action/issues/547 for ongoing investigation.~~ Resolved: windows-2022 is fine without registration, windows-2025 requires it though.

close https://github.com/Rust-GPU/rust-gpu/issues/407