### PR TITLE
ci: split compiletest target-envs into steps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,6 +154,10 @@ jobs:
         run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env spv1.3
       - name: compiletest spv1.4
         run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env spv1.4
+      - name: compiletest spv1.5
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env spv1.5
+      - name: compiletest spv1.6
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env spv1.6
 
   difftest:
     name: Difftest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,8 +140,20 @@ jobs:
         run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
       - name: cargo fetch --locked
         run: cargo fetch --locked --target $TARGET
-      - name: compiletest
-        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1,vulkan1.2,vulkan1.3,vulkan1.4,spv1.3,spv1.4
+      - name: build compiletest
+        run: cargo build -p compiletests --release --no-default-features --features "use-installed-tools"
+      - name: compiletest vulkan1.1
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.1
+      - name: compiletest vulkan1.2
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.2
+      - name: compiletest vulkan1.3
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.3
+      - name: compiletest vulkan1.4
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env vulkan1.4
+      - name: compiletest spv1.3
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env spv1.3
+      - name: compiletest spv1.4
+        run: cargo run -p compiletests --release --no-default-features --features "use-installed-tools" -- --target-env spv1.4
 
   difftest:
     name: Difftest


### PR DESCRIPTION
* split compiletest target-env into individual steps for better readability
* add spv1.5 and spv1.6

Future notes:
* when https://github.com/Rust-GPU/rust-gpu/pull/526 and this is merged, compiletest-windows will be the longest running job due to the addition of spv1.5 and spv1.6, so we may want to split the windows job in two jobs.