### PR TITLE
Use `adt_const_params` for `Scope` and `Semantics` const generics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -380,10 +380,11 @@ jobs:
         run: cargo fmt --check --all --manifest-path tests/difftests/tests/Cargo.toml
       - name: Check docs are valid
         run: RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps
-      - name: Check docs for `spirv-std` and `spirv-builder` on stable (for docs.rs)
-        run: |
-          RUSTDOCFLAGS=-Dwarnings cargo +stable doc --no-deps -p spirv-std
-          RUSTDOCFLAGS=-Dwarnings cargo +stable doc --no-deps -p spirv-builder --no-default-features
+      # TODO: Stable is not supported due to use of nightly features
+      # - name: Check docs for `spirv-std` and `spirv-builder` on stable (for docs.rs)
+      #   run: |
+      #     RUSTDOCFLAGS=-Dwarnings cargo +stable doc --no-deps -p spirv-std
+      #     RUSTDOCFLAGS=-Dwarnings cargo +stable doc --no-deps -p spirv-builder --no-default-features
       - name: cargo clippy
         run: cargo clippy --all-targets -- -D warnings
       - name: custom lints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Changed 🛠
+
+- [PR#635](https://github.com/Rust-GPU/rust-gpu/pull/635) started using `Scope`- and `Semantics`-typed const generics (`control_barrier`, `memory_barrier`, atomic intrinsics, `read_clock_khr`/`read_clock_uvec2_khr`) now take `spirv_std::memory::Scope`/`Semantics` directly (e.g. `{ Scope::Workgroup }`, `{ Semantics::WORKGROUP_MEMORY.union(Semantics::ACQUIRE_RELEASE) }`) instead of raw `u32` bit patterns, using `adt_const_params`. Composing `Semantics` flags now compiles with an assertion that at most one memory-ordering flag (`ACQUIRE`/`RELEASE`/`ACQUIRE_RELEASE`/`SEQUENTIALLY_CONST`) is set, per the SPIR-V spec.
+
 ## [0.10.0-alpha.1](https://github.com/Rust-GPU/rust-gpu/compare/v0.9.0...v0.10.0-alpha.1) - 2026-04-13
 
 Toolchain: `nightly-2026-04-11` (rustc 1.96.0)

--- a/crates/spirv-std/src/arch.rs
+++ b/crates/spirv-std/src/arch.rs
@@ -6,6 +6,7 @@
 #[cfg(target_arch = "spirv")]
 use crate::Integer;
 use crate::glam::UVec2;
+use crate::memory::Scope;
 use crate::{Scalar, SignedInteger, UnsignedInteger, Vector};
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
@@ -150,7 +151,7 @@ pub fn kill() -> ! {
 /// <https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_shader_clock.html>
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpReadClockKHR")]
-pub fn read_clock_khr<const SCOPE: u32>() -> u64 {
+pub fn read_clock_khr<const SCOPE: Scope>() -> u64 {
     unsafe {
         let mut result: u64;
 
@@ -159,7 +160,7 @@ pub fn read_clock_khr<const SCOPE: u32>() -> u64 {
             "%scope = OpConstant %uint {scope}",
             "{result} = OpReadClockKHR typeof*{result} %scope",
             result = out(reg) result,
-            scope = const SCOPE,
+            scope = const { SCOPE as u32 },
         };
 
         result
@@ -172,7 +173,7 @@ pub fn read_clock_khr<const SCOPE: u32>() -> u64 {
 /// bits and the second component containing the 32 most significant bits.'
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpReadClockKHR")]
-pub fn read_clock_uvec2_khr<const SCOPE: u32>() -> UVec2 {
+pub fn read_clock_uvec2_khr<const SCOPE: Scope>() -> UVec2 {
     unsafe {
         let mut result = UVec2::default();
 
@@ -182,7 +183,7 @@ pub fn read_clock_uvec2_khr<const SCOPE: u32>() -> UVec2 {
             "%result = OpReadClockKHR typeof*{result} %scope",
             "OpStore {result} %result",
             result = in(reg) &mut result,
-            scope = const SCOPE,
+            scope = const { SCOPE as u32 },
         };
 
         result

--- a/crates/spirv-std/src/arch/atomics.rs
+++ b/crates/spirv-std/src/arch/atomics.rs
@@ -1,6 +1,7 @@
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
 
+use crate::memory::{Scope, Semantics};
 use crate::{Float, Integer, Number, SignedInteger, UnsignedInteger};
 
 /// Atomically load through `ptr` using the given `SEMANTICS`. All subparts of
@@ -9,7 +10,8 @@ use crate::{Float, Integer, Number, SignedInteger, UnsignedInteger};
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicLoad")]
 #[inline]
-pub unsafe fn atomic_load<N: Number, const SCOPE: u32, const SEMANTICS: u32>(ptr: &N) -> N {
+pub unsafe fn atomic_load<N: Number, const SCOPE: Scope, const SEMANTICS: Semantics>(ptr: &N) -> N {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut result = N::default();
 
@@ -19,8 +21,8 @@ pub unsafe fn atomic_load<N: Number, const SCOPE: u32, const SEMANTICS: u32>(ptr
             "%semantics = OpConstant %u32 {semantics}",
             "%result = OpAtomicLoad _ {ptr} %scope %semantics",
             "OpStore {result} %result",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             result = in(reg) &mut result
         }
@@ -35,10 +37,11 @@ pub unsafe fn atomic_load<N: Number, const SCOPE: u32, const SEMANTICS: u32>(ptr
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicStore")]
 #[inline]
-pub unsafe fn atomic_store<N: Number, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_store<N: Number, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut N,
     value: N,
 ) {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         asm! {
             "%u32 = OpTypeInt 32 0",
@@ -46,8 +49,8 @@ pub unsafe fn atomic_store<N: Number, const SCOPE: u32, const SEMANTICS: u32>(
             "%semantics = OpConstant %u32 {semantics}",
             "%value = OpLoad _ {value}",
             "OpAtomicStore {ptr} %scope %semantics %value",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             value = in(reg) &value
         }
@@ -65,10 +68,11 @@ pub unsafe fn atomic_store<N: Number, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicExchange")]
 #[inline]
-pub unsafe fn atomic_exchange<N: Number, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_exchange<N: Number, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut N,
     value: N,
 ) -> N {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = N::default();
 
@@ -79,8 +83,8 @@ pub unsafe fn atomic_exchange<N: Number, const SCOPE: u32, const SEMANTICS: u32>
             "%value = OpLoad _ {value}",
             "%old = OpAtomicExchange _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -105,14 +109,19 @@ pub unsafe fn atomic_exchange<N: Number, const SCOPE: u32, const SEMANTICS: u32>
 #[inline]
 pub unsafe fn atomic_compare_exchange<
     I: Integer,
-    const SCOPE: u32,
-    const EQUAL: u32,
-    const UNEQUAL: u32,
+    const SCOPE: Scope,
+    const EQUAL: Semantics,
+    const UNEQUAL: Semantics,
 >(
     ptr: &mut I,
     value: I,
     comparator: I,
 ) -> I {
+    const {
+        EQUAL.assert_valid();
+        UNEQUAL.assert_valid();
+    }
+
     unsafe {
         let mut old = I::default();
 
@@ -125,9 +134,9 @@ pub unsafe fn atomic_compare_exchange<
             "%comparator = OpLoad _ {comparator}",
             "%old = OpAtomicCompareExchange _ {ptr} %scope %equal %unequal %value %comparator",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            equal = const EQUAL,
-            unequal = const UNEQUAL,
+            scope = const { SCOPE as u32 },
+            equal = const { EQUAL.bits() },
+            unequal = const { UNEQUAL.bits() },
             ptr = in(reg) ptr,
             value = in(reg) &value,
             comparator = in(reg) &comparator,
@@ -149,9 +158,10 @@ pub unsafe fn atomic_compare_exchange<
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicIIncrement")]
 #[inline]
-pub unsafe fn atomic_i_increment<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_i_increment<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut I,
 ) -> I {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = I::default();
 
@@ -161,8 +171,8 @@ pub unsafe fn atomic_i_increment<I: Integer, const SCOPE: u32, const SEMANTICS: 
             "%semantics = OpConstant %u32 {semantics}",
             "%old = OpAtomicIIncrement _ {ptr} %scope %semantics",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old
         }
@@ -182,9 +192,10 @@ pub unsafe fn atomic_i_increment<I: Integer, const SCOPE: u32, const SEMANTICS: 
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicIDecrement")]
 #[inline]
-pub unsafe fn atomic_i_decrement<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_i_decrement<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut I,
 ) -> I {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = I::default();
 
@@ -194,8 +205,8 @@ pub unsafe fn atomic_i_decrement<I: Integer, const SCOPE: u32, const SEMANTICS: 
             "%semantics = OpConstant %u32 {semantics}",
             "%old = OpAtomicIDecrement _ {ptr} %scope %semantics",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old
         }
@@ -215,10 +226,11 @@ pub unsafe fn atomic_i_decrement<I: Integer, const SCOPE: u32, const SEMANTICS: 
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicIAdd")]
 #[inline]
-pub unsafe fn atomic_i_add<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_i_add<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut I,
     value: I,
 ) -> I {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = I::default();
 
@@ -229,8 +241,8 @@ pub unsafe fn atomic_i_add<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicIAdd _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -251,10 +263,11 @@ pub unsafe fn atomic_i_add<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicISub")]
 #[inline]
-pub unsafe fn atomic_i_sub<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_i_sub<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut I,
     value: I,
 ) -> I {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = I::default();
 
@@ -265,8 +278,8 @@ pub unsafe fn atomic_i_sub<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicISub _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -288,10 +301,11 @@ pub unsafe fn atomic_i_sub<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicSMin")]
 #[inline]
-pub unsafe fn atomic_s_min<S: SignedInteger, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_s_min<S: SignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut S,
     value: S,
 ) -> S {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = S::default();
 
@@ -302,8 +316,8 @@ pub unsafe fn atomic_s_min<S: SignedInteger, const SCOPE: u32, const SEMANTICS: 
             "%value = OpLoad _ {value}",
             "%old = OpAtomicSMin _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -325,10 +339,11 @@ pub unsafe fn atomic_s_min<S: SignedInteger, const SCOPE: u32, const SEMANTICS: 
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicUMin")]
 #[inline]
-pub unsafe fn atomic_u_min<U: UnsignedInteger, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_u_min<U: UnsignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut U,
     value: U,
 ) -> U {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = U::default();
 
@@ -339,8 +354,8 @@ pub unsafe fn atomic_u_min<U: UnsignedInteger, const SCOPE: u32, const SEMANTICS
             "%value = OpLoad _ {value}",
             "%old = OpAtomicUMin _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -362,10 +377,11 @@ pub unsafe fn atomic_u_min<U: UnsignedInteger, const SCOPE: u32, const SEMANTICS
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicSMax")]
 #[inline]
-pub unsafe fn atomic_s_max<S: SignedInteger, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_s_max<S: SignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut S,
     value: S,
 ) -> S {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = S::default();
 
@@ -376,8 +392,8 @@ pub unsafe fn atomic_s_max<S: SignedInteger, const SCOPE: u32, const SEMANTICS: 
             "%value = OpLoad _ {value}",
             "%old = OpAtomicSMax _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -399,10 +415,11 @@ pub unsafe fn atomic_s_max<S: SignedInteger, const SCOPE: u32, const SEMANTICS: 
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicUMax")]
 #[inline]
-pub unsafe fn atomic_u_max<U: UnsignedInteger, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_u_max<U: UnsignedInteger, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut U,
     value: U,
 ) -> U {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = U::default();
 
@@ -413,8 +430,8 @@ pub unsafe fn atomic_u_max<U: UnsignedInteger, const SCOPE: u32, const SEMANTICS
             "%value = OpLoad _ {value}",
             "%old = OpAtomicUMax _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -435,10 +452,11 @@ pub unsafe fn atomic_u_max<U: UnsignedInteger, const SCOPE: u32, const SEMANTICS
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicAnd")]
 #[inline]
-pub unsafe fn atomic_and<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_and<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut I,
     value: I,
 ) -> I {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = I::default();
 
@@ -449,8 +467,8 @@ pub unsafe fn atomic_and<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicAnd _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -471,10 +489,11 @@ pub unsafe fn atomic_and<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicOr")]
 #[inline]
-pub unsafe fn atomic_or<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_or<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut I,
     value: I,
 ) -> I {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = I::default();
 
@@ -485,8 +504,8 @@ pub unsafe fn atomic_or<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicOr _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -507,10 +526,11 @@ pub unsafe fn atomic_or<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicXor")]
 #[inline]
-pub unsafe fn atomic_xor<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_xor<I: Integer, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut I,
     value: I,
 ) -> I {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = I::default();
 
@@ -521,8 +541,8 @@ pub unsafe fn atomic_xor<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicXor _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -544,10 +564,11 @@ pub unsafe fn atomic_xor<I: Integer, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicFMinEXT")]
 #[inline]
-pub unsafe fn atomic_f_min<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_f_min<F: Float, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut F,
     value: F,
 ) -> F {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = F::default();
 
@@ -558,8 +579,8 @@ pub unsafe fn atomic_f_min<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicFMinEXT _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -581,10 +602,11 @@ pub unsafe fn atomic_f_min<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicFMaxEXT")]
 #[inline]
-pub unsafe fn atomic_f_max<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_f_max<F: Float, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut F,
     value: F,
 ) -> F {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = F::default();
 
@@ -595,8 +617,8 @@ pub unsafe fn atomic_f_max<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicFMaxEXT _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value
@@ -617,10 +639,11 @@ pub unsafe fn atomic_f_max<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpAtomicFAddEXT")]
 #[inline]
-pub unsafe fn atomic_f_add<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
+pub unsafe fn atomic_f_add<F: Float, const SCOPE: Scope, const SEMANTICS: Semantics>(
     ptr: &mut F,
     value: F,
 ) -> F {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         let mut old = F::default();
 
@@ -631,8 +654,8 @@ pub unsafe fn atomic_f_add<F: Float, const SCOPE: u32, const SEMANTICS: u32>(
             "%value = OpLoad _ {value}",
             "%old = OpAtomicFAddEXT _ {ptr} %scope %semantics %value",
             "OpStore {old} %old",
-            scope = const SCOPE,
-            semantics = const SEMANTICS,
+            scope = const { SCOPE as u32 },
+            semantics = const { SEMANTICS.bits() },
             ptr = in(reg) ptr,
             old = in(reg) &mut old,
             value = in(reg) &value

--- a/crates/spirv-std/src/arch/barrier.rs
+++ b/crates/spirv-std/src/arch/barrier.rs
@@ -1,25 +1,27 @@
 #[cfg(target_arch = "spirv")]
 use core::arch::asm;
 
+use crate::memory::{Scope, Semantics};
+
 /// Wait for other invocations of this module to reach the current point
 /// of execution.
 ///
 /// All invocations of this module within Execution scope reach this point of
 /// execution before any invocation proceeds beyond it.
 ///
-/// When Execution is [`crate::memory::Scope::Workgroup`] or larger, behavior is
+/// When Execution is [`Scope::Workgroup`] or larger, behavior is
 /// undefined unless all invocations within Execution execute the same dynamic
 /// instance of this instruction. When Execution is Subgroup or Invocation, the
 /// behavior of this instruction in non-uniform control flow is defined by the
 /// client API.
 ///
-/// If [`crate::memory::Semantics`] is not [`crate::memory::Semantics::NONE`],
+/// If [`Semantics`] is not [`Semantics::NONE`],
 /// this instruction also serves as an [`memory_barrier`] function call, and
 /// also performs and adheres to the description and semantics of an
 /// [`memory_barrier`] function with the same `MEMORY` and `SEMANTICS` operands.
 /// This allows atomically specifying both a control barrier and a memory
 /// barrier (that is, without needing two instructions). If
-/// [`crate::memory::Semantics`] is [`crate::memory::Semantics::NONE`], `MEMORY`
+/// [`Semantics`] is [`Semantics::NONE`], `MEMORY`
 /// is ignored.
 ///
 /// Before SPIRV-V version 1.3, it is only valid to use this instruction with
@@ -33,11 +35,8 @@ use core::arch::asm;
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpControlBarrier")]
 #[inline]
-pub fn control_barrier<
-    const EXECUTION: u32, // Scope
-    const MEMORY: u32,    // Scope
-    const SEMANTICS: u32, // Semantics
->() {
+pub fn control_barrier<const EXECUTION: Scope, const MEMORY: Scope, const SEMANTICS: Semantics>() {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         asm! {
             "%u32 = OpTypeInt 32 0",
@@ -45,9 +44,9 @@ pub fn control_barrier<
             "%memory = OpConstant %u32 {memory}",
             "%semantics = OpConstant %u32 {semantics}",
             "OpControlBarrier %execution %memory %semantics",
-            execution = const EXECUTION,
-            memory = const MEMORY,
-            semantics = const SEMANTICS,
+            execution = const { EXECUTION as u32 },
+            memory = const { MEMORY as u32 },
+            semantics = const { SEMANTICS.bits() },
         }
     }
 }
@@ -70,18 +69,16 @@ pub fn control_barrier<
 #[spirv_std_macros::gpu_only]
 #[doc(alias = "OpMemoryBarrier")]
 #[inline]
-pub fn memory_barrier<
-    const MEMORY: u32,    // Scope
-    const SEMANTICS: u32, // Semantics
->() {
+pub fn memory_barrier<const MEMORY: Scope, const SEMANTICS: Semantics>() {
+    const { SEMANTICS.assert_valid() }
     unsafe {
         asm! {
             "%u32 = OpTypeInt 32 0",
             "%memory = OpConstant %u32 {memory}",
             "%semantics = OpConstant %u32 {semantics}",
             "OpMemoryBarrier %memory %semantics",
-            memory = const MEMORY,
-            semantics = const SEMANTICS,
+            memory = const { MEMORY as u32 },
+            semantics = const { SEMANTICS.bits() },
         }
     }
 }
@@ -95,11 +92,8 @@ pub fn memory_barrier<
 #[inline]
 pub fn workgroup_memory_barrier() {
     memory_barrier::<
-        { crate::memory::Scope::Workgroup as u32 },
-        {
-            crate::memory::Semantics::WORKGROUP_MEMORY.bits()
-                | crate::memory::Semantics::ACQUIRE_RELEASE.bits()
-        },
+        { Scope::Workgroup },
+        { Semantics::WORKGROUP_MEMORY.union(Semantics::ACQUIRE_RELEASE) },
     >();
 }
 
@@ -112,12 +106,9 @@ pub fn workgroup_memory_barrier() {
 #[inline]
 pub fn workgroup_memory_barrier_with_group_sync() {
     control_barrier::<
-        { crate::memory::Scope::Workgroup as u32 },
-        { crate::memory::Scope::Workgroup as u32 },
-        {
-            crate::memory::Semantics::WORKGROUP_MEMORY.bits()
-                | crate::memory::Semantics::ACQUIRE_RELEASE.bits()
-        },
+        { Scope::Workgroup },
+        { Scope::Workgroup },
+        { Semantics::WORKGROUP_MEMORY.union(Semantics::ACQUIRE_RELEASE) },
     >();
 }
 
@@ -130,11 +121,11 @@ pub fn workgroup_memory_barrier_with_group_sync() {
 #[inline]
 pub fn device_memory_barrier() {
     memory_barrier::<
-        { crate::memory::Scope::Device as u32 },
+        { Scope::Device },
         {
-            crate::memory::Semantics::IMAGE_MEMORY.bits()
-                | crate::memory::Semantics::UNIFORM_MEMORY.bits()
-                | crate::memory::Semantics::ACQUIRE_RELEASE.bits()
+            Semantics::IMAGE_MEMORY
+                .union(Semantics::UNIFORM_MEMORY)
+                .union(Semantics::ACQUIRE_RELEASE)
         },
     >();
 }
@@ -148,12 +139,12 @@ pub fn device_memory_barrier() {
 #[inline]
 pub fn device_memory_barrier_with_group_sync() {
     control_barrier::<
-        { crate::memory::Scope::Workgroup as u32 },
-        { crate::memory::Scope::Device as u32 },
+        { Scope::Workgroup },
+        { Scope::Device },
         {
-            crate::memory::Semantics::IMAGE_MEMORY.bits()
-                | crate::memory::Semantics::UNIFORM_MEMORY.bits()
-                | crate::memory::Semantics::ACQUIRE_RELEASE.bits()
+            Semantics::IMAGE_MEMORY
+                .union(Semantics::UNIFORM_MEMORY)
+                .union(Semantics::ACQUIRE_RELEASE)
         },
     >();
 }
@@ -167,12 +158,12 @@ pub fn device_memory_barrier_with_group_sync() {
 #[inline]
 pub fn all_memory_barrier() {
     memory_barrier::<
-        { crate::memory::Scope::Device as u32 },
+        { Scope::Device },
         {
-            crate::memory::Semantics::WORKGROUP_MEMORY.bits()
-                | crate::memory::Semantics::IMAGE_MEMORY.bits()
-                | crate::memory::Semantics::UNIFORM_MEMORY.bits()
-                | crate::memory::Semantics::ACQUIRE_RELEASE.bits()
+            Semantics::WORKGROUP_MEMORY
+                .union(Semantics::IMAGE_MEMORY)
+                .union(Semantics::UNIFORM_MEMORY)
+                .union(Semantics::ACQUIRE_RELEASE)
         },
     >();
 }
@@ -186,13 +177,13 @@ pub fn all_memory_barrier() {
 #[inline]
 pub fn all_memory_barrier_with_group_sync() {
     control_barrier::<
-        { crate::memory::Scope::Workgroup as u32 },
-        { crate::memory::Scope::Device as u32 },
+        { Scope::Workgroup },
+        { Scope::Device },
         {
-            crate::memory::Semantics::WORKGROUP_MEMORY.bits()
-                | crate::memory::Semantics::IMAGE_MEMORY.bits()
-                | crate::memory::Semantics::UNIFORM_MEMORY.bits()
-                | crate::memory::Semantics::ACQUIRE_RELEASE.bits()
+            Semantics::WORKGROUP_MEMORY
+                .union(Semantics::IMAGE_MEMORY)
+                .union(Semantics::UNIFORM_MEMORY)
+                .union(Semantics::ACQUIRE_RELEASE)
         },
     >();
 }

--- a/crates/spirv-std/src/arch/subgroup.rs
+++ b/crates/spirv-std/src/arch/subgroup.rs
@@ -60,13 +60,13 @@ pub enum GroupOperation {
 #[inline]
 pub fn subgroup_barrier() {
     barrier::control_barrier::<
-        SUBGROUP,
-        SUBGROUP,
+        { Scope::Subgroup },
+        { Scope::Subgroup },
         {
-            Semantics::ACQUIRE_RELEASE.bits()
-                | Semantics::UNIFORM_MEMORY.bits()
-                | Semantics::WORKGROUP_MEMORY.bits()
-                | Semantics::IMAGE_MEMORY.bits()
+            Semantics::ACQUIRE_RELEASE
+                .union(Semantics::UNIFORM_MEMORY)
+                .union(Semantics::WORKGROUP_MEMORY)
+                .union(Semantics::IMAGE_MEMORY)
         },
     >();
 }
@@ -81,12 +81,12 @@ pub fn subgroup_barrier() {
 #[inline]
 pub fn subgroup_memory_barrier() {
     barrier::memory_barrier::<
-        SUBGROUP,
+        { Scope::Subgroup },
         {
-            Semantics::ACQUIRE_RELEASE.bits()
-                | Semantics::UNIFORM_MEMORY.bits()
-                | Semantics::WORKGROUP_MEMORY.bits()
-                | Semantics::IMAGE_MEMORY.bits()
+            Semantics::ACQUIRE_RELEASE
+                .union(Semantics::UNIFORM_MEMORY)
+                .union(Semantics::WORKGROUP_MEMORY)
+                .union(Semantics::IMAGE_MEMORY)
         },
     >();
 }
@@ -101,8 +101,8 @@ pub fn subgroup_memory_barrier() {
 #[inline]
 pub fn subgroup_memory_barrier_buffer() {
     barrier::memory_barrier::<
-        SUBGROUP,
-        { Semantics::ACQUIRE_RELEASE.bits() | Semantics::UNIFORM_MEMORY.bits() },
+        { Scope::Subgroup },
+        { Semantics::ACQUIRE_RELEASE.union(Semantics::UNIFORM_MEMORY) },
     >();
 }
 
@@ -118,8 +118,8 @@ pub fn subgroup_memory_barrier_buffer() {
 #[inline]
 pub fn subgroup_memory_barrier_shared() {
     barrier::memory_barrier::<
-        SUBGROUP,
-        { Semantics::ACQUIRE_RELEASE.bits() | Semantics::WORKGROUP_MEMORY.bits() },
+        { Scope::Subgroup },
+        { Semantics::ACQUIRE_RELEASE.union(Semantics::WORKGROUP_MEMORY) },
     >();
 }
 
@@ -133,8 +133,8 @@ pub fn subgroup_memory_barrier_shared() {
 #[inline]
 pub fn subgroup_memory_barrier_image() {
     barrier::memory_barrier::<
-        SUBGROUP,
-        { Semantics::ACQUIRE_RELEASE.bits() | Semantics::IMAGE_MEMORY.bits() },
+        { Scope::Subgroup },
+        { Semantics::ACQUIRE_RELEASE.union(Semantics::IMAGE_MEMORY) },
     >();
 }
 

--- a/crates/spirv-std/src/lib.rs
+++ b/crates/spirv-std/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(adt_const_params)]
 #![cfg_attr(
     target_arch = "spirv",
     allow(internal_features),

--- a/crates/spirv-std/src/memory.rs
+++ b/crates/spirv-std/src/memory.rs
@@ -3,9 +3,11 @@
 // NOTE(eddyb) "&-masking with zero", likely due to `NONE = 0` in `bitflags!`.
 #![allow(clippy::bad_bit_mask)]
 
+use core::marker::ConstParamTy;
+
 /// Specification for how large of a scope some instructions should operate on - used when calling
 /// functions that take a configurable scope.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(ConstParamTy, Debug, PartialEq, Eq)]
 pub enum Scope {
     /// Crosses multiple devices.
     CrossDevice = 0,
@@ -29,6 +31,7 @@ pub enum Scope {
 bitflags::bitflags! {
     /// Memory semantics to determine how some operations should function - used when calling such
     /// configurable operations.
+    #[derive(ConstParamTy)]
     #[repr(transparent)]
     #[cfg_attr(feature = "bytemuck", derive(bytemuck::Zeroable, bytemuck::Pod))]
     pub struct Semantics: u32 {
@@ -98,5 +101,21 @@ bitflags::bitflags! {
         /// This access cannot be eliminated, duplicated, or combined with
         /// other accesses.
         const VOLATILE = 0x8000;
+    }
+}
+
+impl Semantics {
+    const ORDERING_MASK: Semantics = Self::ACQUIRE
+        .union(Self::RELEASE)
+        .union(Self::ACQUIRE_RELEASE)
+        .union(Self::SEQUENTIALLY_CONST);
+
+    /// Verify whether the [`Semantics`] flags are valid
+    pub const fn assert_valid(self) {
+        assert!(
+            self.intersection(Self::ORDERING_MASK).bits().count_ones() <= 1,
+            "at most one memory-ordering flag (ACQUIRE, RELEASE, ACQUIRE_RELEASE or \
+            SEQUENTIALLY_CONST) may be set"
+        );
     }
 }

--- a/tests/compiletests/ui/arch/all_memory_barrier.stderr
+++ b/tests/compiletests/ui/arch/all_memory_barrier.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 82 13
+OpLine %5 79 13
 OpMemoryBarrier %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/all_memory_barrier_with_group_sync.stderr
+++ b/tests/compiletests/ui/arch/all_memory_barrier_with_group_sync.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 47 13
+OpLine %5 46 13
 OpControlBarrier %6 %7 %8
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/atomic_i_increment.rs
+++ b/tests/compiletests/ui/arch/atomic_i_increment.rs
@@ -10,8 +10,8 @@ pub fn main(#[spirv(descriptor_set = 0, binding = 0, storage_buffer)] buffer: &m
     let old = unsafe {
         spirv_std::arch::atomic_i_increment::<
             _,
-            { spirv_std::memory::Scope::Workgroup as u32 },
-            { spirv_std::memory::Semantics::NONE.bits() as u32 },
+            { spirv_std::memory::Scope::Workgroup },
+            { spirv_std::memory::Semantics::NONE },
         >(reference)
     };
     assert!(old == 0);

--- a/tests/compiletests/ui/arch/control_barrier.rs
+++ b/tests/compiletests/ui/arch/control_barrier.rs
@@ -10,9 +10,9 @@ use spirv_std::spirv;
 pub fn main() {
     unsafe {
         spirv_std::arch::control_barrier::<
-            { Scope::Subgroup as u32 },
-            { Scope::Subgroup as u32 },
-            { Semantics::NONE.bits() },
+            { Scope::Subgroup },
+            { Scope::Subgroup },
+            { Semantics::NONE },
         >();
     }
 }

--- a/tests/compiletests/ui/arch/device_memory_barrier.stderr
+++ b/tests/compiletests/ui/arch/device_memory_barrier.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 82 13
+OpLine %5 79 13
 OpMemoryBarrier %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/device_memory_barrier_with_group_sync.stderr
+++ b/tests/compiletests/ui/arch/device_memory_barrier_with_group_sync.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 47 13
+OpLine %5 46 13
 OpControlBarrier %6 %7 %8
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/memory_barrier.rs
+++ b/tests/compiletests/ui/arch/memory_barrier.rs
@@ -10,8 +10,8 @@ use spirv_std::spirv;
 pub fn main() {
     unsafe {
         spirv_std::arch::memory_barrier::<
-            { Scope::Subgroup as u32 },
-            { Semantics::ACQUIRE_RELEASE.bits() | Semantics::UNIFORM_MEMORY.bits() },
+            { Scope::Subgroup },
+            { Semantics::ACQUIRE_RELEASE.union(Semantics::UNIFORM_MEMORY) },
         >();
     }
 }

--- a/tests/compiletests/ui/arch/memory_barrier_invalid_ordering.rs
+++ b/tests/compiletests/ui/arch/memory_barrier_invalid_ordering.rs
@@ -1,0 +1,23 @@
+// build-fail
+// normalize-stderr-test "\S*/crates/spirv-std/src/" -> "$$SPIRV_STD_SRC/"
+// normalize-stderr-test "crates/spirv-std/src/" -> "$$SPIRV_STD_SRC/"
+// normalize-stderr-test "\S*/lib/rustlib/" -> "$$SYSROOT/lib/rustlib/"
+// normalize-stderr-test "\$SYSROOT/lib/rustlib/src/rust/library/core/src/panic.rs:\d+:\d+" -> "$$SYSROOT/lib/rustlib/src/rust/library/core/src/panic.rs:LL:CC"
+
+#![feature(adt_const_params)]
+#![allow(incomplete_features)]
+
+use spirv_std::memory::{Scope, Semantics};
+use spirv_std::spirv;
+
+#[spirv(fragment)]
+pub fn main() {
+    unsafe {
+        // ACQUIRE and RELEASE are both memory-ordering flags, and the SPIR-V spec allows at
+        // most one to be set at the same time.
+        spirv_std::arch::memory_barrier::<
+            { Scope::Subgroup },
+            { Semantics::ACQUIRE.union(Semantics::RELEASE) },
+        >();
+    }
+}

--- a/tests/compiletests/ui/arch/memory_barrier_invalid_ordering.stderr
+++ b/tests/compiletests/ui/arch/memory_barrier_invalid_ordering.stderr
@@ -1,0 +1,29 @@
+error[E0080]: evaluation panicked: at most one memory-ordering flag (ACQUIRE, RELEASE, ACQUIRE_RELEASE or SEQUENTIALLY_CONST) may be set
+  --> $SPIRV_STD_SRC/arch/barrier.rs:73:12
+   |
+   = note: evaluation of `spirv_std::arch::memory_barrier::<spirv_std::memory::Scope::Subgroup, spirv_std::memory::Semantics { bits: 6 }>::{constant#0}` failed inside this call
+note: inside `Semantics::assert_valid`
+  --> $SYSROOT/lib/rustlib/src/rust/library/core/src/panic.rs:LL:CC
+   |
+LL |         $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> $SPIRV_STD_SRC/memory.rs:115:8
+  ::: $SPIRV_STD_SRC/memory.rs:119:9
+   |
+   = note: in this macro invocation
+
+note: erroneous constant encountered
+  --> $SPIRV_STD_SRC/arch/barrier.rs:73:4
+
+note: the above error was encountered while instantiating `fn memory_barrier::<Subgroup, Semantics { bits: 6 }>`
+  --> $DIR/memory_barrier_invalid_ordering.rs:18:9
+   |
+LL | /         spirv_std::arch::memory_barrier::<
+LL | |             { Scope::Subgroup },
+LL | |             { Semantics::ACQUIRE.union(Semantics::RELEASE) },
+LL | |         >();
+   | |___________^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/compiletests/ui/arch/read_clock_khr.rs
+++ b/tests/compiletests/ui/arch/read_clock_khr.rs
@@ -10,7 +10,7 @@ use spirv_std::{
 
 #[spirv(fragment)]
 pub fn main() {
-    let clock_time = unsafe { read_clock_khr::<{ Scope::Subgroup as u32 }>() };
+    let clock_time = unsafe { read_clock_khr::<{ Scope::Subgroup }>() };
 
-    let clock_time_uvec2: UVec2 = unsafe { read_clock_uvec2_khr::<{ Scope::Subgroup as u32 }>() };
+    let clock_time_uvec2: UVec2 = unsafe { read_clock_uvec2_khr::<{ Scope::Subgroup }>() };
 }

--- a/tests/compiletests/ui/arch/workgroup_memory_barrier.stderr
+++ b/tests/compiletests/ui/arch/workgroup_memory_barrier.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 82 13
+OpLine %5 79 13
 OpMemoryBarrier %6 %7
 OpNoLine
 OpReturn

--- a/tests/compiletests/ui/arch/workgroup_memory_barrier_with_group_sync.stderr
+++ b/tests/compiletests/ui/arch/workgroup_memory_barrier_with_group_sync.stderr
@@ -1,6 +1,6 @@
 %1 = OpFunction  %2  None %3
 %4 = OpLabel
-OpLine %5 47 13
+OpLine %5 46 13
 OpControlBarrier %6 %6 %7
 OpNoLine
 OpReturn

--- a/tests/difftests/tests/arch/atomic_ops/atomic_ops-rust/src/lib.rs
+++ b/tests/difftests/tests/arch/atomic_ops/atomic_ops-rust/src/lib.rs
@@ -10,8 +10,8 @@ pub fn main_cs(
     #[spirv(storage_buffer, descriptor_set = 0, binding = 1)] output: &mut [u32],
     #[spirv(global_invocation_id)] global_id: spirv_std::glam::UVec3,
 ) {
-    const SCOPE: u32 = Scope::Workgroup as u32;
-    const SEMANTICS: u32 = Semantics::NONE.bits();
+    const SCOPE: Scope = Scope::Workgroup;
+    const SEMANTICS: Semantics = Semantics::NONE;
 
     let tid = global_id.x;
 


### PR DESCRIPTION
This implements https://github.com/Rust-GPU/rust-gpu/issues/607 and resolves https://github.com/Rust-GPU/rust-gpu/issues/414 using `adt_const_params`.

Implementation has been on nightly for a long time without major known issues AFAIK. docs.rs already compiles docs with nightly toolchain, so should not be a problem there either.

This makes developer experience better with improved type safety. As a bonus ordering validity is now checked at compile time.

`|` between memory semantics options is technically possible with even more nightly features, but didn't seem worth it for now.

The changes are essentially mechanical.