### PR TITLE
xtask set-toolchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1611,30 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -5264,6 +5301,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ regex-lite = "0.1.9"
 spirv = { version = "0.4.0", features = ["serialize", "deserialize"] }
 rspirv = "0.13.0"
 rspirv2 = { version = "0.1.0", features = ["bytemuck"] }
+chrono = "0.4.45"
 
 # difftest libraries mirrored from difftest workspace
 difftest = { path = "tests/difftests/tests/lib" }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -14,6 +14,7 @@ log.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 regex-lite.workspace = true
+chrono.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,11 +6,14 @@
     reason = "This is just a workflow tool"
 )]
 
+use crate::toolchain::SetToolchain;
 use anyhow::Context as _;
 use clap::Parser as _;
 use std::borrow::Cow;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+
+mod toolchain;
 
 /// Path to the shader crate
 const SHADER_CRATE_PATH: &str = "crates/shader-crate-template";
@@ -41,6 +44,7 @@ enum Cli {
     RustGpuRev {
         rev: String,
     },
+    SetToolchain(#[clap(flatten)] SetToolchain),
 }
 
 /// run some cmd
@@ -352,6 +356,7 @@ impl Cli {
                 )?;
                 Cli::UpdateExpect.run()?;
             }
+            Cli::SetToolchain(inner) => inner.run()?,
         }
         Ok(())
     }

--- a/crates/xtask/src/toolchain.rs
+++ b/crates/xtask/src/toolchain.rs
@@ -1,0 +1,87 @@
+use anyhow::Context;
+use chrono::{Datelike, Utc};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Set the toolchain of rust-gpu to some nightly
+#[derive(Debug, clap::Parser)]
+pub struct SetToolchain {
+    /// nightly version to set the toolchain to
+    ///
+    /// accepts `nightly-1234-56-78` or `1234-56-78`, defaults to today's nightly
+    version: Option<String>,
+}
+
+impl SetToolchain {
+    pub fn run(&self) -> anyhow::Result<()> {
+        // figure out version and commit-hash
+        let version = self.version.as_ref().map_or_else(
+            || {
+                let time = Utc::now();
+                format!(
+                    "nightly-{:04}-{:02}-{:02}",
+                    time.year(),
+                    time.month(),
+                    time.day()
+                )
+            },
+            |version| {
+                if version.starts_with("nightly-") {
+                    version.clone()
+                } else {
+                    format!("nightly-{version}")
+                }
+            },
+        );
+        println!("Updating toolchain to {version}");
+        let commit_hash = get_rustc_commit_hash(&version)?;
+
+        // update files
+        let regex_channel = regex_lite::Regex::new(r#"channel = "[a-zA-Z\-0-9]*""#)?;
+        let regex_commit_hash = regex_lite::Regex::new(r#"commit_hash = [0-9a-f]*"#)?;
+        let update_file = |file: &Path| -> anyhow::Result<()> {
+            let content = std::fs::read_to_string(file)?;
+            let content = regex_channel.replace(&content, format!(r#"channel = "{version}""#));
+            let content =
+                regex_commit_hash.replace(&content, format!(r#"commit_hash = {commit_hash}"#));
+            std::fs::write(file, &*content)?;
+            Ok(())
+        };
+        let root = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/../.."));
+        update_file(&root.join("rust-toolchain.toml"))?;
+        update_file(&root.join("crates/rustc_codegen_spirv/build.rs"))?;
+
+        // if jj is available and desc is empty, update desc
+        if let Ok(output) = Command::new("jj")
+            .args(["log", "-Gr", "@", "-T", "description"])
+            .output()
+            && String::from_utf8(output.stdout)?.trim().is_empty()
+        {
+            Command::new("jj")
+                .args(["desc", "-m"])
+                .arg(format!("update to {version}"))
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .ok();
+        }
+        Ok(())
+    }
+}
+
+fn get_rustc_commit_hash(toolchain: &str) -> anyhow::Result<String> {
+    let stdout = String::from_utf8(
+        Command::new("rustc")
+            .arg(format!("+{toolchain}"))
+            .arg("-vV")
+            .stderr(Stdio::inherit())
+            .output()?
+            .stdout,
+    )?;
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("commit-hash: "))
+        .map(ToString::to_string)
+        .context("`commit-hash` not found in `rustc -vV` output")
+}


### PR DESCRIPTION
I just couldn't be bothered anymore pasting around the nightly version and it's commit hash every time I want to try a new nightly. (Excuse the xtask crate being a bit messy, it was copied over from cargo-gpu and never cleaned up afterwards.)

Usage:
```bash
# update to today's nightly
cargo xtask set-toolchain
# update to specified nightly
cargo xtask set-toolchain nightly-2026-08-10
cargo xtask set-toolchain 2026-08-10
```

Making this a separate PR so anyone updating toolchains in the future is aware of it @eddyb

@LegNeato I know your [toolchain upgrade action](https://github.com/Rust-GPU/rust-gpu/blob/main/.github/workflows/rust-toolchain-upgrade.yml) uses [this bash script](https://github.com/Rust-GPU/rust-gpu/blob/main/.github/check-rust-toolchain-upgrade.sh) to update the toolchain. But it also contains additional checks specific for the github action, so I'm not sure how these two tools should relate. 