### PR TITLE
support memset on 128-bit integers

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -308,6 +308,11 @@ fn memset_fill_u64(b: u8) -> u64 {
         | ((b as u64) << 56)
 }
 
+fn memset_fill_u128(b: u8) -> u128 {
+    let b64 = memset_fill_u64(b) as u128;
+    b64 | b64 >> 64
+}
+
 fn memset_dynamic_scalar(
     builder: &mut Builder<'_, '_>,
     fill_var: Word,
@@ -387,6 +392,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 64 => self
                     .constant_u64(self.span(), memset_fill_u64(fill_byte))
                     .def(self),
+                128 => self
+                    .constant_u128(self.span(), memset_fill_u128(fill_byte))
+                    .def(self),
                 _ => self.fatal(format!(
                     "memset on integer width {width} not implemented yet"
                 )),
@@ -401,6 +409,9 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .def(self),
                 64 => self
                     .constant_i64(self.span(), memset_fill_u64(fill_byte) as i64)
+                    .def(self),
+                128 => self
+                    .constant_u128(self.span(), memset_fill_u128(fill_byte))
                     .def(self),
                 _ => self.fatal(format!(
                     "memset on integer width {width} not implemented yet"

--- a/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
+++ b/crates/rustc_codegen_spirv/src/codegen_cx/constant.rs
@@ -50,6 +50,10 @@ impl<'tcx> CodegenCx<'tcx> {
         self.constant_int_from_native_unsigned(span, val)
     }
 
+    pub fn constant_u128(&self, span: Span, val: u128) -> SpirvValue {
+        self.constant_int_from_native_unsigned(span, val)
+    }
+
     fn constant_int_from_native_unsigned(&self, span: Span, val: impl Into<u128>) -> SpirvValue {
         let size = Size::from_bytes(std::mem::size_of_val(&val));
         let ty = SpirvType::Integer(size.bits() as u32, false).def(span, self);

--- a/tests/compiletests/ui/lang/core/array/init_array_i128.rs
+++ b/tests/compiletests/ui/lang/core/array/init_array_i128.rs
@@ -1,0 +1,14 @@
+// build-pass
+
+use spirv_std::spirv;
+
+pub fn u128_constant() -> [u128; 4] {
+    return [0x123456789ABCDEF0123456789ABCDEF; 4];
+}
+
+pub fn i128_constant() -> [i128; 4] {
+    return [0x123456789ABCDEF0123456789ABCDEF; 4];
+}
+
+#[spirv(fragment)]
+pub fn main() {}

--- a/tests/compiletests/ui/lang/core/array/init_array_i128_zeroed.rs
+++ b/tests/compiletests/ui/lang/core/array/init_array_i128_zeroed.rs
@@ -1,0 +1,23 @@
+// build-pass
+
+use spirv_std::spirv;
+
+/// `crypto-common` has a proc macro to implement code for u8, u16, u32, u16 and u128,
+/// which means we need our codegen to handle the u128 case for the crate to even compile.
+/// Specifically, this calls `memset_const_pattern` with u128.
+///
+/// <https://github.com/RustCrypto/traits/blob/d9067c494b4ae8f1ecbc9ae72b683e8a65dd53ce/crypto-common/src/hazmat.rs#L347-L363>
+///
+/// Note that the u128 path is unusable anyway as 128-bit integer are not supported in SPIR-V.
+/// So if this is used nowhere in any entry point, our post-link DCE will remove the u128 code,
+/// and the SPIR-V will be valid.
+pub fn u128_zero_fill() -> [u128; 4] {
+    return [0; 4];
+}
+
+pub fn i128_zero_fill() -> [i128; 4] {
+    return [0; 4];
+}
+
+#[spirv(fragment)]
+pub fn main() {}


### PR DESCRIPTION
__resolves #594__

This is a quick solution to support the case I described in #594:

```rs
pub fn new_array_zero_fill_u128() -> [u128; 4] {
    return [0; 4];
}
```

This proposal would help me get past the first build issue I have encountered with RustCrypto.

I would love to support non-zero memset fill for both `u128` & `i128` as discussed in #594, but this would involve some more work in testing to hopefully ensure that this is done correctly & not likely broken by potential future refactoring.

_I would be happy to address any possible feedback on my first contribution to Rust-GPU._

### TODO

- [x] ~~squash commits before merging - Reviewers please let me know if you want me to do this or if you want to do this yourself~~