### PR TITLE
dedup `BuiltIn OpVariable`

### DIFF
--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -559,9 +559,12 @@ pub fn remove_duplicate_builtin_input_variables(module: &mut Module) {
                     Operand::BuiltIn(builtin),
                 ] = inst.operands[..]
             {
-                // Ignore multiple BuiltIn's for one variable ID;
-                // they're invalid AFAIK, but later validation will catch them.
-                let _prev = var_id_to_builtin_mut.insert(var_id, builtin);
+                let prev = var_id_to_builtin_mut.insert(var_id, builtin);
+                assert!(
+                    prev.is_none(),
+                    "An OpVariable `{inst:?}` shouldn't have more than one Builtin decoration, \
+                    but it has at least two: {builtin:?}, {prev:?}"
+                );
             }
         }
         var_id_to_builtin = var_id_to_builtin_mut;
@@ -599,37 +602,10 @@ pub fn remove_duplicate_builtin_input_variables(module: &mut Module) {
         duplicate_vars = duplicate_in_vars_mut;
     };
 
-    // Rewrite entry points, removing duplicate variables.
-    for entry in &mut module.entry_points {
-        if entry.class.opcode != Op::EntryPoint {
-            continue;
-        }
-
-        entry
-            .operands
-            .retain(|op| !matches!(op, Operand::IdRef(id) if duplicate_vars.contains_key(id)));
-    }
-
-    // Rewrite annotations for duplicates to point at de-duplicated variables;
-    // this will merge the annotations sets but produce duplicate annotations
-    // (which we will remove next).
-    for inst in &mut module.annotations {
+    // Rewrite entry points
+    for inst in &mut module.entry_points {
         rewrite_inst_with_rules(inst, &duplicate_vars);
     }
-
-    // Merge the annotations for duplicate vars.
-    {
-        let mut annotations_set = FxHashSet::default();
-        module
-            .annotations
-            // Note: insert returns true when an annotation is inserted for the first time.
-            .retain(|inst| annotations_set.insert(inst.assemble()));
-    }
-
-    // Remove the duplicate variable definitions.
-    module
-        .types_global_values
-        .retain(|inst| !matches!(inst.result_id, Some(id) if duplicate_vars.contains_key(&id)));
 
     // Rewrite function blocks to use de-duplicated variables.
     for inst in &mut module
@@ -640,4 +616,19 @@ pub fn remove_duplicate_builtin_input_variables(module: &mut Module) {
     {
         rewrite_inst_with_rules(inst, &duplicate_vars);
     }
+
+    // Remove duplicate BuiltIn decorations
+    module.annotations.retain(|inst| {
+        !(inst.class.opcode == Op::Decorate
+            && matches!(inst.operands[..], [
+                Operand::IdRef(var_id),
+                Operand::Decoration(Decoration::BuiltIn),
+                Operand::BuiltIn(_),
+            ] if duplicate_vars.contains_key(&var_id)))
+    });
+
+    // Remove the duplicate variable definitions.
+    module
+        .types_global_values
+        .retain(|inst| !matches!(inst.result_id, Some(id) if duplicate_vars.contains_key(&id)));
 }

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -174,32 +174,15 @@ fn make_dedupe_key(
 }
 
 fn rewrite_inst_with_rules(inst: &mut Instruction, rules: &FxHashMap<u32, u32>) {
-    if let Some(ref mut id) = inst.result_id {
+    if let Some(ref mut id) = inst.result_type {
         // If the rewrite rules contain this ID, replace with the mapped value, otherwise don't touch it.
         *id = rules.get(id).copied().unwrap_or(*id);
-    }
-    if let Some(ref mut type_id) = inst.result_type {
-        *type_id = rules.get(type_id).copied().unwrap_or(*type_id);
     }
     for op in &mut inst.operands {
         if let Some(id) = op.id_ref_any_mut() {
             *id = rules.get(id).copied().unwrap_or(*id);
         }
     }
-}
-
-/// Remove duplicate `OpName` and `OpMemberName` instructions from module debug names section.
-fn remove_duplicate_debug_names(debug_names: &mut Vec<Instruction>) {
-    let mut name_ids = FxHashSet::default();
-    let mut member_name_ids = FxHashSet::default();
-    debug_names.retain(|inst| {
-        (inst.class.opcode != Op::Name || name_ids.insert(inst.operands[0].unwrap_id_ref()))
-            && (inst.class.opcode != Op::MemberName
-                || member_name_ids.insert((
-                    inst.operands[0].unwrap_id_ref(),
-                    inst.operands[1].unwrap_literal_bit32(),
-                )))
-    });
 }
 
 pub fn remove_duplicate_types(module: &mut Module) {
@@ -277,9 +260,17 @@ pub fn remove_duplicate_types(module: &mut Module) {
     module
         .annotations
         .retain(|inst| anno_set.insert(inst.assemble()));
-
-    // Same thing with debug names section
-    remove_duplicate_debug_names(&mut module.debug_names);
+    // Same thing with OpName
+    let mut name_ids = FxHashSet::default();
+    let mut member_name_ids = FxHashSet::default();
+    module.debug_names.retain(|inst| {
+        (inst.class.opcode != Op::Name || name_ids.insert(inst.operands[0].unwrap_id_ref()))
+            && (inst.class.opcode != Op::MemberName
+                || member_name_ids.insert((
+                    inst.operands[0].unwrap_id_ref(),
+                    inst.operands[1].unwrap_literal_bit32(),
+                )))
+    });
 }
 
 pub fn remove_duplicate_debuginfo(module: &mut Module) {
@@ -573,7 +564,6 @@ pub fn remove_duplicate_builtin_input_variables(module: &mut Module) {
                 let _prev = var_id_to_builtin_mut.insert(var_id, builtin);
             }
         }
-        // Rebind as immutable.
         var_id_to_builtin = var_id_to_builtin_mut;
     };
 
@@ -606,7 +596,6 @@ pub fn remove_duplicate_builtin_input_variables(module: &mut Module) {
                 };
             }
         }
-        // Rebind as immutable.
         duplicate_vars = duplicate_in_vars_mut;
     };
 
@@ -620,9 +609,6 @@ pub fn remove_duplicate_builtin_input_variables(module: &mut Module) {
             .operands
             .retain(|op| !matches!(op, Operand::IdRef(id) if duplicate_vars.contains_key(id)));
     }
-
-    // Remove duplicate debug names after merging variables.
-    remove_duplicate_debug_names(&mut module.debug_names);
 
     // Rewrite annotations for duplicates to point at de-duplicated variables;
     // this will merge the annotations sets but produce duplicate annotations

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -1,7 +1,7 @@
 use crate::custom_insts::{self, CustomOp};
 use rspirv::binary::Assemble;
 use rspirv::dr::{Instruction, Module, Operand};
-use rspirv::spirv::{Op, Word};
+use rspirv::spirv::{BuiltIn, Decoration, Op, Word};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_middle::bug;
 use smallvec::SmallVec;
@@ -104,6 +104,7 @@ fn gather_annotations(annotations: &[Instruction]) -> FxHashMap<Word, Vec<u32>> 
         .collect()
 }
 
+/// Returns a map from an ID to its debug name (given by `OpName`).
 fn gather_names(debug_names: &[Instruction]) -> FxHashMap<Word, String> {
     debug_names
         .iter()
@@ -173,15 +174,32 @@ fn make_dedupe_key(
 }
 
 fn rewrite_inst_with_rules(inst: &mut Instruction, rules: &FxHashMap<u32, u32>) {
-    if let Some(ref mut id) = inst.result_type {
+    if let Some(ref mut id) = inst.result_id {
         // If the rewrite rules contain this ID, replace with the mapped value, otherwise don't touch it.
         *id = rules.get(id).copied().unwrap_or(*id);
+    }
+    if let Some(ref mut type_id) = inst.result_type {
+        *type_id = rules.get(type_id).copied().unwrap_or(*type_id);
     }
     for op in &mut inst.operands {
         if let Some(id) = op.id_ref_any_mut() {
             *id = rules.get(id).copied().unwrap_or(*id);
         }
     }
+}
+
+/// Remove duplicate `OpName` and `OpMemberName` instructions from module debug names section.
+fn remove_duplicate_debug_names(debug_names: &mut Vec<Instruction>) {
+    let mut name_ids = FxHashSet::default();
+    let mut member_name_ids = FxHashSet::default();
+    debug_names.retain(|inst| {
+        (inst.class.opcode != Op::Name || name_ids.insert(inst.operands[0].unwrap_id_ref()))
+            && (inst.class.opcode != Op::MemberName
+                || member_name_ids.insert((
+                    inst.operands[0].unwrap_id_ref(),
+                    inst.operands[1].unwrap_literal_bit32(),
+                )))
+    });
 }
 
 pub fn remove_duplicate_types(module: &mut Module) {
@@ -259,17 +277,9 @@ pub fn remove_duplicate_types(module: &mut Module) {
     module
         .annotations
         .retain(|inst| anno_set.insert(inst.assemble()));
-    // Same thing with OpName
-    let mut name_ids = FxHashSet::default();
-    let mut member_name_ids = FxHashSet::default();
-    module.debug_names.retain(|inst| {
-        (inst.class.opcode != Op::Name || name_ids.insert(inst.operands[0].unwrap_id_ref()))
-            && (inst.class.opcode != Op::MemberName
-                || member_name_ids.insert((
-                    inst.operands[0].unwrap_id_ref(),
-                    inst.operands[1].unwrap_literal_bit32(),
-                )))
-    });
+
+    // Same thing with debug names section
+    remove_duplicate_debug_names(&mut module.debug_names);
 }
 
 pub fn remove_duplicate_debuginfo(module: &mut Module) {
@@ -539,5 +549,89 @@ pub fn remove_duplicate_debuginfo(module: &mut Module) {
                 .instructions
                 .retain(|inst| inst.class.opcode != Op::Nop);
         }
+    }
+}
+
+pub fn remove_duplicate_builtin_variables(module: &mut Module) {
+    // Find the variables decorated as builtins, and any duplicates of each builtin.
+
+    // A map from deleted duplicate variable ID to the new, de-duplicated ID.
+    let duplicate_vars: FxHashMap<Word, Word> = {
+        // A map from builtin to a de-duplicated variable decorated as that builtin.
+        let mut builtin_to_var_id = FxHashMap::<BuiltIn, Word>::default();
+
+        let mut duplicate_vars = FxHashMap::<Word, Word>::default();
+
+        for inst in module.annotations.iter() {
+            if inst.class.opcode == Op::Decorate
+                && let [
+                    Operand::IdRef(var_id),
+                    Operand::Decoration(Decoration::BuiltIn),
+                    Operand::BuiltIn(builtin),
+                ] = inst.operands[..]
+            {
+                match builtin_to_var_id.entry(builtin) {
+                    // first variable we've seen for this builtin,
+                    // record it in the builtins map.
+                    hash_map::Entry::Vacant(vacant) => {
+                        vacant.insert(var_id);
+                    }
+
+                    // this builtin already has a variable,
+                    // record it in the duplicates map.
+                    hash_map::Entry::Occupied(occupied) => {
+                        duplicate_vars.insert(var_id, *occupied.get());
+                    }
+                };
+            }
+        }
+        // Rebind as immutable in fn scope.
+        duplicate_vars
+    };
+
+    // Rewrite entry points, removing duplicate variables.
+    for entry in &mut module.entry_points {
+        if entry.class.opcode != Op::EntryPoint {
+            continue;
+        }
+
+        entry
+            .operands
+            .retain(|op| !matches!(op, Operand::IdRef(id) if duplicate_vars.contains_key(id)));
+    }
+
+    // Remove duplicate debug names after merging variables.
+    remove_duplicate_debug_names(&mut module.debug_names);
+
+    // Rewrite annotations for duplicates to point at de-duplicated variables;
+    // this will merge the annotations sets but produce duplicate annotations
+    // (which we will remove next).
+    for inst in &mut module.annotations {
+        rewrite_inst_with_rules(inst, &duplicate_vars);
+    }
+
+    // Merge the annotations for duplicate vars.
+    {
+        let mut annotations_set = FxHashSet::default();
+        module
+            .annotations
+            // Note: insert returns true when an annotation is inserted for the first time.
+            .retain(|inst| annotations_set.insert(inst.assemble()));
+    }
+
+    // Remove the duplicate variable definitions.
+    module.types_global_values.retain(|inst| {
+        !matches!(inst.result_id,
+                                   Some(id) if duplicate_vars.contains_key(&id))
+    });
+
+    // Rewrite function blocks to use de-duplicated variables.
+    for inst in &mut module
+        .functions
+        .iter_mut()
+        .flat_map(|f| &mut f.blocks)
+        .flat_map(|b| &mut b.instructions)
+    {
+        rewrite_inst_with_rules(inst, &duplicate_vars);
     }
 }

--- a/crates/rustc_codegen_spirv/src/linker/duplicates.rs
+++ b/crates/rustc_codegen_spirv/src/linker/duplicates.rs
@@ -1,7 +1,7 @@
 use crate::custom_insts::{self, CustomOp};
 use rspirv::binary::Assemble;
 use rspirv::dr::{Instruction, Module, Operand};
-use rspirv::spirv::{BuiltIn, Decoration, Op, Word};
+use rspirv::spirv::{BuiltIn, Decoration, Op, StorageClass, Word};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_middle::bug;
 use smallvec::SmallVec;
@@ -552,15 +552,13 @@ pub fn remove_duplicate_debuginfo(module: &mut Module) {
     }
 }
 
-pub fn remove_duplicate_builtin_variables(module: &mut Module) {
-    // Find the variables decorated as builtins, and any duplicates of each builtin.
+pub fn remove_duplicate_builtin_input_variables(module: &mut Module) {
+    // Find the variables decorated as input builtins, and any duplicates of them..
 
-    // A map from deleted duplicate variable ID to the new, de-duplicated ID.
-    let duplicate_vars: FxHashMap<Word, Word> = {
-        // A map from builtin to a de-duplicated variable decorated as that builtin.
-        let mut builtin_to_var_id = FxHashMap::<BuiltIn, Word>::default();
-
-        let mut duplicate_vars = FxHashMap::<Word, Word>::default();
+    // Build a map: from a variable ID to the builtin it's decorated with.
+    let var_id_to_builtin: FxHashMap<Word, BuiltIn>;
+    {
+        let mut var_id_to_builtin_mut = FxHashMap::default();
 
         for inst in module.annotations.iter() {
             if inst.class.opcode == Op::Decorate
@@ -570,23 +568,46 @@ pub fn remove_duplicate_builtin_variables(module: &mut Module) {
                     Operand::BuiltIn(builtin),
                 ] = inst.operands[..]
             {
-                match builtin_to_var_id.entry(builtin) {
-                    // first variable we've seen for this builtin,
+                // Ignore multiple BuiltIn's for one variable ID;
+                // they're invalid AFAIK, but later validation will catch them.
+                let _prev = var_id_to_builtin_mut.insert(var_id, builtin);
+            }
+        }
+        // Rebind as immutable.
+        var_id_to_builtin = var_id_to_builtin_mut;
+    };
+
+    // Build a map from deleted duplicate input variable ID to the de-duplicated ID.
+    let duplicate_vars: FxHashMap<Word, Word>;
+    {
+        let mut duplicate_in_vars_mut = FxHashMap::<Word, Word>::default();
+
+        // Map from builtin to de-duped input variable ID.
+        let mut builtin_to_input_var_id = FxHashMap::<BuiltIn, Word>::default();
+
+        for inst in module.types_global_values.iter() {
+            if inst.class.opcode == Op::Variable
+                && let [Operand::StorageClass(StorageClass::Input), ..] = inst.operands[..]
+                && let Some(var_id) = inst.result_id
+                && let Some(builtin) = var_id_to_builtin.get(&var_id)
+            {
+                match builtin_to_input_var_id.entry(*builtin) {
+                    // first input variable we've seen for this builtin,
                     // record it in the builtins map.
                     hash_map::Entry::Vacant(vacant) => {
                         vacant.insert(var_id);
                     }
 
-                    // this builtin already has a variable,
+                    // this builtin already has an input variable,
                     // record it in the duplicates map.
                     hash_map::Entry::Occupied(occupied) => {
-                        duplicate_vars.insert(var_id, *occupied.get());
+                        duplicate_in_vars_mut.insert(var_id, *occupied.get());
                     }
                 };
             }
         }
-        // Rebind as immutable in fn scope.
-        duplicate_vars
+        // Rebind as immutable.
+        duplicate_vars = duplicate_in_vars_mut;
     };
 
     // Rewrite entry points, removing duplicate variables.
@@ -620,10 +641,9 @@ pub fn remove_duplicate_builtin_variables(module: &mut Module) {
     }
 
     // Remove the duplicate variable definitions.
-    module.types_global_values.retain(|inst| {
-        !matches!(inst.result_id,
-                                   Some(id) if duplicate_vars.contains_key(&id))
-    });
+    module
+        .types_global_values
+        .retain(|inst| !matches!(inst.result_id, Some(id) if duplicate_vars.contains_key(&id)));
 
     // Rewrite function blocks to use de-duplicated variables.
     for inst in &mut module

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -290,6 +290,7 @@ pub fn link(
         duplicates::remove_duplicate_capabilities(&mut output);
         duplicates::remove_duplicate_ext_inst_imports(&mut output);
         duplicates::remove_duplicate_types(&mut output);
+        duplicates::remove_duplicate_builtin_variables(&mut output);
         // jb-todo: strip identical OpDecoration / OpDecorationGroups
     }
 

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -290,7 +290,7 @@ pub fn link(
         duplicates::remove_duplicate_capabilities(&mut output);
         duplicates::remove_duplicate_ext_inst_imports(&mut output);
         duplicates::remove_duplicate_types(&mut output);
-        duplicates::remove_duplicate_builtin_variables(&mut output);
+        duplicates::remove_duplicate_builtin_input_variables(&mut output);
         // jb-todo: strip identical OpDecoration / OpDecorationGroups
     }
 

--- a/crates/rustc_codegen_spirv/src/linker/mod.rs
+++ b/crates/rustc_codegen_spirv/src/linker/mod.rs
@@ -289,8 +289,8 @@ pub fn link(
         duplicates::remove_duplicate_extensions(&mut output);
         duplicates::remove_duplicate_capabilities(&mut output);
         duplicates::remove_duplicate_ext_inst_imports(&mut output);
-        duplicates::remove_duplicate_types(&mut output);
         duplicates::remove_duplicate_builtin_input_variables(&mut output);
+        duplicates::remove_duplicate_types(&mut output);
         // jb-todo: strip identical OpDecoration / OpDecorationGroups
     }
 

--- a/tests/compiletests/ui/entry/builtin_duplicates.rs
+++ b/tests/compiletests/ui/entry/builtin_duplicates.rs
@@ -1,0 +1,58 @@
+// build-pass
+// compile-flags: -C llvm-args=--disassemble
+// normalize-stderr-test "OpLine .*\n" -> ""
+// normalize-stderr-test "OpSource .*\n" -> ""
+// normalize-stderr-test "%\d+ = OpString .*\n" -> ""
+// normalize-stderr-test "OpCapability VulkanMemoryModel\n" -> ""
+// normalize-stderr-test "OpExtension .SPV_KHR_vulkan_memory_model.\n" -> ""
+// normalize-stderr-test "OpMemoryModel Logical Vulkan" -> "OpMemoryModel Logical Simple"
+// normalize-stderr-test "; .*\n" -> ""
+
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
+// ignore-vulkan1.0
+// ignore-vulkan1.1
+
+use core::arch::asm;
+use spirv_std::{glam::*, spirv};
+
+#[spirv(compute(threads(1)))]
+pub fn entry_1(#[spirv(local_invocation_index)] _local_idx: u32) {
+    let _: u32 = local_invocation_index();
+    let _: u32 = local_invocation_index();
+    let _: u32 = sub_1();
+    let _: u32 = sub_2();
+}
+
+#[spirv(compute(threads(1)))]
+pub fn entry_2(#[spirv(local_invocation_index)] _local_idx: u32) {
+    let _: u32 = local_invocation_index();
+    let _: u32 = sub_1();
+    let _: u32 = sub_2();
+}
+
+#[inline(never)]
+fn sub_1() -> u32 {
+    local_invocation_index()
+}
+
+#[inline(never)]
+fn sub_2() -> u32 {
+    local_invocation_index()
+}
+
+#[inline]
+pub fn local_invocation_index() -> u32 {
+    unsafe {
+        let result = 0;
+        asm! {
+            "%builtin = OpVariable typeof{result} Input",
+            "OpDecorate %builtin BuiltIn LocalInvocationIndex",
+            "%result = OpLoad typeof*{result} %builtin",
+            "OpStore {result} %result",
+            result = in(reg) &result,
+        }
+        result
+    }
+}

--- a/tests/compiletests/ui/entry/builtin_duplicates.stderr
+++ b/tests/compiletests/ui/entry/builtin_duplicates.stderr
@@ -1,0 +1,73 @@
+OpCapability Shader
+OpMemoryModel Logical Simple
+OpEntryPoint GLCompute %1 "entry_1" %2 %3
+OpEntryPoint GLCompute %4 "entry_2" %2 %3
+OpExecutionMode %1 LocalSize 1 1 1
+OpExecutionMode %4 LocalSize 1 1 1
+OpName %6 "builtin_duplicates::entry_1"
+OpName %7 "builtin_duplicates::sub_1"
+OpName %8 "builtin_duplicates::sub_2"
+OpName %9 "builtin_duplicates::entry_2"
+OpDecorate %2 BuiltIn LocalInvocationIndex
+OpDecorate %3 BuiltIn LocalInvocationIndex
+%10 = OpTypeInt 32 0
+%11 = OpTypePointer Input %10
+%12 = OpTypeVoid
+%13 = OpTypeFunction %12
+%2 = OpVariable  %11  Input
+%14 = OpTypeFunction %12 %10
+%3 = OpVariable  %11  Input
+%15 = OpTypeFunction %10
+%1 = OpFunction  %12  None %13
+%16 = OpLabel
+%17 = OpLoad  %10  %2
+%18 = OpFunctionCall  %12  %6 %17
+OpNoLine
+OpReturn
+OpFunctionEnd
+%6 = OpFunction  %12  None %14
+%19 = OpFunctionParameter  %10
+%20 = OpLabel
+%21 = OpLoad  %10  %3
+%22 = OpLoad  %10  %3
+%23 = OpFunctionCall  %10  %7
+%24 = OpFunctionCall  %10  %8
+OpNoLine
+OpReturn
+OpFunctionEnd
+%7 = OpFunction  %10  DontInline %15
+%25 = OpLabel
+%26 = OpLoad  %10  %3
+OpNoLine
+OpReturnValue %26
+OpFunctionEnd
+%8 = OpFunction  %10  DontInline %15
+%27 = OpLabel
+%28 = OpLoad  %10  %3
+OpNoLine
+OpReturnValue %28
+OpFunctionEnd
+%4 = OpFunction  %12  None %13
+%29 = OpLabel
+%30 = OpLoad  %10  %2
+%31 = OpFunctionCall  %12  %9 %30
+OpNoLine
+OpReturn
+OpFunctionEnd
+%9 = OpFunction  %12  None %14
+%32 = OpFunctionParameter  %10
+%33 = OpLabel
+%34 = OpLoad  %10  %3
+%35 = OpFunctionCall  %10  %7
+%36 = OpFunctionCall  %10  %8
+OpNoLine
+OpReturn
+OpFunctionEnd
+error: error:0:0 - [VUID-StandaloneSpirv-OpEntryPoint-09658] OpEntryPoint contains duplicate input variables with LocalInvocationIndex builtin
+         %gl_LocalInvocationIndex = OpVariable %_ptr_Input_uint Input
+   |
+   = note: spirv-val failed
+   = note: module `$TEST_BUILD_DIR/entry/builtin_duplicates.vulkan1.2`
+
+error: aborting due to 1 previous error
+

--- a/tests/compiletests/ui/entry/builtin_duplicates.stderr
+++ b/tests/compiletests/ui/entry/builtin_duplicates.stderr
@@ -1,73 +1,63 @@
 OpCapability Shader
 OpMemoryModel Logical Simple
-OpEntryPoint GLCompute %1 "entry_1" %2 %3
-OpEntryPoint GLCompute %4 "entry_2" %2 %3
+OpEntryPoint GLCompute %1 "entry_1" %2
+OpEntryPoint GLCompute %3 "entry_2" %2
 OpExecutionMode %1 LocalSize 1 1 1
-OpExecutionMode %4 LocalSize 1 1 1
-OpName %6 "builtin_duplicates::entry_1"
-OpName %7 "builtin_duplicates::sub_1"
-OpName %8 "builtin_duplicates::sub_2"
-OpName %9 "builtin_duplicates::entry_2"
+OpExecutionMode %3 LocalSize 1 1 1
+OpName %5 "builtin_duplicates::entry_1"
+OpName %6 "builtin_duplicates::sub_1"
+OpName %7 "builtin_duplicates::sub_2"
+OpName %8 "builtin_duplicates::entry_2"
 OpDecorate %2 BuiltIn LocalInvocationIndex
-OpDecorate %3 BuiltIn LocalInvocationIndex
-%10 = OpTypeInt 32 0
-%11 = OpTypePointer Input %10
-%12 = OpTypeVoid
-%13 = OpTypeFunction %12
-%2 = OpVariable  %11  Input
-%14 = OpTypeFunction %12 %10
-%3 = OpVariable  %11  Input
-%15 = OpTypeFunction %10
-%1 = OpFunction  %12  None %13
-%16 = OpLabel
-%17 = OpLoad  %10  %2
-%18 = OpFunctionCall  %12  %6 %17
+%9 = OpTypeInt 32 0
+%10 = OpTypePointer Input %9
+%11 = OpTypeVoid
+%12 = OpTypeFunction %11
+%2 = OpVariable  %10  Input
+%13 = OpTypeFunction %11 %9
+%14 = OpTypeFunction %9
+%1 = OpFunction  %11  None %12
+%15 = OpLabel
+%16 = OpLoad  %9  %2
+%17 = OpFunctionCall  %11  %5 %16
 OpNoLine
 OpReturn
 OpFunctionEnd
-%6 = OpFunction  %12  None %14
-%19 = OpFunctionParameter  %10
-%20 = OpLabel
-%21 = OpLoad  %10  %3
-%22 = OpLoad  %10  %3
-%23 = OpFunctionCall  %10  %7
-%24 = OpFunctionCall  %10  %8
+%5 = OpFunction  %11  None %13
+%18 = OpFunctionParameter  %9
+%19 = OpLabel
+%20 = OpLoad  %9  %2
+%21 = OpLoad  %9  %2
+%22 = OpFunctionCall  %9  %6
+%23 = OpFunctionCall  %9  %7
 OpNoLine
 OpReturn
 OpFunctionEnd
-%7 = OpFunction  %10  DontInline %15
-%25 = OpLabel
-%26 = OpLoad  %10  %3
+%6 = OpFunction  %9  DontInline %14
+%24 = OpLabel
+%25 = OpLoad  %9  %2
 OpNoLine
-OpReturnValue %26
+OpReturnValue %25
 OpFunctionEnd
-%8 = OpFunction  %10  DontInline %15
-%27 = OpLabel
-%28 = OpLoad  %10  %3
+%7 = OpFunction  %9  DontInline %14
+%26 = OpLabel
+%27 = OpLoad  %9  %2
 OpNoLine
-OpReturnValue %28
+OpReturnValue %27
 OpFunctionEnd
-%4 = OpFunction  %12  None %13
-%29 = OpLabel
-%30 = OpLoad  %10  %2
-%31 = OpFunctionCall  %12  %9 %30
-OpNoLine
-OpReturn
-OpFunctionEnd
-%9 = OpFunction  %12  None %14
-%32 = OpFunctionParameter  %10
-%33 = OpLabel
-%34 = OpLoad  %10  %3
-%35 = OpFunctionCall  %10  %7
-%36 = OpFunctionCall  %10  %8
+%3 = OpFunction  %11  None %12
+%28 = OpLabel
+%29 = OpLoad  %9  %2
+%30 = OpFunctionCall  %11  %8 %29
 OpNoLine
 OpReturn
 OpFunctionEnd
-error: error:0:0 - [VUID-StandaloneSpirv-OpEntryPoint-09658] OpEntryPoint contains duplicate input variables with LocalInvocationIndex builtin
-         %gl_LocalInvocationIndex = OpVariable %_ptr_Input_uint Input
-   |
-   = note: spirv-val failed
-   = note: module `$TEST_BUILD_DIR/entry/builtin_duplicates.vulkan1.2`
-
-error: aborting due to 1 previous error
-
+%8 = OpFunction  %11  None %13
+%31 = OpFunctionParameter  %9
+%32 = OpLabel
+%33 = OpLoad  %9  %2
+%34 = OpFunctionCall  %9  %6
+%35 = OpFunctionCall  %9  %7
+OpNoLine
+OpReturn
+OpFunctionEnd

--- a/tests/compiletests/ui/spirv-attr/all-builtins.rs
+++ b/tests/compiletests/ui/spirv-attr/all-builtins.rs
@@ -1,6 +1,9 @@
 // build-pass
-// only-vulkan1.1
 // compile-flags: -Ctarget-feature=+DeviceGroup,+DrawParameters,+FragmentBarycentricNV,+FragmentBarycentricKHR,+FragmentDensityEXT,+FragmentFullyCoveredEXT,+Geometry,+GroupNonUniform,+GroupNonUniformBallot,+MeshShadingNV,+MultiView,+MultiViewport,+RayTracingKHR,+SampleRateShading,+ShaderSMBuiltinsNV,+ShaderStereoViewNV,+StencilExportEXT,+Tessellation,+ext:SPV_AMD_shader_explicit_vertex_parameter,+ext:SPV_EXT_fragment_fully_covered,+ext:SPV_EXT_fragment_invocation_density,+ext:SPV_EXT_shader_stencil_export,+ext:SPV_KHR_ray_tracing,+ext:SPV_NV_fragment_shader_barycentric,+ext:SPV_NV_mesh_shader,+ext:SPV_NV_shader_sm_builtins,+ext:SPV_NV_stereo_view_rendering
+// ignore-vulkan1.0
+// ignore-spv1.0
+// ignore-spv1.1
+// ignore-spv1.2
 
 use spirv_std::glam::*;
 use spirv_std::matrix::Matrix4x3;
@@ -22,6 +25,7 @@ pub fn tessellation_evaluation(#[spirv(tess_coord)] tess_coord: Vec3) {}
 pub fn compute(
     #[spirv(global_invocation_id)] global_invocation_id: UVec3,
     #[spirv(local_invocation_id)] local_invocation_id: UVec3,
+    #[spirv(local_invocation_index)] local_invocation_index: u32,
     #[spirv(subgroup_local_invocation_id)] subgroup_local_invocation_id: u32,
     #[spirv(num_subgroups)] num_subgroups: u32,
     #[spirv(num_workgroups)] num_workgroups: UVec3,


### PR DESCRIPTION
* Extracted from https://github.com/Rust-GPU/rust-gpu/pull/535 by @fluffysquirrels
* deduplicate `Input` `OpVaraible`s with `BuiltIn` decoration
* caused by builtins declared by `asm!` blocks, see https://github.com/Rust-GPU/rust-gpu/pull/534
  * can't happen with current entry point system