### PR TITLE
update to nightly-2026-04-11, rustc 1.96.0

### DIFF
--- a/crates/rustc_codegen_spirv/build.rs
+++ b/crates/rustc_codegen_spirv/build.rs
@@ -19,9 +19,9 @@ use std::{env, fs, mem};
 /// `cargo publish`. We need to figure out a way to do this properly, but let's hardcode it for now :/
 //const REQUIRED_RUST_TOOLCHAIN: &str = include_str!("../../rust-toolchain.toml");
 const REQUIRED_RUST_TOOLCHAIN: &str = r#"[toolchain]
-channel = "nightly-2026-04-08"
+channel = "nightly-2026-04-11"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = c756124775121dea0e640652c5ee3c89e3dd0eb4"#;
+# commit_hash = 02c7f9bec0fd583160f8bcccb830216023b07bee"#;
 
 fn rustc_output(arg: &str) -> Result<String, Box<dyn Error>> {
     let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".into());

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
-channel = "nightly-2026-04-08"
+channel = "nightly-2026-04-11"
 components = ["rust-src", "rustc-dev", "llvm-tools"]
-# commit_hash = c756124775121dea0e640652c5ee3c89e3dd0eb4
+# commit_hash = 02c7f9bec0fd583160f8bcccb830216023b07bee
 
 # Whenever changing the nightly channel, update the commit hash above, and
 # change `REQUIRED_RUST_TOOLCHAIN` in `crates/rustc_codegen_spirv/build.rs` too.


### PR DESCRIPTION
`nightly-2026-04-11` is commit https://github.com/rust-lang/rust/commit/02c7f9bec0fd583160f8bcccb830216023b07bee
That's also the current `origin/beta` branch, which I'd assume is rustc 1.96.0 "branching" (even if the beta doesn't have any commits on top yet).