### PR TITLE
constant: correctly handle signedness in `const_to_opt_u128`.

### DIFF
--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -214,12 +214,24 @@ impl ConstCodegenMethods for CodegenCx<'_> {
     }
 
     fn const_to_opt_uint(&self, v: Self::Value) -> Option<u64> {
-        self.builder.lookup_const_scalar(v)?.try_into().ok()
+        // HACK(eddyb) this abuses the fact that sign-extension to 128-bit will
+        // exceed `u64::MAX` for negative `v`, and will therefore return `None`.
+        self.const_to_opt_u128(v, true)?.try_into().ok()
     }
-    // FIXME(eddyb) what's the purpose of the `sign_ext` argument, and can it
-    // differ from the signedness of `v`?
-    fn const_to_opt_u128(&self, v: Self::Value, _sign_ext: bool) -> Option<u128> {
-        self.builder.lookup_const_scalar(v)
+
+    fn const_to_opt_u128(&self, v: Self::Value, sign_ext: bool) -> Option<u128> {
+        match self.lookup_type(v.ty) {
+            SpirvType::Integer(bits, _) => {
+                let v = self.builder.lookup_const_scalar(v)?;
+                let size = Size::from_bits(bits);
+                Some(if sign_ext {
+                    size.sign_extend(v) as u128
+                } else {
+                    size.truncate(v)
+                })
+            }
+            _ => None,
+        }
     }
 
     fn scalar_to_backend(


### PR DESCRIPTION
One of the more insidious bugs found via [Rustlantis](https://github.com/cbeuw/rustlantis) (using a sample  from @FractalFir's [Rust-GPU port of it](https://github.com/FractalFir/rustlantis)).

`const_to_opt_u128` is used [by `rustc_codegen_ssa` to optimize `switchInt` on the fly](https://github.com/rust-lang/rust/blob/14196dbfa3eb7c30195251eac092b1b86c8a2d84/compiler/rustc_codegen_ssa/src/mir/block.rs#L383-L398) (i.e. replacing `match CONST {...}` with an unconditional branch to one of its cases), and that was working fine for unsigned discriminants, but we were wrong for signed ones, due to MIR storing `switchInt` cases as zero-extended-to-`u128` (e.g. `-1i8 => ...` becomes `255 => ...`).

More specifically, when `const_to_opt_u128(x, /*sign_ext*/ false)` was called with `x` of a signed integer type, we were wrongly sign-extending (based on type) instead of zero-extending (based on `sign_ext == false`).

---

**TODO**: still needs a test, perhaps something along the lines of:
```rust
#[inline(never)]
fn const_i32_is_neg1<const X: i32>() -> bool {
    match X {
        -1 => true,
        _ => false,
    }
}

fn main() {
    assert!(const_i32_is_neg1::<-1>());
}
```
(you can see the lack of a `switch` in the LLVM IR: https://godbolt.org/z/hj6WEKj3v)
<sub>(also, unrelatedly, that godbolt sample made me notice 1.94 -> 1.95-beta generates more unnecessary LLVM IR in some situations, and nightly still does, too)</sub>