### PR TITLE
Fold OpLoad from Private variables with constant initializers

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/dce.rs
+++ b/crates/rustc_codegen_spirv/src/linker/dce.rs
@@ -282,7 +282,15 @@ fn instruction_is_pure(inst: &Instruction) -> bool {
         | PtrEqual
         | PtrNotEqual
         | PtrDiff => true,
-        Variable => inst.operands.first() == Some(&Operand::StorageClass(StorageClass::Function)),
+        // Variables with Function or Private storage class are pure and can be DCE'd if unused.
+        // Other storage classes (Input, Output, Uniform, etc.) are part of the shader interface
+        // and must be kept.
+        Variable => matches!(
+            inst.operands.first(),
+            Some(&Operand::StorageClass(
+                StorageClass::Function | StorageClass::Private
+            ))
+        ),
         _ => false,
     }
 }


### PR DESCRIPTION
Disclosure: I had AI write this and I only superficially understand the code.

Replace OpLoad from Private/Function
storage class variables with their constant initializers. This eliminates pointer-to-pointer patterns like `&&123` which would otherwise generate invalid SPIR-V in Logical addressing mode (pointer-to-pointer is only allowed for StorageBuffer/Workgroup, not Private).

The optimization runs after inlining (which may expose such patterns) and before DCE (so the now-unused variables can be removed).

Also extend DCE to treat Private storage class variables as pure, allowing them to be removed when unused.

Newer versions of spirv-val catch this, causing our compiletests to fail.