### PR TITLE
Fix bytemuck feature after bitflags update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         run: cargo nextest run -p rustc_codegen_spirv --release --no-default-features --features "use-installed-tools"
 
       - name: workspace test (excluding examples)
-        run: cargo nextest run --release --workspace --exclude "example-runner-*" --exclude "cargo-gpu*" --no-default-features --features "use-installed-tools,clap"
+        run: cargo nextest run --release --workspace --exclude "example-runner-*" --exclude "cargo-gpu*" --no-default-features --features "use-installed-tools,clap,bytemuck"
 
       # Examples
       - name: cargo check examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
+ "bytemuck",
  "serde_core",
 ]
 

--- a/crates/spirv-std/Cargo.toml
+++ b/crates/spirv-std/Cargo.toml
@@ -37,7 +37,7 @@ glam_0_30 = { package = "glam", version = "0.30.8", optional = true, default-fea
 
 [features]
 default = ["glam_0_33"]
-bytemuck = ["dep:bytemuck", "glam_0_30?/bytemuck", "glam_0_31?/bytemuck", "glam_0_32?/bytemuck", "glam_0_33?/bytemuck"]
+bytemuck = ["dep:bytemuck", "bitflags/bytemuck", "glam_0_30?/bytemuck", "glam_0_31?/bytemuck", "glam_0_32?/bytemuck", "glam_0_33?/bytemuck"]
 glam_0_33 = ["dep:glam_0_33"]
 glam_0_32 = ["dep:glam_0_32"]
 glam_0_31 = ["dep:glam_0_31"]

--- a/crates/spirv-std/src/memory.rs
+++ b/crates/spirv-std/src/memory.rs
@@ -30,6 +30,7 @@ bitflags::bitflags! {
     /// Memory semantics to determine how some operations should function - used when calling such
     /// configurable operations.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     #[cfg_attr(feature = "bytemuck", derive(bytemuck::Zeroable, bytemuck::Pod))]
     pub struct Semantics: u32 {
         /// No memory semantics.
@@ -98,5 +99,16 @@ bitflags::bitflags! {
         /// This access cannot be eliminated, duplicated, or combined with
         /// other accesses.
         const VOLATILE = 0x8000;
+    }
+}
+
+#[cfg(all(test, feature = "bytemuck"))]
+mod test_bytemuck {
+    fn is_pod<T: bytemuck::Pod>() {}
+
+    #[test]
+    fn test() {
+        is_pod::<crate::memory::Semantics>();
+        is_pod::<crate::ray_tracing::RayFlags>();
     }
 }

--- a/crates/spirv-std/src/ray_tracing.rs
+++ b/crates/spirv-std/src/ray_tracing.rs
@@ -149,6 +149,7 @@ bitflags::bitflags! {
     /// `CULL_BACK_FACING_TRIANGLES` and `CULL_FRONT_FACING_TRIANGLES` may
     /// be set.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     #[cfg_attr(feature = "bytemuck", derive(bytemuck::Zeroable, bytemuck::Pod))]
     pub struct RayFlags: u32 {
         /// No flags specified.


### PR DESCRIPTION
Docs were not checked in CI, but failed somehow after merging to `main`: https://github.com/Rust-GPU/rust-gpu/actions/runs/30995586739/job/92271767273.

Copy/Clone derived unconditionally, despite only being needed for `bytemuck`. Feel free to update if that is not desirable (I think it is though).