### PR TITLE
Support memset on structs

### DIFF
--- a/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
+++ b/crates/rustc_codegen_spirv/src/builder/builder_methods.rs
@@ -431,7 +431,16 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                     .def(self),
                 _ => self.fatal(format!("memset on float width {width} not implemented yet")),
             },
-            SpirvType::Adt { .. } => self.fatal("memset on structs not implemented yet"),
+            SpirvType::Adt { field_types, .. } => {
+                let field_pats: Vec<_> = field_types
+                    .iter()
+                    .map(|&field_ty| {
+                        self.memset_const_pattern(&self.lookup_type(field_ty), fill_byte)
+                    })
+                    .collect();
+                self.constant_composite(ty.def(self.span(), self), field_pats.into_iter())
+                    .def(self)
+            }
             SpirvType::Vector { element, count, .. } | SpirvType::Matrix { element, count } => {
                 let elem_pat = self.memset_const_pattern(&self.lookup_type(element), fill_byte);
                 self.constant_composite(
@@ -485,7 +494,17 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 64 => memset_dynamic_scalar(self, fill_var, 8, true),
                 _ => self.fatal(format!("memset on float width {width} not implemented yet")),
             },
-            SpirvType::Adt { .. } => self.fatal("memset on structs not implemented yet"),
+            SpirvType::Adt { field_types, .. } => {
+                let field_pats: Vec<_> = field_types
+                    .iter()
+                    .map(|&field_ty| {
+                        self.memset_dynamic_pattern(&self.lookup_type(field_ty), fill_var)
+                    })
+                    .collect();
+                self.emit()
+                    .composite_construct(ty.def(self.span(), self), None, field_pats)
+                    .unwrap()
+            }
             SpirvType::Array { element, count } => {
                 let elem_pat = self.memset_dynamic_pattern(&self.lookup_type(element), fill_var);
                 let count = self.builder.lookup_const_scalar(count).unwrap() as usize;

--- a/tests/compiletests/ui/lang/core/struct/init_struct_zeroed.rs
+++ b/tests/compiletests/ui/lang/core/struct/init_struct_zeroed.rs
@@ -1,0 +1,39 @@
+// build-pass
+
+use spirv_std::spirv;
+
+/// Regression test for `memset` on structs, which used to `fatal!("memset on structs not
+/// implemented yet")`. `core::ptr::write_bytes` on a struct-typed pointer (as used internally
+/// by e.g. `core::mem::zeroed::<T>()`) lowers to a single `memset` whose pointee type is the
+/// struct itself, rather than one of its fields.
+///
+/// <https://github.com/Rust-GPU/rust-gpu/issues/328>
+#[derive(Clone, Copy)]
+pub struct Foo {
+    a: u32,
+    b: [u8; 7],
+    c: u64,
+}
+
+/// Exercises `memset_const_pattern` for `SpirvType::Adt`, since both the fill byte and the size
+/// are known at compile time.
+pub fn zeroed_struct() -> Foo {
+    unsafe { core::mem::zeroed() }
+}
+
+/// Exercises `memset_dynamic_pattern` for `SpirvType::Adt`, since the fill byte is not known at
+/// compile time.
+pub fn filled_struct(byte: u8) -> Foo {
+    let mut foo = Foo {
+        a: 0,
+        b: [0; 7],
+        c: 0,
+    };
+    unsafe {
+        core::ptr::write_bytes(&mut foo, byte, 1);
+    }
+    foo
+}
+
+#[spirv(fragment)]
+pub fn main() {}


### PR DESCRIPTION
I decided to ask Claude to fix https://github.com/Rust-GPU/rust-gpu/issues/312 and it turned out fairly simple.

Here is LLM-generated description of changes:
> Implement memset_const_pattern and memset_dynamic_pattern for SpirvType::Adt by recursively building a fill pattern per field and composing them into a struct constant/composite, instead of hitting `fatal!("memset on structs not implemented yet")`.
>
> This unblocks crates that zero-init or byte-fill whole structs (e.g. `core::mem::zeroed::<T>()` on a struct type), such as the blake3 crate hitting this on `self.buf = [0; BLOCK_LEN]`.


With this change I can add `blake3` crate to dependencies and things continue to compile without issues, while previously I was hitting an error like this:
```
  error: memset on structs not implemented yet
     --> /home/nazar-pc/.cargo/git/checkouts/blake3-697b574540d368df/c7f0d21/src/lib.rs:550:17
      |
  550 |                 self.buf = [0; BLOCK_LEN];
      |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
```

Fixes https://github.com/Rust-GPU/rust-gpu/issues/312, closes https://github.com/Rust-GPU/rust-gpu/pull/328