### PR TITLE
setup release-plz 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -285,11 +285,21 @@ jobs:
       - name: Run a full build
         run: cargo xtask test-build --rust-gpu-version ${{ matrix.rust-gpu-version }}
 
+  release-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: install rust-toolchain
+        run: echo "TARGET=$(rustc --print host-tuple)" >> "$GITHUB_ENV"
+      - name: cargo fetch --locked
+        run: cargo fetch --locked --target $TARGET
+      - run: cargo publish --dry-run
+
   # This allows us to have a single job we can branch protect on, rather than needing
   # to update the branch protection rules when the test matrix changes
   test_success:
     runs-on: ubuntu-latest
-    needs: [test, compiletest, difftest, android, lint, cargo-deny, cargo-gpu-os, cargo-gpu-backwards-compat]
+    needs: [test, compiletest, difftest, android, lint, cargo-deny, release-dry-run, cargo-gpu-os, cargo-gpu-backwards-compat]
     # Hack for buggy GitHub Actions behavior with skipped checks: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
     if: ${{ always() }}
     steps:
@@ -302,6 +312,7 @@ jobs:
           [[ "${{ needs.android.result }}" == "success" ]] || exit 1
           [[ "${{ needs.lint.result }}" == "success" ]] || exit 1
           [[ "${{ needs.cargo-deny.result }}" == "success" ]] || exit 1
+          [[ "${{ needs.release-dry-run.result }}" == "success" ]] || exit 1
           [[ "${{ needs.cargo-gpu-os.result }}" == "success" ]] || exit 1
           [[ "${{ needs.cargo-gpu-backwards-compat.result }}" == "success" ]] || exit 1
 

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,8 +18,7 @@ jobs:
       pull-requests: read
       id-token: write
     steps:
-      - &checkout
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -47,11 +46,48 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - *checkout
+      # `persist-credentials: true` so the follow-up step below can push to
+      # the release PR. See https://release-plz.dev/docs/github/output#example-commit-files-to-the-release-pr
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+          submodules: true
       - *install-rust
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The difftest workspace pulls `spirv-std` / `spirv-builder` via path
+      # deps, so its `Cargo.lock` references their versions. release-plz only
+      # bumps the root workspace, so we update the difftest lockfile here and
+      # push it onto the release PR before CI runs against it.
+      - name: Update difftest Cargo.lock in release PR
+        if: ${{ steps.release-plz.outputs.prs_created == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.release-plz.outputs.pr }}
+          # `rust-toolchain.toml` pins nightly; force stable so rustup doesn't
+          # auto-install ~1GB of nightly + components just to update a lockfile.
+          RUSTUP_TOOLCHAIN: stable
+        run: |
+          set -euo pipefail
+          pr_number=$(echo "$PR" | jq -r '.number')
+          gh pr checkout "$pr_number"
+          cargo update --manifest-path tests/difftests/tests/Cargo.toml \
+            -p spirv-std \
+            -p spirv-std-macros \
+            -p spirv-std-types \
+            -p spirv-builder \
+            -p rustc_codegen_spirv-types
+          if ! git diff --quiet tests/difftests/tests/Cargo.lock; then
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
+            git add tests/difftests/tests/Cargo.lock
+            git commit -m "chore: update difftest Cargo.lock"
+            git push
+          fi

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -6,6 +6,7 @@ body = """
 [workspace]
 changelog_update = false
 git_tag_enable = false
+git_release_enable = false
 
 [[package]]
 name = "spirv-std"
@@ -13,5 +14,6 @@ changelog_update = true
 changelog_include = ["spirv-std-macros", "spirv-std-types", "spirv-builder", "rustc_codegen_spirv", "rustc_codegen_spirv-types", "cargo-gpu", "cargo-gpu-install"]
 changelog_path = "CHANGELOG.md"
 git_tag_enable = true
-git_release_name = "v{{ version }}"
 git_tag_name = "v{{ version }}"
+git_release_enable = true
+git_release_name = "v{{ version }}"


### PR DESCRIPTION
various bug fixes for release-plz after the [first release](https://github.com/Rust-GPU/rust-gpu/pull/564) 
* only create one github release for all crates formatted as `v{version}`, eg. `v0.10.0-alpha.1`
  * I manually removed the per-crate tags of the first release
* add a `release-dry-run` action that `cargo publish --dry-run`
  * this would fail prior to our `alpha.1` release due to us adding a new feature to a crate and another crate depending on it, but as dry-run uses only crates releases, the latter crate would fail to build due to that feature not existing in the crates release
* update the difftest `Cargo.lock` on the release PR by checking it out after release-plz creates it and pushing a follow-up `cargo update` commit (per the [release-plz docs](https://release-plz.dev/docs/github/output#example-commit-files-to-the-release-pr)), so CI on the release PR runs against a consistent lockfile (relates to https://github.com/release-plz/release-plz/issues/2805)