### PR TITLE
remove `has_capability()` checks

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -11,7 +11,7 @@ use crate::custom_insts::CustomInst;
 use crate::spirv_type::SpirvType;
 use itertools::Itertools;
 use rspirv::dr::{InsertPoint, Instruction, Operand};
-use rspirv::spirv::{Capability, MemoryModel, MemorySemantics, Op, Scope, StorageClass, Word};
+use rspirv::spirv::{MemoryModel, MemorySemantics, Op, Scope, StorageClass, Word};
 use rustc_abi::{Align, BackendRepr, Scalar, Size, WrappingRange};
 use rustc_apfloat::{Float, Round, Status, ieee};
 use rustc_codegen_ssa::MemFlags;
@@ -569,12 +569,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     #[instrument(level = "trace", skip(self))]
     fn zombie_ptr_equal(&self, def: Word, inst: &str) {
-        if !self.builder.has_capability(Capability::VariablePointers) {
-            self.zombie(
-                def,
-                &format!("{inst} without OpCapability VariablePointers"),
-            );
-        }
+        self.zombie(
+            def,
+            &format!("{inst} without OpCapability VariablePointers"),
+        );
     }
 
     /// Convenience wrapper for `adjust_pointer_for_sized_access`, falling back

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -12,7 +12,7 @@ use crate::custom_insts::CustomInst;
 use crate::spirv_type::SpirvType;
 use itertools::Itertools;
 use rspirv::dr::{InsertPoint, Instruction, Operand};
-use rspirv::spirv::{Capability, MemoryModel, MemorySemantics, Op, Scope, StorageClass, Word};
+use rspirv::spirv::{MemoryModel, MemorySemantics, Op, Scope, StorageClass, Word};
 use rustc_abi::{Align, BackendRepr, Scalar, Size, WrappingRange};
 use rustc_apfloat::{Float, Round, Status, ieee};
 use rustc_codegen_ssa::MemFlags;
@@ -592,12 +592,10 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
     #[instrument(level = "trace", skip(self))]
     fn zombie_ptr_equal(&self, def: Word, inst: &str) {
-        if !self.builder.has_capability(Capability::VariablePointers) {
-            self.zombie(
-                def,
-                &format!("{inst} without OpCapability VariablePointers"),
-            );
-        }
+        self.zombie(
+            def,
+            &format!("{inst} without OpCapability VariablePointers"),
+        );
     }
 
     /// Convenience wrapper for `adjust_pointer_for_sized_access`, falling back

--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -591,11 +591,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
     }
 
     #[instrument(level = "trace", skip(self))]
-    fn zombie_ptr_equal(&self, def: Word, inst: &str) {
-        self.zombie(
-            def,
-            &format!("{inst} without OpCapability VariablePointers"),
-        );
+    fn zombie_ptr_equal(&self, def: Word) {
+        self.zombie(def, "cannot check pointers for equality");
     }
 
     /// Convenience wrapper for `adjust_pointer_for_sized_access`, falling back
@@ -2594,7 +2591,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                         self.emit()
                             .ptr_equal(b, None, lhs.def(self), rhs.def(self))
                             .inspect(|&result| {
-                                self.zombie_ptr_equal(result, "OpPtrEqual");
+                                self.zombie_ptr_equal(result);
                             })
                     } else {
                         let int_ty = self.type_usize();
@@ -2616,7 +2613,7 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
                         self.emit()
                             .ptr_not_equal(b, None, lhs.def(self), rhs.def(self))
                             .inspect(|&result| {
-                                self.zombie_ptr_equal(result, "OpPtrNotEqual");
+                                self.zombie_ptr_equal(result);
                             })
                     } else {
                         let int_ty = self.type_usize();

--- a/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
+++ b/crates/rustc_codegen_spirv/src/builder/byte_addressable_buffer.rs
@@ -6,7 +6,6 @@ use crate::builder_spirv::{SpirvValue, SpirvValueExt, SpirvValueKind};
 use crate::spirv_type::SpirvType;
 use rspirv::spirv::{Decoration, Word};
 use rustc_abi::{Align, Size};
-use rustc_codegen_spirv_types::Capability;
 use rustc_codegen_ssa::traits::BuilderMethods;
 use rustc_errors::ErrorGuaranteed;
 use rustc_middle::ty::Ty;
@@ -50,13 +49,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             .in_bounds_access_chain(u32_ptr, None, array, [actual_index])
             .unwrap()
             .with_type(u32_ptr);
-        if self.builder.has_capability(Capability::ShaderNonUniform) {
-            // apply NonUniform to the operation and the index
-            self.emit()
-                .decorate(ptr.def(self), Decoration::NonUniform, []);
-            self.emit()
-                .decorate(actual_index, Decoration::NonUniform, []);
-        }
+        // apply NonUniform to the operation and the index
+        self.emit()
+            .decorate(ptr.def(self), Decoration::NonUniform, []);
+        self.emit()
+            .decorate(actual_index, Decoration::NonUniform, []);
         self.load(u32_ty, ptr, Align::ONE)
     }
 
@@ -252,13 +249,11 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             .in_bounds_access_chain(u32_ptr, None, array, [actual_index])
             .unwrap()
             .with_type(u32_ptr);
-        if self.builder.has_capability(Capability::ShaderNonUniform) {
-            // apply NonUniform to the operation and the index
-            self.emit()
-                .decorate(ptr.def(self), Decoration::NonUniform, []);
-            self.emit()
-                .decorate(actual_index, Decoration::NonUniform, []);
-        }
+        // apply NonUniform to the operation and the index
+        self.emit()
+            .decorate(ptr.def(self), Decoration::NonUniform, []);
+        self.emit()
+            .decorate(actual_index, Decoration::NonUniform, []);
         self.store(value, ptr, Align::ONE);
         Ok(())
     }

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -15,12 +15,11 @@ use rspirv::{binary::Assemble, binary::Disassemble};
 use rustc_abi::Size;
 use rustc_arena::DroplessArena;
 use rustc_codegen_ssa::traits::ConstCodegenMethods as _;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::ConstAllocation;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::source_map::SourceMap;
-use rustc_span::symbol::Symbol;
 use rustc_span::{DUMMY_SP, SourceFile, Span};
 use std::assert_matches;
 use std::cell::{RefCell, RefMut};
@@ -442,8 +441,6 @@ pub struct BuilderSpirv<'tcx> {
     id_to_const: RefCell<FxHashMap<Word, WithConstLegality<SpirvConst<'tcx, 'tcx>>>>,
 
     debug_file_cache: RefCell<FxHashMap<DebugFileKey, DebugFileSpirv<'tcx>>>,
-
-    enabled_capabilities: FxHashSet<Capability>,
 }
 
 impl<'tcx> BuilderSpirv<'tcx> {
@@ -460,50 +457,26 @@ impl<'tcx> BuilderSpirv<'tcx> {
         builder.set_version(version.0, version.1);
         builder.module_mut().header.as_mut().unwrap().generator = 0x001B_0000;
 
-        let mut enabled_capabilities = FxHashSet::default();
-
-        fn add_cap(
-            builder: &mut Builder,
-            enabled_capabilities: &mut FxHashSet<Capability>,
-            cap: Capability,
-        ) {
-            // This should be the only callsite of Builder::capability (aside from tests), to make
-            // sure the hashset stays in sync.
-            builder.capability(cap);
-            enabled_capabilities.insert(cap);
-        }
-        fn add_ext(builder: &mut Builder, ext: Symbol) {
-            // This should be the only callsite of Builder::extension (aside from tests), to make
-            // sure the hashset stays in sync.
-            builder.extension(ext.as_str());
-        }
-
         for feature in features {
             match *feature {
                 TargetFeature::Capability(cap) => {
-                    add_cap(&mut builder, &mut enabled_capabilities, cap);
+                    builder.capability(cap);
                 }
                 TargetFeature::Extension(ext) => {
-                    add_ext(&mut builder, ext);
+                    builder.extension(ext.as_str());
                 }
             }
         }
 
-        add_cap(&mut builder, &mut enabled_capabilities, Capability::Shader);
+        builder.capability(Capability::Shader);
         if memory_model == MemoryModel::Vulkan {
             if version < SpirvVersion::V1_5 {
-                add_ext(&mut builder, sym.spv_khr_vulkan_memory_model);
+                builder.extension(sym.spv_khr_vulkan_memory_model.as_str());
             }
-            add_cap(
-                &mut builder,
-                &mut enabled_capabilities,
-                Capability::VulkanMemoryModel,
-            );
+            builder.capability(Capability::VulkanMemoryModel);
         }
-
         // The linker will always be ran on this module
-        add_cap(&mut builder, &mut enabled_capabilities, Capability::Linkage);
-
+        builder.capability(Capability::Linkage);
         builder.memory_model(AddressingModel::Logical, memory_model);
 
         Self {
@@ -513,7 +486,6 @@ impl<'tcx> BuilderSpirv<'tcx> {
             const_to_id: Default::default(),
             id_to_const: Default::default(),
             debug_file_cache: Default::default(),
-            enabled_capabilities,
         }
     }
 
@@ -532,10 +504,6 @@ impl<'tcx> BuilderSpirv<'tcx> {
             .unwrap()
             .write_all(spirv_tools::binary::from_binary(&module))
             .unwrap();
-    }
-
-    pub fn has_capability(&self, capability: Capability) -> bool {
-        self.enabled_capabilities.contains(&capability)
     }
 
     /// See comment on `BuilderCursor`

--- a/crates/rustc_codegen_spirv/src/builder_spirv.rs
+++ b/crates/rustc_codegen_spirv/src/builder_spirv.rs
@@ -15,12 +15,11 @@ use rspirv::{binary::Assemble, binary::Disassemble};
 use rustc_abi::Size;
 use rustc_arena::DroplessArena;
 use rustc_codegen_ssa::traits::ConstCodegenMethods as _;
-use rustc_data_structures::fx::{FxHashMap, FxHashSet};
+use rustc_data_structures::fx::FxHashMap;
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::ConstAllocation;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::source_map::SourceMap;
-use rustc_span::symbol::Symbol;
 use rustc_span::{DUMMY_SP, SourceFile, Span};
 use std::assert_matches;
 use std::cell::{RefCell, RefMut};
@@ -442,8 +441,6 @@ pub struct BuilderSpirv<'tcx> {
     id_to_const: RefCell<FxHashMap<Word, WithConstLegality<SpirvConst<'tcx, 'tcx>>>>,
 
     debug_file_cache: RefCell<FxHashMap<DebugFileKey, DebugFileSpirv<'tcx>>>,
-
-    enabled_capabilities: FxHashSet<Capability>,
 }
 
 impl<'tcx> BuilderSpirv<'tcx> {
@@ -460,50 +457,26 @@ impl<'tcx> BuilderSpirv<'tcx> {
         builder.set_version(version.0, version.1);
         builder.module_mut().header.as_mut().unwrap().generator = 0x001B_0000;
 
-        let mut enabled_capabilities = FxHashSet::default();
-
-        fn add_cap(
-            builder: &mut Builder,
-            enabled_capabilities: &mut FxHashSet<Capability>,
-            cap: Capability,
-        ) {
-            // This should be the only callsite of Builder::capability (aside from tests), to make
-            // sure the hashset stays in sync.
-            builder.capability(cap);
-            enabled_capabilities.insert(cap);
-        }
-        fn add_ext(builder: &mut Builder, ext: Symbol) {
-            // This should be the only callsite of Builder::extension (aside from tests), to make
-            // sure the hashset stays in sync.
-            builder.extension(ext.as_str());
-        }
-
         for feature in features {
             match *feature {
                 TargetFeature::Capability(cap) => {
-                    add_cap(&mut builder, &mut enabled_capabilities, cap);
+                    builder.capability(cap);
                 }
                 TargetFeature::Extension(ext) => {
-                    add_ext(&mut builder, ext);
+                    builder.extension(ext.as_str());
                 }
             }
         }
 
-        add_cap(&mut builder, &mut enabled_capabilities, Capability::Shader);
+        builder.capability(Capability::Shader);
         if memory_model == MemoryModel::Vulkan {
             if version < (1, 5) {
-                add_ext(&mut builder, sym.spv_khr_vulkan_memory_model);
+                builder.extension(sym.spv_khr_vulkan_memory_model.as_str());
             }
-            add_cap(
-                &mut builder,
-                &mut enabled_capabilities,
-                Capability::VulkanMemoryModel,
-            );
+            builder.capability(Capability::VulkanMemoryModel);
         }
-
         // The linker will always be ran on this module
-        add_cap(&mut builder, &mut enabled_capabilities, Capability::Linkage);
-
+        builder.capability(Capability::Linkage);
         builder.memory_model(AddressingModel::Logical, memory_model);
 
         Self {
@@ -513,7 +486,6 @@ impl<'tcx> BuilderSpirv<'tcx> {
             const_to_id: Default::default(),
             id_to_const: Default::default(),
             debug_file_cache: Default::default(),
-            enabled_capabilities,
         }
     }
 
@@ -532,10 +504,6 @@ impl<'tcx> BuilderSpirv<'tcx> {
             .unwrap()
             .write_all(spirv_tools::binary::from_binary(&module))
             .unwrap();
-    }
-
-    pub fn has_capability(&self, capability: Capability) -> bool {
-        self.enabled_capabilities.contains(&capability)
     }
 
     /// See comment on `BuilderCursor`

--- a/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/entry.rs
@@ -9,7 +9,7 @@ use crate::builder_spirv::{SpirvFunctionCursor, SpirvValue, SpirvValueExt};
 use crate::spirv_type::SpirvType;
 use rspirv::dr::Operand;
 use rspirv::spirv::{
-    BuiltIn, Capability, Decoration, Dim, ExecutionModel, FunctionControl, StorageClass, Word,
+    BuiltIn, Decoration, Dim, ExecutionModel, FunctionControl, StorageClass, Word,
 };
 use rustc_abi::FieldsShape;
 use rustc_codegen_ssa::traits::{BaseTypeCodegenMethods, BuilderMethods, MiscCodegenMethods as _};
@@ -931,16 +931,12 @@ impl<'tcx> CodegenCx<'tcx> {
             _ => false,
         };
         if let Some(attachment_index) = attrs.input_attachment_index {
-            if is_subpass_input && self.builder.has_capability(Capability::InputAttachment) {
+            if is_subpass_input {
                 self.emit_global().decorate(
                     var_id.unwrap(),
                     Decoration::InputAttachmentIndex,
                     std::iter::once(Operand::LiteralBit32(attachment_index.value)),
                 );
-            } else if is_subpass_input {
-                self.tcx
-                    .dcx()
-                    .span_err(hir_param.ty_span, "Missing capability InputAttachment");
             } else {
                 self.tcx.dcx().span_err(
                     attachment_index.span,

--- a/tests/compiletests/ui/arch/non_uniform/buffer.rs
+++ b/tests/compiletests/ui/arch/non_uniform/buffer.rs
@@ -1,0 +1,34 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+StorageBufferArrayDynamicIndexing
+// compile-flags: -C target-feature=+ShaderNonUniform,+StorageBufferArrayNonUniformIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buffers: &RuntimeArray<
+        TypedBuffer<Vec4>,
+    >,
+    out: &mut Vec4,
+) {
+    unsafe {
+        *out = **buffers.index(index as usize);
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/buffer.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/buffer.stderr
@@ -1,0 +1,44 @@
+OpCapability Shader
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability ShaderNonUniform
+OpCapability RuntimeDescriptorArray
+OpCapability StorageBufferArrayNonUniformIndexing
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "buffers"
+OpName %4 "out"
+OpDecorate %8 Block
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %2 Location 0
+OpDecorate %3 NonWritable
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+OpDecorate %9 NonUniform
+%10 = OpTypeInt 32 0
+%11 = OpTypePointer Input %10
+%12 = OpTypeFloat 32
+%13 = OpTypeVector %12 4
+%8 = OpTypeStruct %13
+%14 = OpTypeRuntimeArray %8
+%15 = OpTypePointer StorageBuffer %14
+%16 = OpTypePointer Output %13
+%17 = OpTypeVoid
+%18 = OpTypeFunction %17
+%2 = OpVariable  %11  Input
+%19 = OpTypePointer StorageBuffer %8
+%3 = OpVariable  %15  StorageBuffer
+%20 = OpTypePointer StorageBuffer %13
+%21 = OpConstant  %10  0
+%4 = OpVariable  %16  Output
+%1 = OpFunction  %17  None %18
+%22 = OpLabel
+%23 = OpLoad  %10  %2
+%9 = OpAccessChain  %19  %3 %23
+%24 = OpAccessChain  %20  %9 %21
+%25 = OpLoad  %13  %24
+OpStore %4 %25
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/non_uniform/buffer_uniform.rs
+++ b/tests/compiletests/ui/arch/non_uniform/buffer_uniform.rs
@@ -1,0 +1,33 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+StorageBufferArrayDynamicIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buffers: &RuntimeArray<
+        TypedBuffer<Vec4>,
+    >,
+    out: &mut Vec4,
+) {
+    unsafe {
+        *out = **buffers.index(index as usize);
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/buffer_uniform.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/buffer_uniform.stderr
@@ -1,0 +1,41 @@
+OpCapability Shader
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability RuntimeDescriptorArray
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "buffers"
+OpName %4 "out"
+OpDecorate %8 Block
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %2 Location 0
+OpDecorate %3 NonWritable
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+%9 = OpTypeInt 32 0
+%10 = OpTypePointer Input %9
+%11 = OpTypeFloat 32
+%12 = OpTypeVector %11 4
+%8 = OpTypeStruct %12
+%13 = OpTypeRuntimeArray %8
+%14 = OpTypePointer StorageBuffer %13
+%15 = OpTypePointer Output %12
+%16 = OpTypeVoid
+%17 = OpTypeFunction %16
+%2 = OpVariable  %10  Input
+%18 = OpTypePointer StorageBuffer %8
+%3 = OpVariable  %14  StorageBuffer
+%19 = OpTypePointer StorageBuffer %12
+%20 = OpConstant  %9  0
+%4 = OpVariable  %15  Output
+%1 = OpFunction  %16  None %17
+%21 = OpLabel
+%22 = OpLoad  %9  %2
+%23 = OpAccessChain  %18  %3 %22
+%24 = OpAccessChain  %19  %23 %20
+%25 = OpLoad  %12  %24
+OpStore %4 %25
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer.rs
+++ b/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer.rs
@@ -1,0 +1,33 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+StorageBufferArrayDynamicIndexing
+// compile-flags: -C target-feature=+ShaderNonUniform,+StorageBufferArrayNonUniformIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buffer: &[u32],
+    out: &mut Vec4,
+) {
+    unsafe {
+        let buffer = ByteAddressableBuffer::from_slice(buffer);
+        *out = buffer.load_unchecked(index * size_of::<Vec4>() as u32);
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer.stderr
@@ -1,0 +1,72 @@
+OpCapability Shader
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability ShaderNonUniform
+OpCapability RuntimeDescriptorArray
+OpCapability StorageBufferArrayNonUniformIndexing
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "buffer"
+OpName %4 "out"
+OpDecorate %7 ArrayStride 4
+OpDecorate %8 Block
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %2 Location 0
+OpDecorate %3 NonWritable
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+OpDecorate %9 NonUniform
+OpDecorate %10 NonUniform
+OpDecorate %11 NonUniform
+OpDecorate %12 NonUniform
+OpDecorate %13 NonUniform
+OpDecorate %14 NonUniform
+OpDecorate %15 NonUniform
+OpDecorate %16 NonUniform
+%17 = OpTypeInt 32 0
+%18 = OpTypePointer Input %17
+%7 = OpTypeRuntimeArray %17
+%8 = OpTypeStruct %7
+%19 = OpTypePointer StorageBuffer %8
+%20 = OpTypeFloat 32
+%21 = OpTypeVector %20 4
+%22 = OpTypePointer Output %21
+%23 = OpTypeVoid
+%24 = OpTypeFunction %23
+%2 = OpVariable  %18  Input
+%25 = OpTypePointer StorageBuffer %7
+%3 = OpVariable  %19  StorageBuffer
+%26 = OpConstant  %17  0
+%27 = OpConstant  %17  16
+%28 = OpConstant  %17  2
+%29 = OpTypePointer StorageBuffer %17
+%30 = OpConstant  %17  1
+%31 = OpConstant  %17  3
+%4 = OpVariable  %22  Output
+%1 = OpFunction  %23  None %24
+%32 = OpLabel
+%33 = OpLoad  %17  %2
+%34 = OpInBoundsAccessChain  %25  %3 %26
+%35 = OpIMul  %17  %33 %27
+%9 = OpShiftRightLogical  %17  %35 %28
+%10 = OpInBoundsAccessChain  %29  %34 %9
+%36 = OpLoad  %17  %10
+%37 = OpBitcast  %20  %36
+%11 = OpIAdd  %17  %9 %30
+%12 = OpInBoundsAccessChain  %29  %34 %11
+%38 = OpLoad  %17  %12
+%39 = OpBitcast  %20  %38
+%13 = OpIAdd  %17  %9 %28
+%14 = OpInBoundsAccessChain  %29  %34 %13
+%40 = OpLoad  %17  %14
+%41 = OpBitcast  %20  %40
+%15 = OpIAdd  %17  %9 %31
+%16 = OpInBoundsAccessChain  %29  %34 %15
+%42 = OpLoad  %17  %16
+%43 = OpBitcast  %20  %42
+%44 = OpCompositeConstruct  %21  %37 %39 %41 %43
+OpStore %4 %44
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer_uniform.rs
+++ b/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer_uniform.rs
@@ -1,0 +1,32 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+StorageBufferArrayDynamicIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buffer: &[u32],
+    out: &mut Vec4,
+) {
+    unsafe {
+        let buffer = ByteAddressableBuffer::from_slice(buffer);
+        *out = buffer.load_unchecked(index * size_of::<Vec4>() as u32);
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer_uniform.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/byte_addressable_buffer_uniform.stderr
@@ -1,0 +1,62 @@
+OpCapability Shader
+OpCapability StorageBufferArrayDynamicIndexing
+OpCapability RuntimeDescriptorArray
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "buffer"
+OpName %4 "out"
+OpDecorate %7 ArrayStride 4
+OpDecorate %8 Block
+OpMemberDecorate %8 0 Offset 0
+OpDecorate %2 Location 0
+OpDecorate %3 NonWritable
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+%9 = OpTypeInt 32 0
+%10 = OpTypePointer Input %9
+%7 = OpTypeRuntimeArray %9
+%8 = OpTypeStruct %7
+%11 = OpTypePointer StorageBuffer %8
+%12 = OpTypeFloat 32
+%13 = OpTypeVector %12 4
+%14 = OpTypePointer Output %13
+%15 = OpTypeVoid
+%16 = OpTypeFunction %15
+%2 = OpVariable  %10  Input
+%17 = OpTypePointer StorageBuffer %7
+%3 = OpVariable  %11  StorageBuffer
+%18 = OpConstant  %9  0
+%19 = OpConstant  %9  16
+%20 = OpConstant  %9  2
+%21 = OpTypePointer StorageBuffer %9
+%22 = OpConstant  %9  1
+%23 = OpConstant  %9  3
+%4 = OpVariable  %14  Output
+%1 = OpFunction  %15  None %16
+%24 = OpLabel
+%25 = OpLoad  %9  %2
+%26 = OpInBoundsAccessChain  %17  %3 %18
+%27 = OpIMul  %9  %25 %19
+%28 = OpShiftRightLogical  %9  %27 %20
+%29 = OpInBoundsAccessChain  %21  %26 %28
+%30 = OpLoad  %9  %29
+%31 = OpBitcast  %12  %30
+%32 = OpIAdd  %9  %28 %22
+%33 = OpInBoundsAccessChain  %21  %26 %32
+%34 = OpLoad  %9  %33
+%35 = OpBitcast  %12  %34
+%36 = OpIAdd  %9  %28 %20
+%37 = OpInBoundsAccessChain  %21  %26 %36
+%38 = OpLoad  %9  %37
+%39 = OpBitcast  %12  %38
+%40 = OpIAdd  %9  %28 %23
+%41 = OpInBoundsAccessChain  %21  %26 %40
+%42 = OpLoad  %9  %41
+%43 = OpBitcast  %12  %42
+%44 = OpCompositeConstruct  %13  %31 %35 %39 %43
+OpStore %4 %44
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/non_uniform/image.rs
+++ b/tests/compiletests/ui/arch/non_uniform/image.rs
@@ -1,0 +1,32 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+SampledImageArrayDynamicIndexing
+// compile-flags: -C target-feature=+ShaderNonUniform,+SampledImageArrayNonUniformIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0)] images: &RuntimeArray<Image2d>,
+    out: &mut Vec4,
+) {
+    unsafe {
+        *out = images.index(index as usize).fetch(UVec2::new(1, 2));
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/image.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/image.stderr
@@ -1,0 +1,54 @@
+OpCapability Shader
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability ShaderNonUniform
+OpCapability RuntimeDescriptorArray
+OpCapability SampledImageArrayNonUniformIndexing
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "images"
+OpName %4 "out"
+OpName %8 "<glam::f32::scalar::vec4::Vec4 as spirv_std::vector::VectorTruncateInto<glam::f32::scalar::vec4::Vec4>>::truncate_into"
+OpDecorate %2 Location 0
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+OpDecorate %9 NonUniform
+OpDecorate %10 NonUniform
+OpDecorate %11 NonUniform
+%12 = OpTypeInt 32 0
+%13 = OpTypePointer Input %12
+%14 = OpTypeFloat 32
+%15 = OpTypeImage %14 2D 2 0 0 1 Unknown
+%16 = OpTypeRuntimeArray %15
+%17 = OpTypePointer UniformConstant %16
+%18 = OpTypeVector %14 4
+%19 = OpTypePointer Output %18
+%20 = OpTypeVoid
+%21 = OpTypeFunction %20
+%2 = OpVariable  %13  Input
+%22 = OpTypePointer UniformConstant %15
+%3 = OpVariable  %17  UniformConstant
+%23 = OpTypeVector %12 2
+%24 = OpConstant  %12  1
+%25 = OpConstant  %12  2
+%26 = OpConstant  %12  0
+%27 = OpTypeFunction %18 %18
+%4 = OpVariable  %19  Output
+%1 = OpFunction  %20  None %21
+%28 = OpLabel
+%29 = OpLoad  %12  %2
+%9 = OpAccessChain  %22  %3 %29
+%30 = OpCompositeConstruct  %23  %24 %25
+%10 = OpLoad  %15  %9
+%11 = OpImageFetch  %18  %10 %30 Lod %26
+%31 = OpFunctionCall  %18  %8 %11
+OpStore %4 %31
+OpNoLine
+OpReturn
+OpFunctionEnd
+%8 = OpFunction  %18  None %27
+%32 = OpFunctionParameter  %18
+%33 = OpLabel
+OpReturnValue %32
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/non_uniform/image_uniform.rs
+++ b/tests/compiletests/ui/arch/non_uniform/image_uniform.rs
@@ -1,0 +1,31 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+SampledImageArrayDynamicIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0)] images: &RuntimeArray<Image2d>,
+    out: &mut Vec4,
+) {
+    unsafe {
+        *out = images.index(index as usize).fetch(UVec2::new(1, 2));
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/image_uniform.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/image_uniform.stderr
@@ -1,0 +1,49 @@
+OpCapability Shader
+OpCapability SampledImageArrayDynamicIndexing
+OpCapability RuntimeDescriptorArray
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "images"
+OpName %4 "out"
+OpName %8 "<glam::f32::scalar::vec4::Vec4 as spirv_std::vector::VectorTruncateInto<glam::f32::scalar::vec4::Vec4>>::truncate_into"
+OpDecorate %2 Location 0
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+%9 = OpTypeInt 32 0
+%10 = OpTypePointer Input %9
+%11 = OpTypeFloat 32
+%12 = OpTypeImage %11 2D 2 0 0 1 Unknown
+%13 = OpTypeRuntimeArray %12
+%14 = OpTypePointer UniformConstant %13
+%15 = OpTypeVector %11 4
+%16 = OpTypePointer Output %15
+%17 = OpTypeVoid
+%18 = OpTypeFunction %17
+%2 = OpVariable  %10  Input
+%19 = OpTypePointer UniformConstant %12
+%3 = OpVariable  %14  UniformConstant
+%20 = OpTypeVector %9 2
+%21 = OpConstant  %9  1
+%22 = OpConstant  %9  2
+%23 = OpConstant  %9  0
+%24 = OpTypeFunction %15 %15
+%4 = OpVariable  %16  Output
+%1 = OpFunction  %17  None %18
+%25 = OpLabel
+%26 = OpLoad  %9  %2
+%27 = OpAccessChain  %19  %3 %26
+%28 = OpCompositeConstruct  %20  %21 %22
+%29 = OpLoad  %12  %27
+%30 = OpImageFetch  %15  %29 %28 Lod %23
+%31 = OpFunctionCall  %15  %8 %30
+OpStore %4 %31
+OpNoLine
+OpReturn
+OpFunctionEnd
+%8 = OpFunction  %15  None %24
+%32 = OpFunctionParameter  %15
+%33 = OpLabel
+OpReturnValue %32
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/non_uniform/storage_image.rs
+++ b/tests/compiletests/ui/arch/non_uniform/storage_image.rs
@@ -1,0 +1,33 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+StorageImageExtendedFormats,+StorageImageReadWithoutFormat
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+StorageImageArrayDynamicIndexing
+// compile-flags: -C target-feature=+ShaderNonUniform,+StorageImageArrayNonUniformIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0)] images: &RuntimeArray<StorageImage2d>,
+    out: &mut Vec4,
+) {
+    unsafe {
+        *out = images.index(index as usize).read(UVec2::new(1, 2));
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/storage_image.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/storage_image.stderr
@@ -1,0 +1,55 @@
+OpCapability Shader
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageExtendedFormats
+OpCapability StorageImageReadWithoutFormat
+OpCapability ShaderNonUniform
+OpCapability RuntimeDescriptorArray
+OpCapability StorageImageArrayNonUniformIndexing
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "images"
+OpName %4 "out"
+OpName %8 "<glam::f32::scalar::vec4::Vec4 as spirv_std::vector::VectorTruncateInto<glam::f32::scalar::vec4::Vec4>>::truncate_into"
+OpDecorate %2 Location 0
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+OpDecorate %9 NonUniform
+OpDecorate %10 NonUniform
+OpDecorate %11 NonUniform
+%12 = OpTypeInt 32 0
+%13 = OpTypePointer Input %12
+%14 = OpTypeFloat 32
+%15 = OpTypeImage %14 2D 2 0 0 2 Unknown
+%16 = OpTypeRuntimeArray %15
+%17 = OpTypePointer UniformConstant %16
+%18 = OpTypeVector %14 4
+%19 = OpTypePointer Output %18
+%20 = OpTypeVoid
+%21 = OpTypeFunction %20
+%2 = OpVariable  %13  Input
+%22 = OpTypePointer UniformConstant %15
+%3 = OpVariable  %17  UniformConstant
+%23 = OpTypeVector %12 2
+%24 = OpConstant  %12  1
+%25 = OpConstant  %12  2
+%26 = OpTypeFunction %18 %18
+%4 = OpVariable  %19  Output
+%1 = OpFunction  %20  None %21
+%27 = OpLabel
+%28 = OpLoad  %12  %2
+%9 = OpAccessChain  %22  %3 %28
+%29 = OpCompositeConstruct  %23  %24 %25
+%10 = OpLoad  %15  %9
+%11 = OpImageRead  %18  %10 %29
+%30 = OpFunctionCall  %18  %8 %11
+OpStore %4 %30
+OpNoLine
+OpReturn
+OpFunctionEnd
+%8 = OpFunction  %18  None %26
+%31 = OpFunctionParameter  %18
+%32 = OpLabel
+OpReturnValue %31
+OpFunctionEnd

--- a/tests/compiletests/ui/arch/non_uniform/storage_image_uniform.rs
+++ b/tests/compiletests/ui/arch/non_uniform/storage_image_uniform.rs
@@ -1,0 +1,32 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// compile-flags: -C target-feature=+StorageImageExtendedFormats,+StorageImageReadWithoutFormat
+// compile-flags: -C target-feature=+RuntimeDescriptorArray,+StorageImageArrayDynamicIndexing
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "; .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-spv1.3
+// ignore-spv1.4
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use spirv_std::glam::*;
+use spirv_std::image::*;
+use spirv_std::*;
+
+#[spirv(vertex)]
+pub fn main(
+    index: u32,
+    #[spirv(descriptor_set = 0, binding = 0)] images: &RuntimeArray<StorageImage2d>,
+    out: &mut Vec4,
+) {
+    unsafe {
+        *out = images.index(index as usize).read(UVec2::new(1, 2));
+    }
+}

--- a/tests/compiletests/ui/arch/non_uniform/storage_image_uniform.stderr
+++ b/tests/compiletests/ui/arch/non_uniform/storage_image_uniform.stderr
@@ -1,0 +1,50 @@
+OpCapability Shader
+OpCapability StorageImageArrayDynamicIndexing
+OpCapability StorageImageExtendedFormats
+OpCapability StorageImageReadWithoutFormat
+OpCapability RuntimeDescriptorArray
+OpMemoryModel Logical Simple
+OpEntryPoint Vertex %1 "main" %2 %3 %4
+OpName %2 "index"
+OpName %3 "images"
+OpName %4 "out"
+OpName %8 "<glam::f32::scalar::vec4::Vec4 as spirv_std::vector::VectorTruncateInto<glam::f32::scalar::vec4::Vec4>>::truncate_into"
+OpDecorate %2 Location 0
+OpDecorate %3 Binding 0
+OpDecorate %3 DescriptorSet 0
+OpDecorate %4 Location 0
+%9 = OpTypeInt 32 0
+%10 = OpTypePointer Input %9
+%11 = OpTypeFloat 32
+%12 = OpTypeImage %11 2D 2 0 0 2 Unknown
+%13 = OpTypeRuntimeArray %12
+%14 = OpTypePointer UniformConstant %13
+%15 = OpTypeVector %11 4
+%16 = OpTypePointer Output %15
+%17 = OpTypeVoid
+%18 = OpTypeFunction %17
+%2 = OpVariable  %10  Input
+%19 = OpTypePointer UniformConstant %12
+%3 = OpVariable  %14  UniformConstant
+%20 = OpTypeVector %9 2
+%21 = OpConstant  %9  1
+%22 = OpConstant  %9  2
+%23 = OpTypeFunction %15 %15
+%4 = OpVariable  %16  Output
+%1 = OpFunction  %17  None %18
+%24 = OpLabel
+%25 = OpLoad  %9  %2
+%26 = OpAccessChain  %19  %3 %25
+%27 = OpCompositeConstruct  %20  %21 %22
+%28 = OpLoad  %12  %26
+%29 = OpImageRead  %15  %28 %27
+%30 = OpFunctionCall  %15  %8 %29
+OpStore %4 %30
+OpNoLine
+OpReturn
+OpFunctionEnd
+%8 = OpFunction  %15  None %23
+%31 = OpFunctionParameter  %15
+%32 = OpLabel
+OpReturnValue %31
+OpFunctionEnd


### PR DESCRIPTION
* remove `BuilderSpirv::has_capability(&self, capability: Capability) -> bool`, you can no longer check whether some capability is enabled. Progress towards https://github.com/Rust-GPU/rust-gpu/issues/388
* add compiletests for non_uniform removal by post-link pass (previously *partially* gated behind `has_capability` check)