### PR TITLE
Add missing parent capabilities in test compile flags

### DIFF
--- a/tests/compiletests/ui/arch/emit_stream_vertex.rs
+++ b/tests/compiletests/ui/arch/emit_stream_vertex.rs
@@ -1,5 +1,5 @@
 // build-pass
-// compile-flags: -C target-feature=+Int64,+GeometryStreams
+// compile-flags: -C target-feature=+Int64,+Geometry,+GeometryStreams
 
 use spirv_std::spirv;
 

--- a/tests/compiletests/ui/arch/end_stream_primitive.rs
+++ b/tests/compiletests/ui/arch/end_stream_primitive.rs
@@ -1,5 +1,5 @@
 // build-pass
-// compile-flags: -C target-feature=+Int64,+GeometryStreams
+// compile-flags: -C target-feature=+Int64,+Geometry,+GeometryStreams
 
 use spirv_std::spirv;
 

--- a/tests/compiletests/ui/arch/subgroup/subgroup_builtins.rs
+++ b/tests/compiletests/ui/arch/subgroup/subgroup_builtins.rs
@@ -1,5 +1,5 @@
 // build-pass
-// compile-flags: -C target-feature=+GroupNonUniformBallot,+ext:SPV_KHR_vulkan_memory_model
+// compile-flags: -C target-feature=+GroupNonUniform,+GroupNonUniformBallot,+ext:SPV_KHR_vulkan_memory_model
 
 use spirv_std::arch::SubgroupMask;
 use spirv_std::spirv;

--- a/tests/compiletests/ui/lang/consts/nested-ref.rs
+++ b/tests/compiletests/ui/lang/consts/nested-ref.rs
@@ -2,7 +2,7 @@
 // contain references, and where the `T` values aren't immediately loaded from.
 
 // build-pass
-// compile-flags: -C target-feature=+VariablePointers
+// compile-flags: -C target-feature=+VariablePointersStorageBuffer,+VariablePointers
 
 use spirv_std::spirv;
 


### PR DESCRIPTION
These were caught by the new validator.