### PR TITLE
difftest: fix 5 difftests silently passing on zeroed inputs

### DIFF
--- a/tests/difftests/tests/arch/vector_extract_insert/vector_extract_insert-rust/src/main.rs
+++ b/tests/difftests/tests/arch/vector_extract_insert/vector_extract_insert-rust/src/main.rs
@@ -1,15 +1,32 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{RustComputeShader, WgpuComputeTestMultiBuffer};
+use difftest::scaffold::compute::{BufferConfig, RustComputeShader, WgpuComputeTestMultiBuffer};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        RustComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size, buffer_size],
-    );
+    // 64 vec4<f32> inputs with distinct component values so each dynamic
+    // extract/insert case produces an observable difference.
+    let input_data: Vec<[f32; 4]> = (0..64)
+        .map(|i| {
+            let base = i as f32 * 4.0;
+            [base + 1.0, base + 2.0, base + 3.0, base + 4.0]
+        })
+        .collect();
+
+    // The shader picks a switch case with `tid % 8` and a dynamic index with
+    // `indices[tid] % 4`. The 8 threads inside each case have tid stride 8,
+    // so `indices[i] = i / 8` makes them see all four `index % 4` values
+    // (0, 1, 2, 3, 0, 1, 2, 3) — any linear function of `i` would collapse
+    // to a single index per case.
+    let indices_data: Vec<u32> = (0..256).map(|i| (i as u32) / 8).collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::read_only(&indices_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(RustComputeShader::default(), [1, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/arch/vector_extract_insert/vector_extract_insert-wgsl/src/main.rs
+++ b/tests/difftests/tests/arch/vector_extract_insert/vector_extract_insert-wgsl/src/main.rs
@@ -1,15 +1,32 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{WgpuComputeTestMultiBuffer, WgslComputeShader};
+use difftest::scaffold::compute::{BufferConfig, WgpuComputeTestMultiBuffer, WgslComputeShader};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        WgslComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size, buffer_size],
-    );
+    // 64 vec4<f32> inputs with distinct component values so each dynamic
+    // extract/insert case produces an observable difference.
+    let input_data: Vec<[f32; 4]> = (0..64)
+        .map(|i| {
+            let base = i as f32 * 4.0;
+            [base + 1.0, base + 2.0, base + 3.0, base + 4.0]
+        })
+        .collect();
+
+    // The shader picks a switch case with `tid % 8` and a dynamic index with
+    // `indices[tid] % 4`. The 8 threads inside each case have tid stride 8,
+    // so `indices[i] = i / 8` makes them see all four `index % 4` values
+    // (0, 1, 2, 3, 0, 1, 2, 3) — any linear function of `i` would collapse
+    // to a single index per case.
+    let indices_data: Vec<u32> = (0..256).map(|i| (i as u32) / 8).collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::read_only(&indices_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(WgslComputeShader::default(), [1, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/control_flow_complex/control_flow_complex-rust/src/main.rs
+++ b/tests/difftests/tests/lang/control_flow_complex/control_flow_complex-rust/src/main.rs
@@ -1,15 +1,30 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{RustComputeShader, WgpuComputeTestMultiBuffer};
+use difftest::scaffold::compute::{BufferConfig, RustComputeShader, WgpuComputeTestMultiBuffer};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        RustComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size],
-    );
+    // 256 u32 inputs covering every branch of `process_value`.
+    let input_data: Vec<u32> = (0..256)
+        .map(|i| match i {
+            // Hits the `value == 0` early return.
+            0 => 0,
+            // Hit the `value > 1000` early return with differing subtraction magnitudes.
+            1 => 1001,
+            2 => 2500,
+            // Values 3..=255 cycle through all ten `value % 10` arms, straddle the
+            // `< 50` / `>= 50` split for the final transform, and keep case 9's
+            // `for i in 0..value` loop bounded.
+            _ => i as u32,
+        })
+        .collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(RustComputeShader::default(), [4, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/control_flow_complex/control_flow_complex-wgsl/src/main.rs
+++ b/tests/difftests/tests/lang/control_flow_complex/control_flow_complex-wgsl/src/main.rs
@@ -1,15 +1,30 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{WgpuComputeTestMultiBuffer, WgslComputeShader};
+use difftest::scaffold::compute::{BufferConfig, WgpuComputeTestMultiBuffer, WgslComputeShader};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        WgslComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size],
-    );
+    // 256 u32 inputs covering every branch of `process_value`.
+    let input_data: Vec<u32> = (0..256)
+        .map(|i| match i {
+            // Hits the `value == 0` early return.
+            0 => 0,
+            // Hit the `value > 1000` early return with differing subtraction magnitudes.
+            1 => 1001,
+            2 => 2500,
+            // Values 3..=255 cycle through all ten `value % 10` arms, straddle the
+            // `< 50` / `>= 50` split for the final transform, and keep case 9's
+            // `for i in 0..value` loop bounded.
+            _ => i as u32,
+        })
+        .collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(WgslComputeShader::default(), [4, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/core/ops/bitwise_ops/bitwise_ops-rust/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/bitwise_ops/bitwise_ops-rust/src/main.rs
@@ -1,15 +1,27 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{RustComputeShader, WgpuComputeTestMultiBuffer};
+use difftest::scaffold::compute::{BufferConfig, RustComputeShader, WgpuComputeTestMultiBuffer};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        RustComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size, buffer_size],
-    );
+    // `input_a` is mixed with the Fibonacci-hashing constant (fractional bits
+    // of 2^32 / golden ratio) so its bits spread across the full 32-bit range;
+    // plain `i` would give `leading_zeros >= 24` on every thread and hide most
+    // of the popcnt / ctlz / reverse_bits variation we're trying to diff.
+    // `input_b` is just `i`, which for the first workgroup gives `b % 32`
+    // values 0..31 so every shift / rotation amount is exercised.
+    let input_a: Vec<u32> = (0..256)
+        .map(|i| (i as u32).wrapping_mul(0x9E37_79B9))
+        .collect();
+    let input_b: Vec<u32> = (0..256).map(|i| i as u32).collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_a),
+        BufferConfig::read_only(&input_b),
+        BufferConfig::writeback(size_of_val(input_a.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(RustComputeShader::default(), [4, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/core/ops/bitwise_ops/bitwise_ops-wgsl/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/bitwise_ops/bitwise_ops-wgsl/src/main.rs
@@ -1,15 +1,27 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{WgpuComputeTestMultiBuffer, WgslComputeShader};
+use difftest::scaffold::compute::{BufferConfig, WgpuComputeTestMultiBuffer, WgslComputeShader};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        WgslComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size, buffer_size],
-    );
+    // `input_a` is mixed with the Fibonacci-hashing constant (fractional bits
+    // of 2^32 / golden ratio) so its bits spread across the full 32-bit range;
+    // plain `i` would give `leading_zeros >= 24` on every thread and hide most
+    // of the popcnt / ctlz / reverse_bits variation we're trying to diff.
+    // `input_b` is just `i`, which for the first workgroup gives `b % 32`
+    // values 0..31 so every shift / rotation amount is exercised.
+    let input_a: Vec<u32> = (0..256)
+        .map(|i| (i as u32).wrapping_mul(0x9E37_79B9))
+        .collect();
+    let input_b: Vec<u32> = (0..256).map(|i| i as u32).collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_a),
+        BufferConfig::read_only(&input_b),
+        BufferConfig::writeback(size_of_val(input_a.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(WgslComputeShader::default(), [4, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/core/ops/trig_ops/trig_ops-rust/src/lib.rs
+++ b/tests/difftests/tests/lang/core/ops/trig_ops/trig_ops-rust/src/lib.rs
@@ -21,8 +21,8 @@ pub fn main_cs(
             0 => x.sin(),
             1 => x.cos(),
             2 => x.tan(),
-            3 => x.asin().clamp(-1.0, 1.0), // Clamp to avoid NaN for values outside [-1, 1]
-            4 => x.acos().clamp(-1.0, 1.0), // Clamp to avoid NaN for values outside [-1, 1]
+            3 => x.clamp(-1.0, 1.0).asin(), // Clamp the input to asin's domain to avoid NaN
+            4 => x.clamp(-1.0, 1.0).acos(), // Clamp the input to acos's domain to avoid NaN
             5 => x.atan(),
             6 => x.sinh(),
             7 => x.cosh(),

--- a/tests/difftests/tests/lang/core/ops/trig_ops/trig_ops-rust/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/trig_ops/trig_ops-rust/src/main.rs
@@ -1,15 +1,29 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{RustComputeShader, WgpuComputeTestMultiBuffer};
+use difftest::scaffold::compute::{BufferConfig, RustComputeShader, WgpuComputeTestMultiBuffer};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        RustComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size],
-    );
+    // 256 f32 inputs spread across [-1.2, 1.2]. The range is deliberately
+    // kept away from ±π/2 so `tan` doesn't blow up, while still reaching
+    // outside [-1, 1] so the asin/acos clamp branches actually clamp.
+    let input_data: Vec<f32> = (0..256)
+        .map(|i| {
+            let t = (i as f32) / 255.0;
+            (t * 2.0 - 1.0) * 1.2
+        })
+        .collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(RustComputeShader::default(), [4, 1, 1], buffers);
+
+    config
+        .write_metadata(&difftest::config::TestMetadata::f32(1e-4))
+        .unwrap();
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/core/ops/trig_ops/trig_ops-wgsl/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/trig_ops/trig_ops-wgsl/src/main.rs
@@ -1,15 +1,29 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{WgpuComputeTestMultiBuffer, WgslComputeShader};
+use difftest::scaffold::compute::{BufferConfig, WgpuComputeTestMultiBuffer, WgslComputeShader};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        WgslComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size],
-    );
+    // 256 f32 inputs spread across [-1.2, 1.2]. The range is deliberately
+    // kept away from ±π/2 so `tan` doesn't blow up, while still reaching
+    // outside [-1, 1] so the asin/acos clamp branches actually clamp.
+    let input_data: Vec<f32> = (0..256)
+        .map(|i| {
+            let t = (i as f32) / 255.0;
+            (t * 2.0 - 1.0) * 1.2
+        })
+        .collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(WgslComputeShader::default(), [4, 1, 1], buffers);
+
+    config
+        .write_metadata(&difftest::config::TestMetadata::f32(1e-4))
+        .unwrap();
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/core/ops/vector_swizzle/vector_swizzle-rust/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/vector_swizzle/vector_swizzle-rust/src/main.rs
@@ -1,15 +1,25 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{RustComputeShader, WgpuComputeTestMultiBuffer};
+use difftest::scaffold::compute::{BufferConfig, RustComputeShader, WgpuComputeTestMultiBuffer};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        RustComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size],
-    );
+    // 64 vec4<f32> inputs with all four components distinct, so every
+    // swizzle permutation produces a different result (zeroed input would
+    // make e.g. `.xyzw` and `.wzyx` indistinguishable).
+    let input_data: Vec<[f32; 4]> = (0..64)
+        .map(|i| {
+            let base = i as f32 * 4.0;
+            [base + 1.0, base + 2.0, base + 3.0, base + 4.0]
+        })
+        .collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(RustComputeShader::default(), [1, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }

--- a/tests/difftests/tests/lang/core/ops/vector_swizzle/vector_swizzle-wgsl/src/main.rs
+++ b/tests/difftests/tests/lang/core/ops/vector_swizzle/vector_swizzle-wgsl/src/main.rs
@@ -1,15 +1,25 @@
 use difftest::config::Config;
-use difftest::scaffold::compute::{WgpuComputeTestMultiBuffer, WgslComputeShader};
+use difftest::scaffold::compute::{BufferConfig, WgpuComputeTestMultiBuffer, WgslComputeShader};
 
 fn main() {
     let config = Config::from_path(std::env::args().nth(1).unwrap()).unwrap();
 
-    let buffer_size = 1024;
-    let test = WgpuComputeTestMultiBuffer::new_with_sizes(
-        WgslComputeShader::default(),
-        [64, 1, 1],
-        &[buffer_size, buffer_size],
-    );
+    // 64 vec4<f32> inputs with all four components distinct, so every
+    // swizzle permutation produces a different result (zeroed input would
+    // make e.g. `.xyzw` and `.wzyx` indistinguishable).
+    let input_data: Vec<[f32; 4]> = (0..64)
+        .map(|i| {
+            let base = i as f32 * 4.0;
+            [base + 1.0, base + 2.0, base + 3.0, base + 4.0]
+        })
+        .collect();
+
+    let buffers = vec![
+        BufferConfig::read_only(&input_data),
+        BufferConfig::writeback(size_of_val(input_data.as_slice())),
+    ];
+
+    let test = WgpuComputeTestMultiBuffer::new(WgslComputeShader::default(), [1, 1, 1], buffers);
 
     test.run_test(&config).unwrap();
 }


### PR DESCRIPTION
Also fixes `trig_ops-rust` clamping asin's output instead of its input.