### PR TITLE
ci: fix `cargo-gpu-backwards-compat` failure on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -253,8 +253,9 @@ jobs:
 
           # just after target specs v2 refactor, we updated to rustc 1.85 and needed to change them again
           # before
-          - rust-gpu-version: a547c6e45266d613d9fec673e869d7a96181e47b
-            glam-version: =0.30.7
+          # * fails: indexmap-2.14.0 requires edition 2024, not yet stabilized on this toolchain
+          # - rust-gpu-version: a547c6e45266d613d9fec673e869d7a96181e47b
+          #   glam-version: =0.30.7
           # after
           - rust-gpu-version: 2326b87fe1542eeb898065e36ac949307b55386d
             glam-version: =0.30.7


### PR DESCRIPTION
Caused by [indexmap](https://crates.io/crates/indexmap/versions) releasing 2.14.0 which raises msrv to 1.85.

More so our fault for `cargo-gpu` building `rustc_codegen_spirv` without a lockfile, and those old toolchains aren't msrv-aware so will always grab whatever the newest version is