### PR TITLE
Add Git information to cargo-gpu's `--version` CLI subcommand

### DIFF
--- a/crates/cargo-gpu/Cargo.toml
+++ b/crates/cargo-gpu/Cargo.toml
@@ -23,6 +23,10 @@ serde_json.workspace = true
 semver.workspace = true
 dunce.workspace = true
 
+[build-dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
 [dev-dependencies]
 cargo-gpu-install = { workspace = true, features = ["test"] }
 test-log.workspace = true

--- a/crates/cargo-gpu/build.rs
+++ b/crates/cargo-gpu/build.rs
@@ -1,9 +1,26 @@
 //! cargo-gpu build script.
 
+use serde_json::Value;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 
 fn main() {
+    compute_version_extra();
+}
+
+fn compute_version_extra() {
+    let extra = version_crates_io()
+        .or_else(version_git)
+        .unwrap_or(String::from(" installed from unknown source"));
+
+    std::fs::write(
+        PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("version_extra"),
+        extra,
+    )
+    .unwrap();
+}
+
+fn version_git() -> Option<String> {
     if let Some(git_directory) = invoke_git(["rev-parse", "--git-dir"]) {
         println!("cargo:rerun-if-changed={git_directory}/HEAD");
     }
@@ -17,20 +34,15 @@ fn main() {
         "HEAD",
     ]);
 
-    let extra = if let Some(git_rev) = git_rev
+    if let Some(rev) = git_rev
         && let Some(git_date) = git_date
     {
-        let git_rev = git_rev.get(..8).unwrap_or(&git_rev);
+        let rev = rev.get(..8).unwrap_or(&rev);
         let git_date = git_date.strip_suffix("\n").unwrap_or(&git_date);
-        format!(" ({git_rev} {git_date})")
+        Some(format!(" installed from repo at rev {rev} ({git_date})"))
     } else {
-        " (installed from crates.io)".into()
-    };
-    std::fs::write(
-        PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("version_extra"),
-        extra,
-    )
-    .unwrap();
+        None
+    }
 }
 
 fn invoke_git<I, S>(args: I) -> Option<String>
@@ -43,4 +55,16 @@ where
         .output()
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
+}
+
+/// `cargo package` adds the `.cargo_vcs_info.json` file on it's own, let's just use that to resolve the rev
+fn version_crates_io() -> Option<String> {
+    let json = std::fs::read_to_string(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(".cargo_vcs_info.json"),
+    )
+    .ok()?;
+    let value = serde_json::from_str::<Value>(&json).ok()?;
+    let rev = value.get("git")?.get("sha1")?.as_str()?;
+    let rev = rev.get(..8).unwrap_or(rev);
+    Some(format!(" installed from crates.io (rev {rev})"))
 }

--- a/crates/cargo-gpu/build.rs
+++ b/crates/cargo-gpu/build.rs
@@ -1,12 +1,33 @@
 //! cargo-gpu build script.
 
+use std::ffi::OsStr;
+
 fn main() {
-    let git_hash = std::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .map_or_else(
-            |_| "unknown".to_owned(),
-            |output| String::from_utf8(output.stdout).unwrap_or_else(|_| "unknown".to_owned()),
-        );
+    let git_directory = invoke_git(["rev-parse", "--git-dir"]);
+    println!("cargo:rerun-if-changed={git_directory}/HEAD");
+
+    let git_hash = invoke_git(["rev-parse", "HEAD"]);
     println!("cargo:rustc-env=GIT_HASH={git_hash}");
+
+    let git_date = invoke_git([
+        "show",
+        "-s",
+        "--format=%cd",
+        "--date=format:%Y-%m-%d",
+        "HEAD",
+    ]);
+    println!("cargo:rustc-env=GIT_DATE={git_date}");
+}
+
+fn invoke_git<I, S>(args: I) -> String
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    std::process::Command::new("git")
+        .args(args)
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .unwrap_or_else(|| "unknown".to_owned())
 }

--- a/crates/cargo-gpu/build.rs
+++ b/crates/cargo-gpu/build.rs
@@ -1,14 +1,14 @@
 //! cargo-gpu build script.
 
 use std::ffi::OsStr;
+use std::path::PathBuf;
 
 fn main() {
-    let git_directory = invoke_git(["rev-parse", "--git-dir"]);
-    println!("cargo:rerun-if-changed={git_directory}/HEAD");
+    if let Some(git_directory) = invoke_git(["rev-parse", "--git-dir"]) {
+        println!("cargo:rerun-if-changed={git_directory}/HEAD");
+    }
 
-    let git_hash = invoke_git(["rev-parse", "HEAD"]);
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
-
+    let git_rev = invoke_git(["rev-parse", "HEAD"]);
     let git_date = invoke_git([
         "show",
         "-s",
@@ -16,10 +16,24 @@ fn main() {
         "--date=format:%Y-%m-%d",
         "HEAD",
     ]);
-    println!("cargo:rustc-env=GIT_DATE={git_date}");
+
+    let extra = if let Some(git_rev) = git_rev
+        && let Some(git_date) = git_date
+    {
+        let git_rev = git_rev.get(..8).unwrap_or(&git_rev);
+        let git_date = git_date.strip_suffix("\n").unwrap_or(&git_date);
+        format!(" ({git_rev} {git_date})")
+    } else {
+        " (installed from crates.io)".into()
+    };
+    std::fs::write(
+        PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("version_extra"),
+        extra,
+    )
+    .unwrap();
 }
 
-fn invoke_git<I, S>(args: I) -> String
+fn invoke_git<I, S>(args: I) -> Option<String>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
@@ -29,5 +43,4 @@ where
         .output()
         .ok()
         .and_then(|output| String::from_utf8(output.stdout).ok())
-        .unwrap_or_else(|| "unknown".to_owned())
 }

--- a/crates/cargo-gpu/src/lib.rs
+++ b/crates/cargo-gpu/src/lib.rs
@@ -153,7 +153,7 @@ impl Command {
 
 /// the Cli struct representing the main cli
 #[derive(clap::Parser)]
-#[clap(author, version, about, subcommand_required = true)]
+#[clap(author, version, long_version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), "; ", env!("GIT_DATE"), ")"), about, subcommand_required = true)]
 #[non_exhaustive]
 pub struct Cli {
     /// The command to run.

--- a/crates/cargo-gpu/src/lib.rs
+++ b/crates/cargo-gpu/src/lib.rs
@@ -153,10 +153,17 @@ impl Command {
 
 /// the Cli struct representing the main cli
 #[derive(clap::Parser)]
-#[clap(author, version, long_version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), "; ", env!("GIT_DATE"), ")"), about, subcommand_required = true)]
+#[clap(author, version = VERSION, about, subcommand_required = true)]
 #[non_exhaustive]
 pub struct Cli {
     /// The command to run.
     #[clap(subcommand)]
     pub command: Command,
 }
+
+const VERSION: &str = {
+    concat!(
+        env!("CARGO_PKG_VERSION"),
+        include_str!(concat!(env!("OUT_DIR"), "/version_extra")),
+    )
+};

--- a/crates/cargo-gpu/src/show.rs
+++ b/crates/cargo-gpu/src/show.rs
@@ -20,8 +20,6 @@ pub enum Info {
     CacheDirectory,
     /// The source location of spirv-std
     SpirvSource(SpirvSourceDep),
-    /// The git commitsh of this cli tool.
-    Commitsh,
     /// All the available SPIR-V capabilities that can be set with `--capabilities`
     Capabilities,
 }
@@ -52,9 +50,6 @@ impl Show {
                 let metadata = CrateMetadata::query(shader_crate.clone())?;
                 let rust_gpu_source = SpirvSource::get_rust_gpu_deps_from_shader(&metadata)?;
                 println!("{rust_gpu_source}\n");
-            }
-            Info::Commitsh => {
-                println!("{}", env!("GIT_HASH"));
             }
             Info::Capabilities => {
                 println!("All available options to the `cargo gpu build --capabilities` argument:");


### PR DESCRIPTION
Old:

```bash
$ cargo-gpu --version
cargo-gpu 0.10.0-alpha.1
```

New:

```bash
$ cargo-gpu --version
cargo-gpu 0.10.0-alpha.1 installed from crates.io (rev d95ec972)

$ cargo-gpu --version
cargo-gpu 0.10.0-alpha.1 installed from repo at rev d95ec972 (2026-07-16)

$ cargo-gpu --version
cargo-gpu 0.10.0-alpha.1 installed from unknown source
```