### PR TITLE
fix No OpEntryPoint for non-public entry points

### DIFF
--- a/crates/spirv-std/macros/src/lib.rs
+++ b/crates/spirv-std/macros/src/lib.rs
@@ -151,6 +151,19 @@ pub fn spirv(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut tokens = quote! { #[cfg_attr(target_arch="spirv", rust_gpu::#spirv(#attr))] };
 
     let item: proc_macro2::TokenStream = item.into();
+    // If the annotated item is a function without `pub`, automatically add it.
+    // SPIR-V entry points must be publicly visible to the codegen backend.
+    // Also emit `#[allow(missing_docs)]` so the forced-public visibility doesn't
+    // trigger the `missing_docs` lint on crates that have it enabled.
+    let item = if let Ok(mut func) = syn::parse2::<syn::ItemFn>(item.clone()) {
+        if !matches!(func.vis, syn::Visibility::Public(_)) {
+            func.vis = syn::parse_quote!(pub);
+            func.attrs.push(syn::parse_quote!(#[allow(missing_docs)]));
+        }
+        func.into_token_stream()
+    } else {
+        item
+    };
     for tt in item {
         match tt {
             TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis => {

--- a/tests/compiletests/ui/spirv-attr/entry-not-pub.rs
+++ b/tests/compiletests/ui/spirv-attr/entry-not-pub.rs
@@ -1,0 +1,9 @@
+// Tests that `#[spirv(...)]` entry-point functions don't need to be declared
+// `pub` — the macro adds it automatically.
+
+// build-pass
+
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+fn main() {}


### PR DESCRIPTION
fixes the confusing `No OpEntryPoint instruction was found` you get when entry point is private 
#293 