### PR TITLE
builder: allow unsigned integers in `neg` and `exactsdiv`.

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -1600,9 +1600,9 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     // Same note and TODO as exactudiv
     simple_op! {
         exactsdiv,
-        sint: s_div,
+        int: s_div,
         fold_const {
-            sint(a, b) => a.checked_div(b)?;
+            int(a, b) => a.checked_div(b)?;
         }
     }
     simple_op! {fdiv, float: f_div}
@@ -1648,9 +1648,9 @@ impl<'a, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'tcx> {
     }
     simple_uni_op! {
         neg,
-        sint: s_negate,
+        int: s_negate,
         fold_const {
-            sint(a) => a.checked_neg()?;
+            int(a) => a.checked_neg()?;
         }
     }
     simple_uni_op! {fneg, float: f_negate}

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -573,9 +573,10 @@ impl<'tcx> CodegenCx<'tcx> {
                     SpirvType::Array { count, .. } => {
                         u64::try_from(self.builder.lookup_const_scalar(count).unwrap()).unwrap()
                     }
-                    SpirvType::RuntimeArray { .. } => {
-                        (alloc.inner().size() - offset).bytes() / stride.bytes()
-                    }
+                    SpirvType::RuntimeArray { .. } => (alloc.inner().size() - offset)
+                        .bytes()
+                        .checked_div(stride.bytes())
+                        .unwrap_or(0),
                     _ => unreachable!(),
                 };
 

--- a/tests/compiletests/ui/lang/core/mem/size_of_val_unsized.rs
+++ b/tests/compiletests/ui/lang/core/mem/size_of_val_unsized.rs
@@ -1,0 +1,11 @@
+use spirv_std::spirv;
+
+#[spirv(vertex)]
+pub fn main(out: &mut usize) {
+    *out = core::mem::size_of_val(
+        const {
+            struct S<T: ?Sized>(T);
+            &S([]) as &S<[()]>
+        },
+    );
+}

--- a/tests/compiletests/ui/lang/core/mem/size_of_val_unsized.stderr
+++ b/tests/compiletests/ui/lang/core/mem/size_of_val_unsized.stderr
@@ -1,0 +1,23 @@
+error: unsupported unsized `[struct () {  }]` constant
+   |
+   = note: used by unnamed global (%68)
+   = note: used by unnamed global (%69)
+note: used from within `size_of_val_unsized::main`
+  --> <$DIR/size_of_val_unsized.rs>:5:12
+   |
+LL |       *out = core::mem::size_of_val(
+   |  ____________^
+LL | |         const {
+LL | |             struct S<T: ?Sized>(T);
+LL | |             &S([]) as &S<[()]>
+LL | |         },
+LL | |     );
+   | |_____^
+note: called by `main`
+  --> <$DIR/size_of_val_unsized.rs>:4:8
+   |
+LL | pub fn main(out: &mut usize) {
+   |        ^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
`rustc_codegen_ssa` relies on signed operations on unsigned integers for e.g. `size_of_val`.

---

**TODO**: move this from the compute shader (see diff) to a proper test:
```rust
core::mem::size_of_val(
    const {
        struct S<T: ?Sized>(T);
        &S([]) as &S<[()]>
    },
)
```