### PR TITLE
ci: fix docs script

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -17,6 +17,6 @@ function doc() {
 }
 
 # Core crates only!
-cargo doc --manifest-path "crates/spirv-std/Cargo.toml" --all-features
+cargo doc --manifest-path "crates/spirv-std/Cargo.toml"
 doc crates/rustc_codegen_spirv
 doc crates/spirv-builder


### PR DESCRIPTION
> Docs failed to build with these changes: https://github.com/Rust-GPU/rust-gpu/actions/runs/27157018177/job/80162386469

https://github.com/Rust-GPU/rust-gpu/pull/609#issuecomment-4651962049

https://github.com/Rust-GPU/rust-gpu/pull/609 added mutually exclusive features (`glam_0_33`, `glam_0_32`, etc.) and the script passes `--all-features`, which ofc fails... so let's just do default features