### PR TITLE
ci: add rust-cache action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,11 @@ jobs:
       # figure out native target triple while we're at it
       - name: install rust-toolchain
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       # Fetch dependencies in a separate step to clearly show how long each part
       # of the testing takes
       - name: cargo fetch --locked
@@ -94,6 +99,11 @@ jobs:
           stripdown: true
       - name: install rust-toolchain
         run: cargo version
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: cargo fetch --locked
         run: cargo fetch --locked --target ${{ matrix.target }}
 
@@ -138,6 +148,11 @@ jobs:
           stripdown: true
       - name: install rust-toolchain
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: compiletest
@@ -173,6 +188,11 @@ jobs:
           sudo apt install -y xvfb libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
       - name: install rust-toolchain
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: cargo fetch --locked difftests
@@ -220,6 +240,11 @@ jobs:
       # cargo version is a random command that forces the installation of rust-toolchain
       - name: install rust-toolchain
         run: cargo version
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: Install rustup components
         run: rustup component add rustfmt clippy
       - name: cargo fetch --locked

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,9 +43,8 @@ jobs:
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "base"
       # Fetch dependencies in a separate step to clearly show how long each part
       # of the testing takes
       - name: cargo fetch --locked
@@ -101,9 +100,8 @@ jobs:
         run: cargo version
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "android"
       - name: cargo fetch --locked
         run: cargo fetch --locked --target ${{ matrix.target }}
 
@@ -150,9 +148,9 @@ jobs:
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "base"
+          save-if: "false"
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: compiletest
@@ -190,9 +188,14 @@ jobs:
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "base"
+          save-if: "false"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          add-job-id-key: "false"
+          shared-key: "difftest"
+          workspaces: "tests/difftests/tests"
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: cargo fetch --locked difftests
@@ -240,11 +243,6 @@ jobs:
       # cargo version is a random command that forces the installation of rust-toolchain
       - name: install rust-toolchain
         run: cargo version
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-            tests/difftests/tests
       - name: Install rustup components
         run: rustup component add rustfmt clippy
       - name: cargo fetch --locked

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
         with:
           add-job-id-key: "false"
           shared-key: "base"
+          save-if: ${{ github.ref_name == 'main' }}
       # Fetch dependencies in a separate step to clearly show how long each part
       # of the testing takes
       - name: cargo fetch --locked
@@ -85,6 +86,7 @@ jobs:
       # * difftests depends on `spirv-builder` with no features, which excludes `rustc_codegen_spirv` entirely.
       #   The individual difftest crates depend on it and run the spirv compile, never the test runner itself.
       - name: prep cache for other jobs
+        if: github.ref_name == 'main'
         run: |
           cargo build -p compiletests --release --no-default-features --features "use-installed-tools"
           cargo build -p difftests --release --no-default-features --features "use-installed-tools"
@@ -112,6 +114,7 @@ jobs:
         with:
           add-job-id-key: "false"
           shared-key: "android"
+          save-if: ${{ github.ref_name == 'main' }}
       - name: cargo fetch --locked
         run: cargo fetch --locked --target ${{ matrix.target }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,16 @@ jobs:
           OUT_DIR: "target/debug/ci/out"
         run: cargo run -p example-runner-wgpu-builder --no-default-features --features "use-installed-tools"
 
+      # Our test runners select very different features for dependencies, so they need to be two separate builds.
+      # * compiletests depends on `rustc_codegen_spirv` directly with features `use-installed-tools`
+      # * difftests depends on `spirv-builder` with no features, which excludes `rustc_codegen_spirv` entirely.
+      #   The individual difftest crates depend on it and run the spirv compile, never the test runner itself.
+      - name: prep cache for other jobs
+        run: |
+          cargo build -p compiletests --release --no-default-features --features "use-installed-tools"
+          cargo build -p difftests --release --no-default-features --features "use-installed-tools"
+
+
   android:
     name: Android
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           add-job-id-key: "false"
           shared-key: "base"
+          save-if: ${{ github.ref_name == 'main' }}
       # Fetch dependencies in a separate step to clearly show how long each part
       # of the testing takes
       - name: cargo fetch --locked
@@ -87,6 +88,7 @@ jobs:
       # * difftests depends on `spirv-builder` with no features, which excludes `rustc_codegen_spirv` entirely.
       #   The individual difftest crates depend on it and run the spirv compile, never the test runner itself.
       - name: prep cache for other jobs
+        if: github.ref_name == 'main'
         run: |
           cargo build -p compiletests --release --no-default-features --features "use-installed-tools"
           cargo build -p difftests --release --no-default-features --features "use-installed-tools"
@@ -114,6 +116,7 @@ jobs:
         with:
           add-job-id-key: "false"
           shared-key: "android"
+          save-if: ${{ github.ref_name == 'main' }}
       - name: cargo fetch --locked
         run: cargo fetch --locked --target ${{ matrix.target }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,16 @@ jobs:
           OUT_DIR: "target/debug/ci/out"
         run: cargo run -p example-runner-wgpu-builder --no-default-features --features "use-installed-tools"
 
+      # Our test runners select very different features for dependencies, so they need to be two separate builds.
+      # * compiletests depends on `rustc_codegen_spirv` directly with features `use-installed-tools`
+      # * difftests depends on `spirv-builder` with no features, which excludes `rustc_codegen_spirv` entirely.
+      #   The individual difftest crates depend on it and run the spirv compile, never the test runner itself.
+      - name: prep cache for other jobs
+        run: |
+          cargo build -p compiletests --release --no-default-features --features "use-installed-tools"
+          cargo build -p difftests --release --no-default-features --features "use-installed-tools"
+
+
   android:
     name: Android
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,11 @@ jobs:
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - name: install nextest
         uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       # Fetch dependencies in a separate step to clearly show how long each part
       # of the testing takes
       - name: cargo fetch --locked
@@ -96,6 +101,11 @@ jobs:
           stripdown: true
       - name: install rust-toolchain
         run: cargo version
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: cargo fetch --locked
         run: cargo fetch --locked --target ${{ matrix.target }}
 
@@ -140,6 +150,11 @@ jobs:
           stripdown: true
       - name: install rust-toolchain
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: build compiletest
@@ -193,6 +208,11 @@ jobs:
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - name: install nextest
         uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: cargo fetch --locked difftests
@@ -368,6 +388,11 @@ jobs:
       # cargo version is a random command that forces the installation of rust-toolchain
       - name: install rust-toolchain
         run: cargo version
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+            tests/difftests/tests
       - name: Install rustup components
         run: rustup component add rustfmt clippy
       - name: cargo fetch --locked

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,9 +45,8 @@ jobs:
         uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "base"
       # Fetch dependencies in a separate step to clearly show how long each part
       # of the testing takes
       - name: cargo fetch --locked
@@ -103,9 +102,8 @@ jobs:
         run: cargo version
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "android"
       - name: cargo fetch --locked
         run: cargo fetch --locked --target ${{ matrix.target }}
 
@@ -152,9 +150,9 @@ jobs:
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "base"
+          save-if: "false"
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: build compiletest
@@ -210,9 +208,14 @@ jobs:
         uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: |
-            .
-            tests/difftests/tests
+          add-job-id-key: "false"
+          shared-key: "base"
+          save-if: "false"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          add-job-id-key: "false"
+          shared-key: "difftest"
+          workspaces: "tests/difftests/tests"
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
       - name: cargo fetch --locked difftests
@@ -388,11 +391,6 @@ jobs:
       # cargo version is a random command that forces the installation of rust-toolchain
       - name: install rust-toolchain
         run: cargo version
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            .
-            tests/difftests/tests
       - name: Install rustup components
         run: rustup component add rustfmt clippy
       - name: cargo fetch --locked


### PR DESCRIPTION
# Requires https://github.com/Rust-GPU/rust-gpu/pull/530

* implement [rust-cache](https://github.com/Swatinem/rust-cache) in our CI
* "base" cache
  * "test" job creates the cache
  * "compiletest" and "difftest" just use the cache
  * "test" [warms the cache](https://github.com/Rust-GPU/rust-gpu/pull/526/changes#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR84-R91) for "compiletests" and "difftests", saves ~2min each
* "android" cache, only for the android action since it compiles for an arm target
* lint get's no cache, while speedup is significant (6m -> 1m), not worth the cache space cost
* github has a cache usage limit of 10GB, this is using ~4GB *per branch*
* thus, caches are only created on main, but can be reused on branches based on main

(slightly outdated table, should still be accurate enough)

 job             | windows | mac | linux | total
----------------|-------------|-------|--------|-------
test|620 MB|580 MB|730 MB|1930 MB
difftest|230 MB|240 MB|240 MB|710 MB
android|||460 MB|460 MB
vulkan-sdk|290 MB||460 MB|750 MB
total|1140 MB|820 MB|1890 MB|3850 MB

# Final Results
* Results (same table, new values for "test cache"):
  * [own cache](https://github.com/Rust-GPU/rust-gpu/actions/runs/21870034827/attempts/1) @ https://github.com/Rust-GPU/rust-gpu/pull/526/commits/de88135a343dc428f8230061fcdfe7af80c05fa9 (every job it's own cache, incremental build, without https://github.com/Rust-GPU/rust-gpu/pull/530)
  * [test cache](https://github.com/Rust-GPU/rust-gpu/actions/runs/22067436049/attempts/2) @ https://github.com/Rust-GPU/rust-gpu/pull/526/changes/7519e71558ac7292fcd7560c7b4666d8cfbaca71 (incremental build with good cache, cherry-picked https://github.com/Rust-GPU/rust-gpu/pull/530)
  * [test clean](https://github.com/Rust-GPU/rust-gpu/actions/runs/22067436049/attempts/1) @ https://github.com/Rust-GPU/rust-gpu/pull/526/changes/7519e71558ac7292fcd7560c7b4666d8cfbaca71 (clean build with cache creation, cherry-picked https://github.com/Rust-GPU/rust-gpu/pull/530)
  * [main](https://github.com/Rust-GPU/rust-gpu/actions/runs/21899616996) @ https://github.com/Rust-GPU/rust-gpu/pull/526/changes/6441dc7c8cd0ba3ba3e6cb41f9e4718de6b85421 (without https://github.com/Rust-GPU/rust-gpu/pull/530)

 job             | windows | mac | linux
----------------|-------------|-------|--------
test own cache|9m 26s|11m 54s|4m 59s
test test cache|10m 31s|6m 17s|5m 37s
test test clean|27m 48s*|20m 25s|15m 15s
test main|18m 10s|15m 41s|11m 28s
compiletest own cache|14m 17s|7m 43s|6m 12s
compiletest test cache|14m 40s|8m 42s|6m 21s
compiletest test clean|16m 38s*|11m 45s|8m 32s
compiletest main|19m 32s|14m 42s|8m 3s
difftest own cache|15m 15s|10m 29s|8m 22s
difftest test cache|15m 13s|9m 13s|7m 44s
difftest test clean|23m 43s|15m 40s|11m 51s
difftest main|26m 30s|15m 0s|14m 30s
lint own cache|||1m 42s
lint test cache|||5m 21s
lint test clean|||6m 14s
lint main|||5m 58s

End to end:
* own cache: 15m 41s
* test cache: 15m 24s 
* test clean: 27m 59s*
* test main: 26m 41s

*adjusted due to flakyness of rustup install, usually takes only 40s on windows

# Analysis

1. Speedup with a good cache, before https://github.com/Rust-GPU/rust-gpu/pull/530? negative = speedup, "main" - "test cache"

 job             | windows | mac | linux
----------------|-------------|-------|--------
test|-8m 45s|-4m|-6m 30s
compiletest|-5m|-7m|-2m
difftest|-11m 15s|-4m 30s|-6m

End to end: -11m 20s

2. Overhead of a clean build without caches? positive = slowdown, "test clean" - "main"

**Note:** this includes https://github.com/Rust-GPU/rust-gpu/pull/530

 job             | windows | mac | linux
----------------|-------------|-------|--------
test|+9m 45s|+5m|+4m
compiletest|-3m|-3m|-30s
difftest|-3m|-40s|-2m 30s

End to end: +1m 20s*

3. How much faster would individual caches vs current shared "test" cache be? negative = speedup, "test cache" - "own cache"

**Note:** This is unfair as "own cache" data does not include https://github.com/Rust-GPU/rust-gpu/pull/530. Expect difftest to be worse and test to be better than a retest with that PR.

 job             | windows | mac | linux
----------------|-------------|-------|--------
test|-1m|flaky|-40s
compiletest|-20s|-1m|9s
difftest|+2s|+1m 10s|+40s

End to end: +20s




# My investigation log
<details><summary>Feel free to ignore and just look at the results</summary>
<p>

## Adding caching

First run (with no cache present) is looking real bad:
* [windows test](https://github.com/Rust-GPU/rust-gpu/actions/runs/21860844492/job/63089268520?pr=526) +1m 8s
* [windows difftest](https://github.com/Rust-GPU/rust-gpu/actions/runs/21860844492/job/63089268534?pr=526) +6m 24s
  * no idea why the cache would take so long when there's nothing to download and nothing has been compiled???
* all "install rust toolchain" are now 0s, so we probably have to move them before the cache action

## First CI with restore

Comparing [latest main](https://github.com/Rust-GPU/rust-gpu/actions/runs/21707602203) to [this PR](https://github.com/Rust-GPU/rust-gpu/actions/runs/21863295454?pr=526):
* overall time: 27m 39s -> 16m 8s
* longest job "windows-difftest": 27m 29s -> 16m 0s
* cache restore, measured from [seconded empty commit in this PR](https://github.com/Rust-GPU/rust-gpu/actions/runs/21863295454), which may have been removed:
  * windows: [58s](https://github.com/Rust-GPU/rust-gpu/actions/runs/21863295454/job/63097803661?pr=526) to [2m 3s](https://github.com/Rust-GPU/rust-gpu/actions/runs/21863295454/job/63097803636?pr=526)
    * first run of [windows difftest](https://github.com/Rust-GPU/rust-gpu/actions/runs/21860844492/job/63089268534?pr=526) has an obscene "restore" of 6m 24s even though there's nothing to restore???
  * linux: ~30s
  * mac: 30s - 40s
* cache creation, measured from [first commit in this PR](https://github.com/Rust-GPU/rust-gpu/actions/runs/21860844492):
  * windows: 30s - 1m
  * linux: 8s - 15s
  * mac: 30s - 50s
  
### [Install toolchain before restore (run attempt #1)](https://github.com/Rust-GPU/rust-gpu/actions/runs/21870034827/attempts/1)

* rust-cache seems to install the toolchain for you via rustup if you don't do it yourself, toolchain install has 0s execution time
* Action: move it before cache restore
* Results: old rust-cache time is now split between rustup install and new rust-cache
* Could caches contain rustup builds? Try purging caches

### [purging caches and retrying CI (run attempt #2)](https://github.com/Rust-GPU/rust-gpu/actions/runs/21870034827/attempts/2)

* as expected, a lot of runtime is moved from "rust-cache" to "install toolchain"
* rust-cache restore times:
  * windows: 2-3s
  * mac: 1-2s
  * linux: 1-2s
  * => couldn't repo crazy CI times from first attempt, just a fluke?
* cache creation:
  * windows: 30-50s
  * mac: 30-40s, 60s fluke?
  * linux: ~10s
* Results: rustup before rust-cache to separate out toolchain install time

## [Lessen cache usage](https://github.com/Rust-GPU/rust-gpu/pull/526/changes/def4546ebd7900aad526e4e4fe62db99a51bce93)
* [github cache is reporting high cache usage](https://github.com/Rust-GPU/rust-gpu/actions/caches)
  * 10GB limit by gh
  * caches take up:

 job             | windows | mac | linux | total
----------------|-------------|-------|--------|-------
test|620 MB|590 MB|740 MB|1950 MB
compiletest|310 MB|300 MB|320 MB|930 MB
difftest|550 MB|550 MB|560 MB|1660 MB
lint|||720 MB|720 MB
android|||460 MB|460 MB
vulkan-sdk|290 MB|500 MB|460 MB|1250 MB
total|1770 MB|1940 MB|3260 MB|6970 MB

* Idea: can we reuse the same cache between actions?
  * only `test` creates the cache, for each platform
  * `difftest` may get a separate cache for the difftest target dir
* [attempt #1, creating caches](https://github.com/Rust-GPU/rust-gpu/actions/runs/21944257220/attempts/1)
  * windows randomly taking [15min to rustup install toolchain](https://github.com/Rust-GPU/rust-gpu/actions/runs/21944257220/job/63377624717), likely the culprit of rust-cache taking so long the first time?
* [attempt #2, restoring caches](https://github.com/Rust-GPU/rust-gpu/actions/runs/21944257220/attempts/2)
  * Mac: vulkan sdk caching doesn't work *at all*, but still creates new caches? https://github.com/jakoch/install-vulkan-sdk-action/issues/558
  * jobs have different cache hash due to rustup env vars... retry entire experiment

## [remove rustup env vars](https://github.com/Rust-GPU/rust-gpu/pull/526/changes/7519e71558ac7292fcd7560c7b4666d8cfbaca71)

* cache usage (limit of 10GB):

 job             | windows | mac | linux | total
----------------|-------------|-------|--------|-------
test|620 MB|580 MB|730 MB|1930 MB
difftest|230 MB|240 MB|240 MB|710 MB
android|||460 MB|460 MB
vulkan-sdk|290 MB|500 MB|460 MB|1250 MB
total|1140 MB|1320 MB|1890 MB|4350 MB

* CI times:
  * [own cache](https://github.com/Rust-GPU/rust-gpu/actions/runs/21870034827/attempts/1) @ https://github.com/Rust-GPU/rust-gpu/pull/526/commits/de88135a343dc428f8230061fcdfe7af80c05fa9
  * [test cache](https://github.com/Rust-GPU/rust-gpu/actions/runs/21946348061/attempts/2) @ https://github.com/Rust-GPU/rust-gpu/pull/526/changes/7519e71558ac7292fcd7560c7b4666d8cfbaca71
  * [main](https://github.com/Rust-GPU/rust-gpu/actions/runs/21899616996) @ https://github.com/Rust-GPU/rust-gpu/commit/79acad1f916d953275c93c16f006543ce18a14b1 (without https://github.com/Rust-GPU/rust-gpu/pull/530)

 job             | windows | mac | linux
----------------|-------------|-------|--------
compiletest own cache|14m 17s|7m 43s|6m 12s
compiletest test cache|16m 4s|7m 28s|6m 21s
compiletest main|19m 32s|14m 42s|8m 3s
difftest own cache|15m 15s|10m 29s|8m 22s
difftest test cache|21m 18s|16m 11s|11m 8s
difftest main|26m 30s|15m 0s|14m 30s
lint own cache|||1m 42s
lint test cache|||6m 1s
lint main|||5m 58s

* Analysis of difftest slowdown:
  * windows & mac +6min:
    * +3min from "test difftest" aka. `cargo test -p difftest`
    * +3min from "difftest" themselves
  * linux follows similar pattern but less worse

## [move "test difftest" to test job](https://github.com/Rust-GPU/rust-gpu/pull/526/changes/f19845929e4c7fee4a263093240ef6cc391a768b)
* Idea: On [main windows difftest](https://github.com/Rust-GPU/rust-gpu/actions/runs/21899616996/job/63224178876):
  * test difftest: 7m 29s
  * difftest: 14m 44s
  * move work from the longest running task difftest to test
  * maybe also improve rust-cache reuse, and speed up difftest some more?
* Results (incremental only)
  * difftest-windows: from [21m 18s](https://github.com/Rust-GPU/rust-gpu/actions/runs/21946348061/job/63388076413) to [16m 44s](https://github.com/Rust-GPU/rust-gpu/actions/runs/21953500803/job/63423051660)
  * test-windows: [9m 46s](https://github.com/Rust-GPU/rust-gpu/actions/runs/21946348061/job/63388076435) to [9m 13s](https://github.com/Rust-GPU/rust-gpu/actions/runs/21953500803/job/63423051664), should have increased, likely just run to run variance
  * caching was useless, almost nothing is shared between "test difftest" and "difftest"
  * free -5min win :tada: 

## [ci: make "test" prep better cache for compiletests and difftests](https://github.com/Rust-GPU/rust-gpu/pull/526/changes/056199e414b980d71ada39abe7f85c973cb6e772)
didn't work, try again

## [ci: fix prep cache being useless due to weird feature selection](https://github.com/Rust-GPU/rust-gpu/pull/526/changes/6441dc7c8cd0ba3ba3e6cb41f9e4718de6b85421)
* Idea: both compiletest and difftest spent 1-2min compiling the test runners, cache that
* see final results below

</p>
</details>